### PR TITLE
Add health endpoint and layout with static build

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -41,6 +41,16 @@ http {
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location /static/ {
+      proxy_pass http://portal_up/static/;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      expires 1y;
+      add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
     # OnlyOffice Document Server subpath
     location /onlyoffice/ {
       proxy_pass http://onlyoffice_up/;

--- a/portal/static/build.py
+++ b/portal/static/build.py
@@ -1,0 +1,27 @@
+import hashlib, os, json
+
+SRC_DIR = 'src'
+DIST_DIR = 'dist'
+
+def minify(content):
+    return ''.join(line.strip() for line in content.splitlines())
+
+def build_file(name):
+    with open(os.path.join(SRC_DIR, name)) as f:
+        content = f.read()
+    minified = minify(content)
+    digest = hashlib.md5(minified.encode()).hexdigest()[:8]
+    base, ext = os.path.splitext(name)
+    out_name = f"{base}-{digest}{ext}"
+    with open(os.path.join(DIST_DIR, out_name), 'w') as f:
+        f.write(minified)
+    return name, out_name
+
+if __name__ == '__main__':
+    os.makedirs(DIST_DIR, exist_ok=True)
+    manifest = {}
+    for fname in ['app.css', 'app.js']:
+        key, out = build_file(fname)
+        manifest[key] = out
+    with open(os.path.join(DIST_DIR, 'manifest.json'), 'w') as f:
+        json.dump(manifest, f, indent=2)

--- a/portal/static/dist/app-900a75a7.js
+++ b/portal/static/dist/app-900a75a7.js
@@ -1,0 +1,1 @@
+import 'bootstrap';console.log('app loaded');

--- a/portal/static/dist/app-bfd4bd45.css
+++ b/portal/static/dist/app-bfd4bd45.css
@@ -1,0 +1,1 @@
+@import "bootstrap/dist/css/bootstrap.css";/* custom styles */body {padding-top: 60px;}

--- a/portal/static/dist/manifest.json
+++ b/portal/static/dist/manifest.json
@@ -1,0 +1,4 @@
+{
+  "app.css": "app-bfd4bd45.css",
+  "app.js": "app-900a75a7.js"
+}

--- a/portal/static/src/app.css
+++ b/portal/static/src/app.css
@@ -1,0 +1,5 @@
+@import "bootstrap/dist/css/bootstrap.css";
+/* custom styles */
+body {
+  padding-top: 60px;
+}

--- a/portal/static/src/app.js
+++ b/portal/static/src/app.js
@@ -1,0 +1,2 @@
+import 'bootstrap';
+console.log('app loaded');

--- a/portal/templates/capa_track.html
+++ b/portal/templates/capa_track.html
@@ -1,7 +1,8 @@
-<!doctype html>
-<title>CAPA Tracker</title>
+{% extends "layout.html" %}
+{% block title %}CAPA Tracker{% endblock %}
+{% block content %}
 <h1>CAPA Actions</h1>
-<table border="1" cellpadding="5">
+<table class="table table-bordered">
   <tr>
     <th>ID</th>
     <th>Document ID</th>
@@ -17,3 +18,4 @@
   </tr>
   {% endfor %}
 </table>
+{% endblock %}

--- a/portal/templates/index.html
+++ b/portal/templates/index.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block title %}Home{% endblock %}
+{% block content %}
+<h1>Welcome</h1>
+<p>QDMS Portal running.</p>
+{% endblock %}

--- a/portal/templates/layout.html
+++ b/portal/templates/layout.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}Portal{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ asset_url('app.css') }}">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">Portal</a>
+  </div>
+</nav>
+<div class="container-fluid">
+  <div class="row">
+    <aside class="col-md-2 d-none d-md-block bg-light sidebar">
+      {% block sidebar %}
+      <ul class="nav flex-column mt-4">
+        <li class="nav-item"><a class="nav-link" href="/search">Search</a></li>
+        <li class="nav-item"><a class="nav-link" href="/reports">Reports</a></li>
+      </ul>
+      {% endblock %}
+    </aside>
+    <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+      {% block content %}{% endblock %}
+    </main>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ asset_url('app.js') }}" defer></script>
+</body>
+</html>

