### PR TITLE
Add document lifecycle, workflow steps and periodic review job

### DIFF
--- a/portal/periodic_review.py
+++ b/portal/periodic_review.py
@@ -1,0 +1,24 @@
+"""Send annual periodic review alerts for documents.
+
+This module is expected to be invoked by an external cron scheduler once per year.
+Example crontab entry:
+0 0 1 1 * python -m portal.periodic_review
+"""
+from models import get_session, Document
+
+
+def send_periodic_review_alert(doc: Document) -> None:
+    """Placeholder alert implementation."""
+    print(f"Periodic review alert for document {doc.id}")
+
+
+def run() -> None:
+    session = get_session()
+    docs = session.query(Document).filter(Document.status != "Archived").all()
+    for doc in docs:
+        send_periodic_review_alert(doc)
+    session.close()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add status lifecycle states to Document model
- track multi-step approvals with WorkflowStep model and submit_for_approval service
- introduce periodic_review cron job script to trigger annual alerts

## Testing
- `python -m py_compile portal/models.py portal/services.py portal/periodic_review.py`


------
https://chatgpt.com/codex/tasks/task_e_689ed573916c832bb33e3353323e67cb