### PR TITLE
Add toast and skeleton partials with HTMX error handling

### DIFF
--- a/portal/static/src/app.js
+++ b/portal/static/src/app.js
@@ -1,11 +1,43 @@
 import 'bootstrap';
-document.addEventListener('showToast', (event) => {
+
+function displayToast(message) {
   const toastEl = document.getElementById('action-toast');
   if (!toastEl) return;
-  toastEl.querySelector('.toast-body').textContent = event.detail;
+  toastEl.querySelector('.toast-body').textContent = message;
   const toast = bootstrap.Toast.getOrCreateInstance(toastEl);
   toast.show();
+}
+
+document.addEventListener('showToast', (event) => {
+  displayToast(event.detail);
 });
+
+document.body.addEventListener('htmx:responseError', (event) => {
+  displayToast(event.detail.xhr.response || 'Request failed');
+  if (event.detail.target) {
+    event.detail.target.innerHTML = '';
+  }
+});
+
+document.body.addEventListener('htmx:sendError', () => {
+  displayToast('Request failed');
+});
+
+document.body.addEventListener('htmx:beforeRequest', (event) => {
+  const target = event.detail.target;
+  const tmpl = document.getElementById('skeleton-template');
+  if (target && tmpl) {
+    target.innerHTML = tmpl.innerHTML;
+  }
+});
+
+document.body.addEventListener('htmx:afterSwap', (event) => {
+  const target = event.detail.target;
+  if (target && !target.innerHTML.trim()) {
+    target.innerHTML = '<div class="text-muted text-center py-5">No content available.</div>';
+  }
+});
+
 console.log('app loaded');
 
 function connectEvents() {

--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -29,11 +29,8 @@
     </main>
   </div>
 </div>
-<div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
-  <div id="action-toast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-    <div class="toast-body"></div>
-  </div>
-</div>
+{% include 'partials/_toasts.html' %}
+{% include 'partials/_skeleton.html' %}
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{{ asset_url('app.js') }}" defer></script>
 <script>

--- a/portal/templates/partials/_skeleton.html
+++ b/portal/templates/partials/_skeleton.html
@@ -1,0 +1,7 @@
+<template id="skeleton-template">
+  <div class="placeholder-glow">
+    <span class="placeholder col-12 mb-2"></span>
+    <span class="placeholder col-12 mb-2"></span>
+    <span class="placeholder col-12 mb-2"></span>
+  </div>
+</template>

--- a/portal/templates/partials/_toasts.html
+++ b/portal/templates/partials/_toasts.html
@@ -1,0 +1,5 @@
+<div class="position-fixed bottom-0 end-0 p-3" style="z-index: 11">
+  <div id="action-toast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="toast-body"></div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- factor toast markup into a partial and include from base template
- provide skeleton placeholder partial for HTMX loading states
- enhance app.js with HTMX error handling, skeleton injection and empty-state fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f8eefb5a0832bbee8be5f1c10125e