### PR TITLE
Ensure CSRF protection for HTMX submissions

### DIFF
--- a/portal/templates/_approval_modals.html
+++ b/portal/templates/_approval_modals.html
@@ -9,6 +9,7 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
         <form hx-post="{{ url_for('approve_step', step_id=step.id) }}" hx-target="#step-{{ step.id }}" hx-swap="outerHTML">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <button type="submit" class="btn btn-success" data-bs-dismiss="modal">Approve</button>
         </form>
       </div>
@@ -27,6 +28,7 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
         <form hx-post="{{ url_for('reject_step', step_id=step.id) }}" hx-target="#step-{{ step.id }}" hx-swap="outerHTML">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <button type="submit" class="btn btn-danger" data-bs-dismiss="modal">Reject</button>
         </form>
       </div>

--- a/portal/templates/acknowledgements.html
+++ b/portal/templates/acknowledgements.html
@@ -20,13 +20,13 @@
       <td>{{ doc.department }}</td>
       <td>{{ doc.tags }}</td>
       <td>
-        <button class="btn btn-sm btn-success"
-                hx-post="{{ url_for('acknowledge_document', doc_id=doc.id) }}"
-                hx-target="closest tr"
-                hx-swap="delete"
-                hx-on="htmx:afterRequest: document.getElementById('remaining').innerText = parseInt(document.getElementById('remaining').innerText) - 1">
-          Okudum
-        </button>
+        <form hx-post="{{ url_for('acknowledge_document', doc_id=doc.id) }}"
+              hx-target="closest tr"
+              hx-swap="delete"
+              hx-on="htmx:afterRequest: document.getElementById('remaining').innerText = parseInt(document.getElementById('remaining').innerText) - 1">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" class="btn btn-sm btn-success">Okudum</button>
+        </form>
       </td>
     </tr>
     {% else %}

--- a/portal/templates/layout.html
+++ b/portal/templates/layout.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>{% block title %}Portal{% endblock %}</title>
+  <meta name="csrf-token" content="{{ csrf_token() }}">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="{{ asset_url('app.css') }}">
 </head>
@@ -60,5 +61,11 @@
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{{ asset_url('app.js') }}" defer></script>
+<script>
+  document.body.addEventListener('htmx:configRequest', function (event) {
+    var token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+    event.detail.headers['X-CSRFToken'] = token;
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add hidden CSRF tokens to approval and rejection modals
- convert acknowledgement action to an HTMX form including CSRF token
- configure HTMX to attach CSRF token header for all requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f643e6450832b8bd0d6212eeaf5a8