### PR TITLE
Add security headers and test scaffolding

### DIFF
--- a/SECURITY_REPORT.md
+++ b/SECURITY_REPORT.md
@@ -1,0 +1,9 @@
+# Security Test Results
+
+`run_security_tests.sh` was executed to perform static analysis and dynamic scans.
+
+- **Bandit**: not installed in the environment; no Python security analysis was run.
+- **OWASP ZAP**: not installed; no baseline scan was performed.
+- **Lighthouse**: command not available; no audit report generated.
+
+These tools should be installed and the script re-run in a full environment to produce complete reports.

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,6 +27,10 @@ http {
     listen 80;
     server_name _;
 
+    add_header Content-Security-Policy "default-src 'self'; frame-ancestors 'none'";
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "DENY";
+
     # 443 kullanacaksanız:
     # listen 443 ssl http2;
     # ssl_certificate     /etc/nginx/certs/fullchain.pem;

--- a/portal/app.py
+++ b/portal/app.py
@@ -51,11 +51,20 @@ app = Flask(__name__, static_folder="static/dist")
 app.secret_key = os.environ.get("SECRET_KEY", "dev")
 app.config.update(
     SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SAMESITE="Lax",
 )
 
 app.config["SESSION_COOKIE_SECURE"] = (
     os.environ.get("SESSION_COOKIE_SECURE", "true").lower() == "true"
 )
+
+
+@app.after_request
+def set_security_headers(response):
+    response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none'"
+    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    response.headers["X-Frame-Options"] = "DENY"
+    return response
 
 CSRFProtect(app)
 auth_init(app)

--- a/scripts/run_security_tests.sh
+++ b/scripts/run_security_tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Run security scanners and generate reports.
+set -e
+
+# Bandit: Python static analysis
+if command -v bandit >/dev/null 2>&1; then
+  bandit -r portal -f json -o bandit-report.json
+else
+  echo "bandit not installed" >&2
+fi
+
+# OWASP ZAP baseline scan
+if command -v zap-baseline.py >/dev/null 2>&1; then
+  zap-baseline.py -t http://localhost:8090 -r zap-report.html || true
+else
+  echo "OWASP ZAP baseline not installed" >&2
+fi
+
+# Lighthouse audit
+if command -v lighthouse >/dev/null 2>&1; then
+  lighthouse http://localhost:8090 --output html --output-path lighthouse-report.html || true
+else
+  echo "Lighthouse not installed" >&2
+fi


### PR DESCRIPTION
## Summary
- enforce secure cookie policy and HTTP headers (CSP, HSTS, X-Frame-Options)
- configure nginx reverse proxy with security headers
- add script and report scaffolding for security scans

## Testing
- `scripts/run_security_tests.sh` *(fails: bandit not installed, OWASP ZAP baseline not installed, Lighthouse not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689f846a11a0832b8b96855b25ef167c