### PR TITLE
Add document revision tracking and restore utility

### DIFF
--- a/portal/models.py
+++ b/portal/models.py
@@ -1,0 +1,38 @@
+import os
+from datetime import datetime
+from sqlalchemy import create_engine, Column, Integer, String, Text, ForeignKey, DateTime, JSON
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker, scoped_session
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///portal.db")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = scoped_session(sessionmaker(bind=engine))
+Base = declarative_base()
+
+class Document(Base):
+    __tablename__ = "documents"
+    id = Column(Integer, primary_key=True)
+    doc_key = Column(String, nullable=False, unique=True)
+    major_version = Column(Integer, default=1)
+    minor_version = Column(Integer, default=0)
+    revision_notes = Column(Text)
+
+    revisions = relationship("DocumentRevision", back_populates="document", cascade="all, delete-orphan")
+
+class DocumentRevision(Base):
+    __tablename__ = "document_revisions"
+    id = Column(Integer, primary_key=True)
+    doc_id = Column(Integer, ForeignKey('documents.id'), nullable=False)
+    major_version = Column(Integer, nullable=False)
+    minor_version = Column(Integer, nullable=False)
+    revision_notes = Column(Text)
+    track_changes = Column(JSON)
+    compare_result = Column(JSON)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    document = relationship("Document", back_populates="revisions")
+
+Base.metadata.create_all(engine)
+
+def get_session():
+    return SessionLocal()

--- a/portal/services.py
+++ b/portal/services.py
@@ -1,0 +1,27 @@
+from models import get_session, Document, DocumentRevision
+
+
+def restore_version(doc_id: int, version: str) -> Document:
+    """Restore a document to a previous major.minor version."""
+    major, minor = (int(x) for x in version.split("."))
+    session = get_session()
+    rev = (
+        session.query(DocumentRevision)
+        .filter_by(doc_id=doc_id, major_version=major, minor_version=minor)
+        .order_by(DocumentRevision.created_at.desc())
+        .first()
+    )
+    if not rev:
+        session.close()
+        raise ValueError("Revision not found")
+    doc = session.get(Document, doc_id)
+    if not doc:
+        session.close()
+        raise ValueError("Document not found")
+    doc.major_version = major
+    doc.minor_version = minor
+    doc.revision_notes = rev.revision_notes
+    session.commit()
+    session.refresh(doc)
+    session.close()
+    return doc


### PR DESCRIPTION
## Summary
- add document and revision models with version fields
- store OnlyOffice track changes and compare results via revision endpoint
- implement service to restore documents to previous versions

## Testing
- `python -m py_compile portal/app.py portal/models.py portal/services.py`


------
https://chatgpt.com/codex/tasks/task_e_689ed4a1f978832bb449eeb0700aa6cd