### PR TITLE
Add reusable header with responsive search

### DIFF
--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -10,18 +10,7 @@
 <body>
 <header>
   {% block header %}
-  <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
-    <div class="container">
-      <a class="navbar-brand" href="/">Portal</a>
-      <ul class="navbar-nav ms-auto">
-        {% if current_user %}
-        <li class="nav-item"><span class="navbar-text">{{ current_user.username }}</span></li>
-        {% else %}
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Login</a></li>
-        {% endif %}
-      </ul>
-    </div>
-  </nav>
+  {% include 'partials/_header.html' %}
   {% endblock %}
 </header>
 <div class="container">

--- a/portal/templates/partials/_header.html
+++ b/portal/templates/partials/_header.html
@@ -1,0 +1,39 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+  <div class="container">
+    <a class="navbar-brand" href="/">Portal</a>
+
+    <form class="d-none d-lg-flex ms-auto me-3" role="search" action="{{ url_for('search_view') }}" method="get">
+      <input class="form-control" type="search" placeholder="Search" aria-label="Search" name="q">
+    </form>
+
+    <button class="btn btn-outline-secondary d-lg-none ms-auto me-2" type="button"
+            data-bs-toggle="collapse" data-bs-target="#navbar-search"
+            aria-controls="navbar-search" aria-expanded="false" aria-label="Toggle search">
+      🔍
+    </button>
+
+    <ul class="navbar-nav align-items-center">
+      {% if current_user %}
+      <li class="nav-item"><a class="nav-link" href="/notifications/{{ current_user.id }}/view">🔔</a></li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          {{ current_user.username }}
+        </a>
+        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+          <li><a class="dropdown-item" href="/profile">Profile</a></li>
+          <li><a class="dropdown-item" href="/language">Language</a></li>
+          <li><hr class="dropdown-divider"></li>
+          <li><a class="dropdown-item" href="/logout">Logout</a></li>
+        </ul>
+      </li>
+      {% else %}
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Login</a></li>
+      {% endif %}
+    </ul>
+  </div>
+  <div class="collapse w-100" id="navbar-search">
+    <form class="p-3" action="{{ url_for('search_view') }}" method="get">
+      <input class="form-control" type="search" placeholder="Search" aria-label="Search" name="q">
+    </form>
+  </div>
+</nav>


### PR DESCRIPTION
## Summary
- Create `_header.html` partial with logo, search bar, notifications and user menu
- Hide search below 992px and toggle via a search icon
- Include header partial in base template for site-wide use

## Testing
- `pytest`
- `bash scripts/run_security_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689f89a85898832baa70b8d7a170900c