### PR TITLE
Replace textract with pdfminer and python-docx

### DIFF
--- a/portal/ocr.py
+++ b/portal/ocr.py
@@ -1,10 +1,17 @@
-import textract
+import os
+from pdfminer.high_level import extract_text as pdf_extract_text
+from docx import Document
 
 
 def extract_text(file_path: str) -> str:
-    """Extract text from a PDF or Office document using textract."""
+    """Extract text from a PDF or DOCX document."""
     try:
-        text = textract.process(file_path)
-        return text.decode("utf-8")
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext == ".pdf":
+            return pdf_extract_text(file_path)
+        if ext == ".docx":
+            doc = Document(file_path)
+            return "\n".join(p.text for p in doc.paragraphs)
+        return ""
     except Exception:
         return ""

--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -6,8 +6,8 @@ boto3==1.34.162
 python-dotenv==1.0.1
 ldap3==2.9.1
 elasticsearch==8.13.0
-# textract 1.6.4 and 1.6.5 have issues; use 1.6.3 instead
-textract==1.6.3
+pdfminer.six==20231228
+python-docx==0.8.11
 fpdf==1.7.2
 pandas==2.2.2
 openpyxl==3.1.2


### PR DESCRIPTION
## Summary
- replace textract-based text extraction with pdfminer and python-docx
- remove textract dependency and add pdfminer.six and python-docx to requirements

## Testing
- `pip install pdfminer.six==20231228 python-docx==0.8.11` *(fails: Could not find a version that satisfies the requirement pdfminer.six==20231228)*
- `python -m py_compile portal/ocr.py portal/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689f06c19f80832bbd91f30fbf830962