### PR TITLE
fix: pin textract dependency at 1.6.3

### DIFF
--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -6,4 +6,5 @@ boto3==1.34.162
 python-dotenv==1.0.1
 ldap3==2.9.1
 elasticsearch==8.13.0
-textract==1.6.4
+# textract 1.6.4 and 1.6.5 have issues; use 1.6.3 instead
+textract==1.6.3


### PR DESCRIPTION
## Summary
- pin textract to 1.6.3 since 1.6.4 and 1.6.5 fail to install

## Testing
- `pip install -r portal/requirements.txt` *(fails: Could not find a version that satisfies the requirement flask==3.0.3: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ee018993c832b97ce0cc49295c3cc