### PR TITLE
Add LDAP login with JWT refresh tokens

### DIFF
--- a/portal/auth.py
+++ b/portal/auth.py
@@ -1,4 +1,18 @@
-from flask import Blueprint, redirect, url_for, session
+import os
+from datetime import datetime, timedelta
+
+import jwt
+from ldap3 import Connection, Server, ALL
+from flask import (
+    Blueprint,
+    redirect,
+    url_for,
+    session,
+    request,
+    jsonify,
+    current_app,
+    render_template,
+)
 from authlib.integrations.flask_client import OAuth
 
 oauth = OAuth()
@@ -6,7 +20,7 @@ auth_bp = Blueprint('auth', __name__)
 
 
 def init_app(app):
-    """Initialize OAuth client with application config."""
+    """Initialize OAuth client and authentication config."""
     oauth.init_app(app)
     oauth.register(
         name='oidc',
@@ -16,12 +30,102 @@ def init_app(app):
         client_kwargs={'scope': 'openid profile email'},
     )
 
+    app.config['LDAP_ENABLED'] = os.environ.get('LDAP_ENABLED', '').lower() == 'true'
+    app.config['LDAP_URL'] = os.environ.get('LDAP_URL', 'ldap://localhost')
+    app.config['LDAP_USER_BASE'] = os.environ.get(
+        'LDAP_USER_BASE', 'ou=users,dc=example,dc=com'
+    )
+    app.config['JWT_SECRET'] = os.environ.get(
+        'PORTAL_JWT_SECRET', app.secret_key
+    )
+    app.config['JWT_ACCESS_MINUTES'] = int(os.environ.get('JWT_ACCESS_MINUTES', 15))
+    app.config['JWT_REFRESH_DAYS'] = int(os.environ.get('JWT_REFRESH_DAYS', 7))
+
 
 @auth_bp.route('/login')
 def login():
-    """Redirect user to the identity provider."""
+    """Render LDAP login form or redirect to OIDC."""
+    if current_app.config.get('LDAP_ENABLED'):
+        return render_template('login.html')
     redirect_uri = url_for('auth.oidc_callback', _external=True)
     return oauth.oidc.authorize_redirect(redirect_uri)
+
+
+@auth_bp.post('/api/auth/login')
+def api_login():
+    """Authenticate user via LDAP or delegate to OIDC."""
+    if not current_app.config.get('LDAP_ENABLED'):
+        return redirect(url_for('auth.login'))
+
+    data = request.get_json(silent=True) or request.form
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        return jsonify(error='Missing credentials'), 400
+
+    server = Server(current_app.config['LDAP_URL'], get_info=ALL)
+    user_dn = f"uid={username},{current_app.config['LDAP_USER_BASE']}"
+    try:
+        Connection(server, user=user_dn, password=password, auto_bind=True)
+    except Exception:
+        return jsonify(error='Invalid credentials'), 401
+
+    secret = current_app.config['JWT_SECRET']
+    now = datetime.utcnow()
+    access_payload = {
+        'sub': username,
+        'exp': now + timedelta(minutes=current_app.config['JWT_ACCESS_MINUTES'])
+    }
+    refresh_payload = {
+        'sub': username,
+        'exp': now + timedelta(days=current_app.config['JWT_REFRESH_DAYS'])
+    }
+    access_token = jwt.encode(access_payload, secret, algorithm='HS256')
+    refresh_token = jwt.encode(refresh_payload, secret, algorithm='HS256')
+
+    session['user'] = {'username': username}
+    resp = jsonify(status='ok')
+    resp.set_cookie('access_token', access_token, httponly=True, samesite='Strict')
+    resp.set_cookie('refresh_token', refresh_token, httponly=True, samesite='Strict')
+    return resp
+
+
+@auth_bp.post('/api/auth/refresh')
+def refresh():
+    """Refresh access token using refresh token."""
+    secret = current_app.config['JWT_SECRET']
+    token = request.cookies.get('refresh_token')
+    if not token:
+        return jsonify(error='Missing refresh token'), 401
+    try:
+        data = jwt.decode(token, secret, algorithms=['HS256'])
+    except jwt.ExpiredSignatureError:
+        return jsonify(error='Refresh token expired'), 401
+    except jwt.InvalidTokenError:
+        return jsonify(error='Invalid refresh token'), 401
+
+    username = data.get('sub')
+    now = datetime.utcnow()
+    new_access = jwt.encode(
+        {
+            'sub': username,
+            'exp': now + timedelta(minutes=current_app.config['JWT_ACCESS_MINUTES'])
+        },
+        secret,
+        algorithm='HS256',
+    )
+    new_refresh = jwt.encode(
+        {
+            'sub': username,
+            'exp': now + timedelta(days=current_app.config['JWT_REFRESH_DAYS'])
+        },
+        secret,
+        algorithm='HS256',
+    )
+    resp = jsonify(status='refreshed')
+    resp.set_cookie('access_token', new_access, httponly=True, samesite='Strict')
+    resp.set_cookie('refresh_token', new_refresh, httponly=True, samesite='Strict')
+    return resp
 
 
 @auth_bp.route('/oidc/callback')

--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -15,3 +15,4 @@ reportlab==4.1.0
 authlib
 Flask-WTF
 six==1.16.0
+PyJWT==2.8.0

--- a/portal/templates/login.html
+++ b/portal/templates/login.html
@@ -1,0 +1,17 @@
+{% extends "layout.html" %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1>Login</h1>
+<form method="post" action="/api/auth/login">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- support LDAP authentication with JWT issuance and refresh endpoints
- render login form when LDAP is enabled
- include PyJWT dependency for token generation

## Testing
- `pytest`
- `pip install PyJWT==2.8.0` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f087df514832b982412ca27ebb045