### PR TITLE
Add approvals queue with HTMX actions and toast alerts

### DIFF
--- a/portal/static/dist/app-8b588082.js
+++ b/portal/static/dist/app-8b588082.js
@@ -1,0 +1,1 @@
+import 'bootstrap';document.addEventListener('showToast', (event) => {const toastEl = document.getElementById('action-toast');if (!toastEl) return;toastEl.querySelector('.toast-body').textContent = event.detail;const toast = bootstrap.Toast.getOrCreateInstance(toastEl);toast.show();});console.log('app loaded');

--- a/portal/static/dist/app-900a75a7.js
+++ b/portal/static/dist/app-900a75a7.js
@@ -1,1 +1,0 @@
-import 'bootstrap';console.log('app loaded');

--- a/portal/static/dist/manifest.json
+++ b/portal/static/dist/manifest.json
@@ -1,7 +1,7 @@
 {
-  "app.js": "app-900a75a7.js",
-  "document_edit.js": "document_edit-42d55077.js",
-  "app.css": "app-bfd4bd45.css",
   "document_detail.js": "document_detail-eb1344bc.js",
+  "app.css": "app-bfd4bd45.css",
+  "document_edit.js": "document_edit-42d55077.js",
+  "app.js": "app-8b588082.js",
   "document_list.js": "document_list-f404e197.js"
 }

--- a/portal/static/src/app.js
+++ b/portal/static/src/app.js
@@ -1,2 +1,9 @@
 import 'bootstrap';
+document.addEventListener('showToast', (event) => {
+  const toastEl = document.getElementById('action-toast');
+  if (!toastEl) return;
+  toastEl.querySelector('.toast-body').textContent = event.detail;
+  const toast = bootstrap.Toast.getOrCreateInstance(toastEl);
+  toast.show();
+});
 console.log('app loaded');

--- a/portal/templates/_approval_modals.html
+++ b/portal/templates/_approval_modals.html
@@ -1,0 +1,35 @@
+<div class="modal fade" id="approveModal-{{ step.id }}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Approve "{{ step.document.title }}"?</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">Are you sure you want to approve this document?</div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <form hx-post="{{ url_for('approve_step', step_id=step.id) }}" hx-target="#step-{{ step.id }}" hx-swap="outerHTML">
+          <button type="submit" class="btn btn-success" data-bs-dismiss="modal">Approve</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="rejectModal-{{ step.id }}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Reject "{{ step.document.title }}"?</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">Are you sure you want to reject this document?</div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <form hx-post="{{ url_for('reject_step', step_id=step.id) }}" hx-target="#step-{{ step.id }}" hx-swap="outerHTML">
+          <button type="submit" class="btn btn-danger" data-bs-dismiss="modal">Reject</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/portal/templates/_approval_row.html
+++ b/portal/templates/_approval_row.html
@@ -1,0 +1,13 @@
+<tr id="step-{{ step.id }}">
+  <td>{{ step.document.title }}</td>
+  <td>{{ step.step_order }}</td>
+  <td>{{ step.status }}</td>
+  <td>
+    {% if step.status == 'Pending' %}
+    <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#approveModal-{{ step.id }}">Approve</button>
+    <button class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#rejectModal-{{ step.id }}">Reject</button>
+    {% else %}
+    {{ step.status }}
+    {% endif %}
+  </td>
+</tr>

--- a/portal/templates/approvals.html
+++ b/portal/templates/approvals.html
@@ -1,0 +1,25 @@
+{% extends "layout.html" %}
+{% block title %}Approvals{% endblock %}
+{% block content %}
+<h1>Approvals</h1>
+<table class="table" id="approval-table">
+  <thead>
+    <tr>
+      <th>Document</th>
+      <th>Step</th>
+      <th>Status</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for step in steps %}
+      {% include "_approval_row.html" %}
+    {% else %}
+    <tr><td colspan="4">No pending approvals.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% for step in steps %}
+  {% include "_approval_modals.html" %}
+{% endfor %}
+{% endblock %}

--- a/portal/templates/layout.html
+++ b/portal/templates/layout.html
@@ -53,6 +53,11 @@
     </main>
   </div>
 </div>
+<div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
+  <div id="action-toast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-body"></div>
+  </div>
+</div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{{ asset_url('app.js') }}" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- Implement `/approvals` page with role-based access and HTMX approve/reject actions
- Provide approval row and modal fragments and toast notifications
- Add client-side toast handler and build updated static assets

## Testing
- `python -m py_compile portal/app.py`
- `cd portal/static && python build.py`


------
https://chatgpt.com/codex/tasks/task_e_689f5cf8b5e8832bbfc3066329ea4cb6