### PR TITLE
Add document retention and archival support

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -52,6 +52,23 @@ def index():
     return jsonify(ok=True, msg="QDMS Portal running")
 
 
+@app.get("/archive")
+def list_archived_documents():
+    session = get_session()
+    docs = session.query(Document).filter_by(status="Archived").all()
+    result = [
+        {
+            "id": d.id,
+            "doc_key": d.doc_key,
+            "title": d.title,
+            "archived_at": d.archived_at.isoformat() if d.archived_at else None,
+        }
+        for d in docs
+    ]
+    session.close()
+    return jsonify(result)
+
+
 @app.post("/documents")
 def create_document():
     data = request.get_json(silent=True) or {}
@@ -62,6 +79,7 @@ def create_document():
         tags=",".join(data.get("tags", [])) if isinstance(data.get("tags"), list) else data.get("tags"),
         department=data.get("department"),
         process=data.get("process"),
+        retention_period=data.get("retention_period"),
     )
     session = get_session()
     session.add(doc)

--- a/portal/archive_job.py
+++ b/portal/archive_job.py
@@ -1,0 +1,28 @@
+"""Cron job to archive documents whose retention period has expired."""
+from datetime import datetime, timedelta
+from models import get_session, Document
+from storage import move_to_archive
+
+
+def run() -> None:
+    session = get_session()
+    now = datetime.utcnow()
+    docs = (
+        session.query(Document)
+        .filter(Document.retention_period != None)
+        .filter(Document.status != "Archived")
+        .all()
+    )
+    for doc in docs:
+        base = doc.created_at or now
+        expire_at = base + timedelta(days=doc.retention_period)
+        if expire_at <= now:
+            move_to_archive(doc.doc_key, doc.retention_period or 0)
+            doc.status = "Archived"
+            doc.archived_at = now
+    session.commit()
+    session.close()
+
+
+if __name__ == "__main__":
+    run()

--- a/portal/models.py
+++ b/portal/models.py
@@ -33,6 +33,9 @@ class Document(Base):
     major_version = Column(Integer, default=1)
     minor_version = Column(Integer, default=0)
     revision_notes = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    retention_period = Column(Integer)
+    archived_at = Column(DateTime)
 
     status = Column(
         Enum("Draft", "Review", "Approved", "Published", "Archived", name="document_status"),


### PR DESCRIPTION
## Summary
- add `retention_period`, `created_at`, and `archived_at` fields to Document model
- create cron job for moving expired documents to S3/MinIO archive with object lock
- add `/archive` endpoint to list archived documents and storage helper module

## Testing
- `python -m py_compile portal/app.py portal/models.py portal/storage.py portal/archive_job.py`
- `python portal/archive_job.py` *(fails: ModuleNotFoundError: No module named 'six.moves')*

------
https://chatgpt.com/codex/tasks/task_e_689ee743d494832b9cf5d68575f7d0ac