--- a/portal/templates/reports.html
+++ b/portal/templates/reports.html
@@ -1,27 +1,25 @@
-<!doctype html>
-<html>
-<head><title>Reports</title></head>
-<body>
-  <h1>Reports</h1>
-  <ul>
-    <li>
-      Revision Report:
-      <a href="/reports/revisions?format=csv">CSV</a> |
-      <a href="/reports/revisions?format=xlsx">Excel</a> |
-      <a href="/reports/revisions?format=pdf">PDF</a>
-    </li>
-    <li>
-      Training Compliance:
-      <a href="/reports/training?format=csv">CSV</a> |
-      <a href="/reports/training?format=xlsx">Excel</a> |
-      <a href="/reports/training?format=pdf">PDF</a>
-    </li>
-    <li>
-      Pending Approvals:
-      <a href="/reports/pending-approvals?format=csv">CSV</a> |
-      <a href="/reports/pending-approvals?format=xlsx">Excel</a> |
-      <a href="/reports/pending-approvals?format=pdf">PDF</a>
-    </li>
-  </ul>
-</body>
-</html>
+{% extends "layout.html" %}
+{% block title %}Reports{% endblock %}
+{% block content %}
+<h1>Reports</h1>
+<ul>
+  <li>
+    Revision Report:
+    <a href="/reports/revisions?format=csv">CSV</a> |
+    <a href="/reports/revisions?format=xlsx">Excel</a> |
+    <a href="/reports/revisions?format=pdf">PDF</a>
+  </li>
+  <li>
+    Training Compliance:
+    <a href="/reports/training?format=csv">CSV</a> |
+    <a href="/reports/training?format=xlsx">Excel</a> |
+    <a href="/reports/training?format=pdf">PDF</a>
+  </li>
+  <li>
+    Pending Approvals:
+    <a href="/reports/pending-approvals?format=csv">CSV</a> |
+    <a href="/reports/pending-approvals?format=xlsx">Excel</a> |
+    <a href="/reports/pending-approvals?format=pdf">PDF</a>
+  </li>
+</ul>
+{% endblock %}

--- a/portal/templates/search.html
+++ b/portal/templates/search.html
@@ -1,22 +1,20 @@
-<!doctype html>
-<html>
-<head><title>Document Search</title></head>
-<body>
-  <h1>Search Documents</h1>
-  <form method="get">
-    <input name="title" placeholder="Title" value="{{ filters.title or '' }}" />
-    <input name="code" placeholder="Code" value="{{ filters.code or '' }}" />
-    <input name="tags" placeholder="Tags" value="{{ filters.tags or '' }}" />
-    <input name="department" placeholder="Department" value="{{ filters.department or '' }}" />
-    <input name="process" placeholder="Process" value="{{ filters.process or '' }}" />
-    <button type="submit">Search</button>
-  </form>
-  <ul>
-  {% for doc in results %}
-    <li>{{ doc.title }} ({{ doc.code }}) - {{ doc.department }} - {{ doc.process }} - {{ doc.tags }}</li>
-  {% else %}
-    <li>No results found.</li>
-  {% endfor %}
-  </ul>
-</body>
-</html>
+{% extends "layout.html" %}
+{% block title %}Document Search{% endblock %}
+{% block content %}
+<h1>Search Documents</h1>
+<form method="get" class="row g-2">
+  <div class="col-md-2"><input class="form-control" name="title" placeholder="Title" value="{{ filters.title or '' }}"></div>
+  <div class="col-md-2"><input class="form-control" name="code" placeholder="Code" value="{{ filters.code or '' }}"></div>
+  <div class="col-md-2"><input class="form-control" name="tags" placeholder="Tags" value="{{ filters.tags or '' }}"></div>
+  <div class="col-md-2"><input class="form-control" name="department" placeholder="Department" value="{{ filters.department or '' }}"></div>
+  <div class="col-md-2"><input class="form-control" name="process" placeholder="Process" value="{{ filters.process or '' }}"></div>
+  <div class="col-md-2"><button class="btn btn-primary w-100" type="submit">Search</button></div>
+</form>
+<ul class="mt-3">
+{% for doc in results %}
+  <li>{{ doc.title }} ({{ doc.code }}) - {{ doc.department }} - {{ doc.process }} - {{ doc.tags }}</li>
+{% else %}
+  <li>No results found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/portal/templates/settings_notifications.html
+++ b/portal/templates/settings_notifications.html
@@ -1,17 +1,17 @@
-<html>
-<body>
+{% extends "layout.html" %}
+{% block title %}Notification Settings{% endblock %}
+{% block content %}
 <h3>Notification Settings</h3>
 <form method="post">
-  <label>
-    <input type="checkbox" name="email_enabled" {% if settings.email_enabled %}checked{% endif %}>
-    Email
-  </label><br>
-  <label>
-    <input type="checkbox" name="webhook_enabled" {% if settings.webhook_enabled %}checked{% endif %}>
-    Webhook URL
-  </label>
-  <input type="text" name="webhook_url" value="{{ settings.webhook_url }}"><br>
-  <button type="submit">Save</button>
+  <div class="form-check">
+    <input class="form-check-input" type="checkbox" name="email_enabled" {% if settings.email_enabled %}checked{% endif %}>
+    <label class="form-check-label">Email</label>
+  </div>
+  <div class="form-check">
+    <input class="form-check-input" type="checkbox" name="webhook_enabled" {% if settings.webhook_enabled %}checked{% endif %}>
+    <label class="form-check-label">Webhook URL</label>
+  </div>
+  <input class="form-control my-2" type="text" name="webhook_url" value="{{ settings.webhook_url }}">
+  <button class="btn btn-primary" type="submit">Save</button>
 </form>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Flask /health endpoint and HTML homepage
- introduce Bootstrap-based layout template and update pages to extend it
- add simple static asset build with hashed filenames and configure Nginx caching

## Testing
- `python -m py_compile app.py`
- `cd portal/static && python build.py && ls dist`

------
https://chatgpt.com/codex/tasks/task_e_689eeff7ff80832b92f581b2f952bf1c