### PR TITLE
Add acknowledgements list and HTMX table partial

### DIFF
--- a/portal/templates/ack/list.html
+++ b/portal/templates/ack/list.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Acknowledgements{% endblock %}
+{% block content %}
+<h1>Acknowledgements (<span id="ack-count">{{ remaining }}</span>)</h1>
+<form hx-get="{{ url_for('ack.list') }}" hx-target="#ack-table" hx-push-url="true" class="row g-2 mb-3">
+  <div class="col-md-3">
+    <input class="form-control" name="status" placeholder="Status" value="{{ filters.status or '' }}">
+  </div>
+  <div class="col-md-3">
+    <input class="form-control" type="date" name="due" value="{{ filters.due or '' }}">
+  </div>
+  <div class="col-md-2">
+    <button class="btn btn-primary w-100" type="submit">Filter</button>
+  </div>
+</form>
+<div id="ack-table">
+  {% include 'partials/ack/_table.html' %}
+</div>
+{% endblock %}

--- a/portal/templates/partials/ack/_table.html
+++ b/portal/templates/partials/ack/_table.html
@@ -1,0 +1,34 @@
+<table class="table table-striped">
+  <thead class="table-light">
+    <tr>
+      <th>Code</th>
+      <th>Title</th>
+      <th>Status</th>
+      <th>Due</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in acknowledgements %}
+    <tr>
+      <td>{{ item.code }}</td>
+      <td>{{ item.title }}</td>
+      <td>{{ item.status }}</td>
+      <td>{{ item.due_date }}</td>
+      <td>
+        <form hx-post="{{ url_for('acknowledge_document', doc_id=item.id) }}"
+              hx-target="closest tr"
+              hx-swap="delete"
+              hx-on="htmx:afterRequest: document.getElementById('ack-count').innerText = parseInt(document.getElementById('ack-count').innerText) - 1">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" class="btn btn-sm btn-success">Acknowledge</button>
+        </form>
+      </td>
+    </tr>
+    {% else %}
+    <tr>
+      <td colspan="5" class="text-center py-3">All acknowledgements completed. Great job!</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary
- Add acknowledgements list template with status and due filters
- Create HTMX-enabled acknowledgements table partial with empty guidance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f9d5200e8832bbbc977392757caeb