### PR TITLE
Use semantic base layout and constrain container width

### DIFF
--- a/portal/static/src/app.css
+++ b/portal/static/src/app.css
@@ -3,3 +3,16 @@
 body {
   padding-top: 60px;
 }
+
+/* Ensure containers span the full width on small screens */
+.container {
+  width: 100%;
+  margin: 0 auto;
+}
+
+/* Constrain container width on large displays */
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}

--- a/portal/templates/acknowledgements.html
+++ b/portal/templates/acknowledgements.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Acknowledgements{% endblock %}
 {% block content %}
 {% macro table(docs) %}

--- a/portal/templates/admin/departments.html
+++ b/portal/templates/admin/departments.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block content %}
 <h1>Departments</h1>
 <table class="table">

--- a/portal/templates/admin/roles.html
+++ b/portal/templates/admin/roles.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block content %}
 <h1>Assign Role</h1>
 <form id="roleForm">

--- a/portal/templates/admin/users.html
+++ b/portal/templates/admin/users.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block content %}
 <h1>Users</h1>
 <table class="table">

--- a/portal/templates/approvals.html
+++ b/portal/templates/approvals.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Approvals{% endblock %}
 {% block content %}
 <h1>Approvals</h1>

--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -8,19 +8,23 @@
   <link rel="stylesheet" href="{{ asset_url('app.css') }}">
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="/">Portal</a>
-    <ul class="navbar-nav ms-auto">
-      {% if current_user %}
-      <li class="nav-item"><span class="navbar-text">{{ current_user.username }}</span></li>
-      {% else %}
-      <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Login</a></li>
-      {% endif %}
-    </ul>
-  </div>
-</nav>
-<div class="container-fluid">
+<header>
+  {% block header %}
+  <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+    <div class="container">
+      <a class="navbar-brand" href="/">Portal</a>
+      <ul class="navbar-nav ms-auto">
+        {% if current_user %}
+        <li class="nav-item"><span class="navbar-text">{{ current_user.username }}</span></li>
+        {% else %}
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Login</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </nav>
+  {% endblock %}
+</header>
+<div class="container">
   <div class="row">
     <aside class="col-md-2 d-none d-md-block bg-light sidebar">
       {% block sidebar %}

--- a/portal/templates/capa_track.html
+++ b/portal/templates/capa_track.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}CAPA Tracker{% endblock %}
 {% block content %}
 <h1>CAPA Actions</h1>

--- a/portal/templates/document_compare.html
+++ b/portal/templates/document_compare.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Compare Versions{% endblock %}
 {% block content %}
 <h1>Version Comparison</h1>

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Document Detail{% endblock %}
 {% block content %}
 {% macro version_list(doc, revisions) %}

--- a/portal/templates/document_edit.html
+++ b/portal/templates/document_edit.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Edit Document{% endblock %}
 {% block content %}
 <div id="editor-wrapper" style="height:80vh;">

--- a/portal/templates/document_list.html
+++ b/portal/templates/document_list.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Documents{% endblock %}
 {% block content %}
 {% macro table(docs, page, pages, params) %}

--- a/portal/templates/index.html
+++ b/portal/templates/index.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Home{% endblock %}
 {% block content %}
 <h1>Welcome</h1>

--- a/portal/templates/login.html
+++ b/portal/templates/login.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Login{% endblock %}
 {% block content %}
 <h1>Login</h1>

--- a/portal/templates/reports.html
+++ b/portal/templates/reports.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Reports{% endblock %}
 {% block content %}
 <h1>Reports Dashboard</h1>

--- a/portal/templates/search.html
+++ b/portal/templates/search.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Document Search{% endblock %}
 {% block content %}
 <h1>Search Documents</h1>

--- a/portal/templates/settings.html
+++ b/portal/templates/settings.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}User Settings{% endblock %}
 {% block content %}
 <h3>User Settings</h3>


### PR DESCRIPTION
## Summary
- replace `layout.html` with `base.html` using semantic `<header>`, `<aside>`, and `<main>` regions
- limit `.container` width to 1280px while keeping full width on small screens
- update all templates to extend the new base layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f880382a8832b86132dd7d997c0e0