### PR TITLE
Ensure six dependency is installed

### DIFF
--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -14,4 +14,4 @@ openpyxl==3.1.2
 reportlab==4.1.0
 authlib
 Flask-WTF
-six==1.12.0
+six==1.16.0


### PR DESCRIPTION
## Summary
- Specify `six` 1.16.0 in portal's Python requirements to provide `six.moves` for dateutil and pandas.

## Testing
- `pip install six==1.16.0` *(fails: Cannot connect to proxy)*
- `python portal/app.py` *(fails: ModuleNotFoundError: No module named 'six.moves')*

------
https://chatgpt.com/codex/tasks/task_e_689ef72a92f8832bba8a93a756cb8826