### PR TITLE
Add role-based access control and navigation

### DIFF
--- a/portal/templates/layout.html
+++ b/portal/templates/layout.html
@@ -10,6 +10,13 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
   <div class="container-fluid">
     <a class="navbar-brand" href="/">Portal</a>
+    <ul class="navbar-nav ms-auto">
+      {% if current_user %}
+      <li class="nav-item"><span class="navbar-text">{{ current_user.username }}</span></li>
+      {% else %}
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Login</a></li>
+      {% endif %}
+    </ul>
   </div>
 </nav>
 <div class="container-fluid">
@@ -17,8 +24,27 @@
     <aside class="col-md-2 d-none d-md-block bg-light sidebar">
       {% block sidebar %}
       <ul class="nav flex-column mt-4">
+        {% if has_role('reader') %}
         <li class="nav-item"><a class="nav-link" href="/search">Search</a></li>
+        {% endif %}
+        {% if has_role('contributor') %}
+        <li class="nav-item"><a class="nav-link" href="/documents/new">New Document</a></li>
+        {% endif %}
+        {% if has_role('reviewer') %}
+        <li class="nav-item"><a class="nav-link" href="/reviews">Review Queue</a></li>
+        {% endif %}
+        {% if has_role('approver') %}
+        <li class="nav-item"><a class="nav-link" href="/approvals">Approvals</a></li>
+        {% endif %}
+        {% if has_role('publisher') %}
+        <li class="nav-item"><a class="nav-link" href="/publish">Publish</a></li>
+        {% endif %}
+        {% if has_role('quality_admin') %}
+        <li class="nav-item"><a class="nav-link" href="/admin">Admin</a></li>
+        {% endif %}
+        {% if has_role('quality_admin') or has_role('auditor') %}
         <li class="nav-item"><a class="nav-link" href="/reports">Reports</a></li>
+        {% endif %}
       </ul>
       {% endblock %}
     </aside>


### PR DESCRIPTION
## Summary
- Introduce `RoleEnum` with default role and user seeding
- Implement `login_required` and `roles_required` decorators and apply them to routes
- Render navbar and sidebar menus based on user roles

## Testing
- `python -m py_compile portal/app.py portal/auth.py portal/models.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f0d6ab3a0832b806a85cb39a07572