### PR TITLE
Remove OpenID and simplify LDAP login

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -43,9 +43,6 @@ from signing import create_signed_pdf
 app = Flask(__name__, static_folder="static/dist")
 app.secret_key = os.environ.get("SECRET_KEY", "dev")
 app.config.update(
-    OIDC_CLIENT_ID=os.environ.get("OIDC_CLIENT_ID", ""),
-    OIDC_CLIENT_SECRET=os.environ.get("OIDC_CLIENT_SECRET", ""),
-    OIDC_ISSUER=os.environ.get("OIDC_ISSUER", ""),
     SESSION_COOKIE_HTTPONLY=True,
 )
 

--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -12,7 +12,6 @@ fpdf==1.7.2
 pandas==2.2.2
 openpyxl==3.1.2
 reportlab==4.1.0
-authlib
 Flask-WTF
 six==1.16.0
 PyJWT==2.8.0


### PR DESCRIPTION
## Summary
- Drop OpenID Connect integration and configuration
- Streamline LDAP-only authentication and setup
- Remove unused `authlib` dependency

## Testing
- `python -m py_compile portal/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f41605cf8832b96b2fdd323783dc8