### PR TITLE
Add HTMX-powered dashboard cards

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -186,8 +186,55 @@ def sse_events():
 
 @app.route("/")
 @login_required
-def index():
-    return render_template("index.html", breadcrumbs=[{"title": "Home"}])
+def dashboard():
+    context = {
+        "breadcrumbs": [{"title": "Dashboard"}],
+        "pending_approvals": [],
+        "mandatory_reading": [],
+        "recent_revisions": [],
+        "quick_access": [],
+    }
+    return render_template("dashboard.html", **context)
+
+
+@app.get("/dashboard/cards/pending")
+@login_required
+def dashboard_cards_pending():
+    return render_template(
+        "partials/dashboard/_cards.html",
+        card="pending",
+        pending_approvals=[],
+    )
+
+
+@app.get("/dashboard/cards/mandatory")
+@login_required
+def dashboard_cards_mandatory():
+    return render_template(
+        "partials/dashboard/_cards.html",
+        card="mandatory",
+        mandatory_reading=[],
+    )
+
+
+@app.get("/dashboard/cards/recent")
+@login_required
+def dashboard_cards_recent():
+    return render_template(
+        "partials/dashboard/_cards.html",
+        card="recent",
+        recent_revisions=[],
+    )
+
+
+@app.get("/dashboard/cards/quick")
+@login_required
+def dashboard_cards_quick():
+    return render_template(
+        "partials/dashboard/_cards.html",
+        card="quick",
+        quick_access=[],
+    )
 
 
 @app.get("/health")

--- a/portal/templates/dashboard.html
+++ b/portal/templates/dashboard.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+  {% include 'partials/dashboard/_cards.html' %}
+{% endblock %}

--- a/portal/templates/partials/dashboard/_cards.html
+++ b/portal/templates/partials/dashboard/_cards.html
@@ -1,0 +1,35 @@
+{% macro render_card(title, items, empty_text, endpoint) %}
+<div class="col-md-6 mb-3">
+  <div class="card" hx-get="{{ endpoint }}" hx-trigger="load, every 10s" hx-target="this">
+    <div class="card-header">{{ title }}</div>
+    <div class="card-body">
+      {% if items %}
+        <ul class="list-unstyled mb-0">
+        {% for item in items %}
+          <li>{{ item }}</li>
+        {% endfor %}
+        </ul>
+      {% else %}
+        <p class="text-muted mb-0">{{ empty_text }}</p>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endmacro %}
+
+{% if card == 'pending' %}
+  {{ render_card('Pending Approvals', pending_approvals, 'No pending approvals.', url_for('dashboard_cards_pending')) }}
+{% elif card == 'mandatory' %}
+  {{ render_card('Mandatory Reading', mandatory_reading, 'No mandatory documents.', url_for('dashboard_cards_mandatory')) }}
+{% elif card == 'recent' %}
+  {{ render_card('Recent Revisions', recent_revisions, 'No recent revisions.', url_for('dashboard_cards_recent')) }}
+{% elif card == 'quick' %}
+  {{ render_card('Quick Access', quick_access, 'No quick links available.', url_for('dashboard_cards_quick')) }}
+{% else %}
+<div class="row">
+  {{ render_card('Pending Approvals', pending_approvals, 'No pending approvals.', url_for('dashboard_cards_pending')) }}
+  {{ render_card('Mandatory Reading', mandatory_reading, 'No mandatory documents.', url_for('dashboard_cards_mandatory')) }}
+  {{ render_card('Recent Revisions', recent_revisions, 'No recent revisions.', url_for('dashboard_cards_recent')) }}
+  {{ render_card('Quick Access', quick_access, 'No quick links available.', url_for('dashboard_cards_quick')) }}
+</div>
+{% endif %}


### PR DESCRIPTION
## Summary
- Add dashboard view bound to `/` with placeholder data
- Introduce reusable card partials refreshed every 10s via HTMX
- Include dashboard template to render auto-refreshing widgets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f908da0cc832bb42cd29098c927b0