### PR TITLE
feat: expand search facets

### DIFF
--- a/portal/templates/search.html
+++ b/portal/templates/search.html
@@ -3,18 +3,43 @@
 {% block content %}
 <h1>Search Documents</h1>
 <form method="get" class="row g-2">
-  <div class="col-md-2"><input class="form-control" name="title" placeholder="Title" value="{{ filters.title or '' }}"></div>
-  <div class="col-md-2"><input class="form-control" name="code" placeholder="Code" value="{{ filters.code or '' }}"></div>
-  <div class="col-md-2"><input class="form-control" name="tags" placeholder="Tags" value="{{ filters.tags or '' }}"></div>
+  <div class="col-md-3"><input class="form-control" name="q" placeholder="Keyword" value="{{ keyword or '' }}"></div>
   <div class="col-md-2"><input class="form-control" name="department" placeholder="Department" value="{{ filters.department or '' }}"></div>
-  <div class="col-md-2"><input class="form-control" name="process" placeholder="Process" value="{{ filters.process or '' }}"></div>
+  <div class="col-md-2"><input class="form-control" name="status" placeholder="Status" value="{{ filters.status or '' }}"></div>
+  <div class="col-md-2"><input class="form-control" name="type" placeholder="Type" value="{{ filters.type or '' }}"></div>
   <div class="col-md-2"><button class="btn btn-primary w-100" type="submit">Search</button></div>
 </form>
-<ul class="mt-3">
-{% for doc in results %}
-  <li>{{ doc.title }} ({{ doc.code }}) - {{ doc.department }} - {{ doc.process }} - {{ doc.tags }}</li>
-{% else %}
-  <li>No results found.</li>
-{% endfor %}
-</ul>
+
+<div class="row mt-3">
+  <div class="col-md-3">
+    <h5>Facets</h5>
+    <strong>Department</strong>
+    <ul>
+    {% for val, count in facets.department.items() %}
+      <li><a href="{{ url_for('search_view', q=keyword, department=val) }}">{{ val }} ({{ count }})</a></li>
+    {% endfor %}
+    </ul>
+    <strong>Status</strong>
+    <ul>
+    {% for val, count in facets.status.items() %}
+      <li><a href="{{ url_for('search_view', q=keyword, status=val) }}">{{ val }} ({{ count }})</a></li>
+    {% endfor %}
+    </ul>
+    <strong>Type</strong>
+    <ul>
+    {% for val, count in facets.type.items() %}
+      <li><a href="{{ url_for('search_view', q=keyword, type=val) }}">{{ val }} ({{ count }})</a></li>
+    {% endfor %}
+    </ul>
+  </div>
+  <div class="col-md-9">
+    <ul>
+    {% for doc in results %}
+      <li>{{ doc.title }} ({{ doc.code }}) - {{ doc.department }} - {{ doc.status }} - {{ doc.type }}</li>
+    {% else %}
+      <li>No results found.</li>
+    {% endfor %}
+    </ul>
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- index department, status, and type in Elasticsearch with cached aggregations
- support keyword and facet filters in `/search`
- show facet counts and metadata in search results

## Testing
- `python -m py_compile portal/search.py portal/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f68a65aac832b8f0796488c9cd60a