### PR TITLE
fix: adjust textract requirement

### DIFF
--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -6,4 +6,4 @@ boto3==1.34.162
 python-dotenv==1.0.1
 ldap3==2.9.1
 elasticsearch==8.13.0
-textract==1.6.5
+textract==1.6.4


### PR DESCRIPTION
## Summary
- downgrade textract to 1.6.4 to avoid invalid metadata error when installing requirements

## Testing
- `python -m py_compile portal/*.py`
- `pip install -r portal/requirements.txt` *(fails: Could not find a version that satisfies the requirement flask==3.0.3 due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_689edcadd1cc832b922bf29a84f4e8db