### PR TITLE
Make session cookie security configurable

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -47,7 +47,10 @@ app.config.update(
     OIDC_CLIENT_SECRET=os.environ.get("OIDC_CLIENT_SECRET", ""),
     OIDC_ISSUER=os.environ.get("OIDC_ISSUER", ""),
     SESSION_COOKIE_HTTPONLY=True,
-    SESSION_COOKIE_SECURE=True,
+)
+
+app.config["SESSION_COOKIE_SECURE"] = (
+    os.environ.get("SESSION_COOKIE_SECURE", "true").lower() == "true"
 )
 
 CSRFProtect(app)


### PR DESCRIPTION
## Summary
- configure session cookie security via `SESSION_COOKIE_SECURE` env variable

## Testing
- `pytest`
- `docker compose build portal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f1ba78400832b9505424eb6a8b6b7