### PR TITLE
Use session user for acknowledgements

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -527,11 +527,10 @@ def save_revision(doc_id):
 @app.post("/documents/<int:doc_id>/acknowledge")
 @roles_required(RoleEnum.READER.value)
 def acknowledge_document(doc_id):
-    data = request.get_json(silent=True) or {}
-    user_id = data.get("user_id") or request.form.get("user_id")
-    if not user_id:
-        return jsonify(error="user_id required"), 400
-    user_id = int(user_id)
+    user = session.get("user")
+    if not user:
+        return jsonify(error="user not logged in"), 401
+    user_id = user["id"]
     session = get_session()
     try:
         doc = session.get(Document, doc_id)

--- a/portal/templates/acknowledgements.html
+++ b/portal/templates/acknowledgements.html
@@ -22,7 +22,6 @@
       <td>
         <button class="btn btn-sm btn-success"
                 hx-post="{{ url_for('acknowledge_document', doc_id=doc.id) }}"
-                hx-vals='{"user_id":"{{ current_user.id }}"}'
                 hx-target="closest tr"
                 hx-swap="delete"
                 hx-on="htmx:afterRequest: document.getElementById('remaining').innerText = parseInt(document.getElementById('remaining').innerText) - 1">


### PR DESCRIPTION
## Summary
- get user id from session in `acknowledge_document`
- stop sending `user_id` via `hx-vals` in acknowledgements template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f633af534832ba06cd4085abdf708