### PR TITLE
Add document version comparison view

### DIFF
--- a/portal/templates/document_compare.html
+++ b/portal/templates/document_compare.html
@@ -1,0 +1,9 @@
+{% extends "layout.html" %}
+{% block title %}Compare Versions{% endblock %}
+{% block content %}
+<h1>Version Comparison</h1>
+<div class="mb-3">
+  {{ diff|safe }}
+</div>
+<a class="btn btn-secondary" href="{{ url_for('document_detail', doc_id=doc_id) }}">Back</a>
+{% endblock %}

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -2,16 +2,22 @@
 {% block title %}Document Detail{% endblock %}
 {% block content %}
 {% macro version_list(doc, revisions) %}
+<form method="get" action="{{ url_for('compare_document_versions', doc_id=doc.id) }}">
 <ul class="list-group">
   {% for rev in revisions %}
   <li class="list-group-item d-flex justify-content-between align-items-center">
-    <a hx-get="{{ url_for('document_detail', doc_id=doc.id, revision_id=rev.id) }}" hx-target="#version-area" hx-push-url="false">{{ rev.major_version }}.{{ rev.minor_version }}</a>
+    <div class="d-flex align-items-center">
+      <input class="form-check-input me-2" type="checkbox" name="rev_id" value="{{ rev.id }}" id="rev-{{ rev.id }}">
+      <a hx-get="{{ url_for('document_detail', doc_id=doc.id, revision_id=rev.id) }}" hx-target="#version-area" hx-push-url="false">{{ rev.major_version }}.{{ rev.minor_version }}</a>
+    </div>
     <small class="text-muted">{{ rev.created_at.strftime('%Y-%m-%d') if rev.created_at else '' }}</small>
   </li>
   {% else %}
   <li class="list-group-item">No versions found.</li>
   {% endfor %}
 </ul>
+<button type="submit" class="btn btn-primary mt-2">Compare</button>
+</form>
 {% endmacro %}
 
 {% macro version_detail(doc, revision) %}


### PR DESCRIPTION
## Summary
- add multi-select version list with Compare button on document detail page
- implement `/documents/<doc_id>/compare` route to render diffs
- show differences in new `document_compare.html` template with back link

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f5b7b57c0832bbe5b70ff58de61e4