### PR TITLE
Add six dependency for pandas support

### DIFF
--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -14,3 +14,4 @@ openpyxl==3.1.2
 reportlab==4.1.0
 authlib
 Flask-WTF
+six==1.16.0


### PR DESCRIPTION
## Summary
- include `six` package in Python requirements to satisfy pandas/dateutil dependencies

## Testing
- `pip install -r portal/requirements.txt` *(fails: Could not connect to proxy for six)*

------
https://chatgpt.com/codex/tasks/task_e_689ef37818a8832b96cf8ddbb3d797d4