### PR TITLE
Add document list view with filtering and pagination

### DIFF
--- a/portal/static/build.py
+++ b/portal/static/build.py
@@ -20,8 +20,9 @@ def build_file(name):
 if __name__ == '__main__':
     os.makedirs(DIST_DIR, exist_ok=True)
     manifest = {}
-    for fname in ['app.css', 'app.js']:
-        key, out = build_file(fname)
-        manifest[key] = out
+    for fname in os.listdir(SRC_DIR):
+        if fname.endswith(('.css', '.js')):
+            key, out = build_file(fname)
+            manifest[key] = out
     with open(os.path.join(DIST_DIR, 'manifest.json'), 'w') as f:
         json.dump(manifest, f, indent=2)

--- a/portal/static/dist/document_list-f404e197.js
+++ b/portal/static/dist/document_list-f404e197.js
@@ -1,0 +1,1 @@
+document.addEventListener('htmx:afterSwap', function (evt) {if (evt.target.id === 'document-table') {window.scrollTo(0, 0);}});

--- a/portal/static/dist/manifest.json
+++ b/portal/static/dist/manifest.json
@@ -1,4 +1,5 @@
 {
   "app.css": "app-bfd4bd45.css",
+  "document_list.js": "document_list-f404e197.js",
   "app.js": "app-900a75a7.js"
 }

--- a/portal/static/src/document_list.js
+++ b/portal/static/src/document_list.js
@@ -1,0 +1,5 @@
+document.addEventListener('htmx:afterSwap', function (evt) {
+  if (evt.target.id === 'document-table') {
+    window.scrollTo(0, 0);
+  }
+});

--- a/portal/templates/document_list.html
+++ b/portal/templates/document_list.html
@@ -1,0 +1,59 @@
+{% extends "layout.html" %}
+{% block title %}Documents{% endblock %}
+{% block content %}
+{% macro table(docs, page, pages, params) %}
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Code</th>
+      <th>Title</th>
+      <th>Status</th>
+      <th>Department</th>
+      <th>Tags</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for doc in docs %}
+    <tr>
+      <td>{{ doc.code }}</td>
+      <td>{{ doc.title }}</td>
+      <td>{{ doc.status }}</td>
+      <td>{{ doc.department }}</td>
+      <td>{{ doc.tags }}</td>
+    </tr>
+    {% else %}
+    <tr><td colspan="5">No documents found.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+<nav>
+  <ul class="pagination">
+    {% if page > 1 %}
+    <li class="page-item"><a class="page-link" hx-get="{{ url_for('list_documents', page=page-1, **params) }}" hx-target="#document-table" hx-push-url="true">Previous</a></li>
+    {% endif %}
+    <li class="page-item disabled"><span class="page-link">{{ page }} / {{ pages }}</span></li>
+    {% if page < pages %}
+    <li class="page-item"><a class="page-link" hx-get="{{ url_for('list_documents', page=page+1, **params) }}" hx-target="#document-table" hx-push-url="true">Next</a></li>
+    {% endif %}
+  </ul>
+</nav>
+{% endmacro %}
+
+{% if partial %}
+  {{ table(documents, page, pages, params) }}
+{% else %}
+<h1>Documents</h1>
+<form hx-get="{{ url_for('list_documents') }}" hx-target="#document-table" hx-push-url="true" class="row g-2 mb-3">
+  <div class="col-md-2"><input class="form-control" name="code" placeholder="Code" value="{{ filters.code or '' }}"></div>
+  <div class="col-md-2"><input class="form-control" name="title" placeholder="Title" value="{{ filters.title or '' }}"></div>
+  <div class="col-md-2"><input class="form-control" name="status" placeholder="Status" value="{{ filters.status or '' }}"></div>
+  <div class="col-md-2"><input class="form-control" name="department" placeholder="Department" value="{{ filters.department or '' }}"></div>
+  <div class="col-md-2"><input class="form-control" name="tag" placeholder="Tag" value="{{ filters.tag or '' }}"></div>
+  <div class="col-md-2"><button class="btn btn-primary w-100" type="submit">Filter</button></div>
+</form>
+<div id="document-table">
+  {{ table(documents, page, pages, params) }}
+</div>
+<script src="{{ asset_url('document_list.js') }}" defer></script>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/documents` route supporting code, title, status, department and tag filters with limit/offset pagination
- create HTMX-powered document list template and JS helper
- build static assets automatically for all JS/CSS sources

## Testing
- `python -m pytest`
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_689f19a09228832bb18760a6cc83db48