### PR TITLE
Add OnlyOffice document editing page with full-height iframe

### DIFF
--- a/portal/templates/documents/detail.html
+++ b/portal/templates/documents/detail.html
@@ -2,7 +2,7 @@
 {% block title %}Document Detail{% endblock %}
 {% block page_actions %}
 {% if has_role('CONTRIBUTOR') %}
-<a class="btn btn-primary" href="{{ url_for('edit', doc_key=doc.doc_key) }}">Edit</a>
+<a class="btn btn-primary" href="{{ url_for('edit_document', doc_id=doc.id) }}">Edit</a>
 {% endif %}
 {% endblock %}
 {% block content %}

--- a/portal/templates/documents/edit.html
+++ b/portal/templates/documents/edit.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Edit Document{% endblock %}
+{% block page_actions %}
+<a class="btn btn-secondary" href="{{ url_for('document_detail', doc_id=doc_id) }}">Back</a>
+<a class="btn btn-secondary" href="{{ url_for('document_detail', doc_id=doc_id) }}#versions">Versions</a>
+<a class="btn btn-secondary" href="{{ url_for('compare_document_versions', doc_id=doc_id) }}">Compare</a>
+{% endblock %}
+{% block content %}
+<div id="editor-container" class="vh-100 overflow-auto">
+  <!-- OnlyOffice editor iframe placeholder -->
+  <iframe id="docEditor" class="w-100 h-100 border-0" title="Document editor"></iframe>
+</div>
+<script>
+  const editorConfig = {{ config | tojson }};
+  const editorToken = {{ token | tojson }};
+</script>
+<script src="{{ editor_js }}"></script>
+<script>
+  if (editorToken && window.DocsAPI && window.DocsAPI.setRequestHeaders) {
+    window.DocsAPI.setRequestHeaders([{ header: '{{ token_header|default('Authorization') }}', value: editorToken }]);
+  }
+  window.docEditor = new DocsAPI.DocEditor('docEditor', editorConfig);
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add `/documents/<id>/edit` route wiring OnlyOffice config and token to the template
- Provide new `documents/edit.html` with back, versions and compare controls plus full-height iframe editor
- Update document detail page to link to new edit route

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f97e8a608832bb43ad2e1bd7b419e