### PR TITLE
Add notifications panel with HTMX and offcanvas UI

### DIFF
--- a/portal/models.py
+++ b/portal/models.py
@@ -143,6 +143,17 @@ class Acknowledgement(Base):
     )
 
 
+class Notification(Base):
+    __tablename__ = "notifications"
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    message = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    read = Column(Boolean, default=False, nullable=False)
+
+    user = relationship("User")
+
+
 class TrainingResult(Base):
     __tablename__ = "training_results"
     id = Column(Integer, primary_key=True)

--- a/portal/templates/partials/_header.html
+++ b/portal/templates/partials/_header.html
@@ -14,7 +14,11 @@
 
     <ul class="navbar-nav align-items-center">
       {% if current_user %}
-      <li class="nav-item"><a class="nav-link" href="/notifications/{{ current_user.id }}/view">🔔</a></li>
+      <li class="nav-item">
+        <a class="nav-link" role="button"
+           data-bs-toggle="offcanvas" data-bs-target="#notificationsOffcanvas"
+           aria-controls="notificationsOffcanvas">🔔</a>
+      </li>
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
           {{ current_user.username }}
@@ -37,3 +41,17 @@
     </form>
   </div>
 </nav>
+
+<div class="offcanvas offcanvas-end" tabindex="-1" id="notificationsOffcanvas"
+     style="--bs-offcanvas-width: min(100vw, 400px);">
+  <div class="offcanvas-header">
+    <h5 class="offcanvas-title">Notifications</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+  </div>
+  <div class="offcanvas-body p-0" id="notifications-panel"
+       hx-get="{{ url_for('notifications_panel') }}"
+       hx-trigger="revealed"
+       hx-target="#notifications-panel"
+       hx-swap="outerHTML">
+  </div>
+</div>

--- a/portal/templates/partials/_notifications_panel.html
+++ b/portal/templates/partials/_notifications_panel.html
@@ -1,0 +1,22 @@
+<div id="notifications-panel">
+  <div class="list-group list-group-flush">
+    {% for n in notifications %}
+    <div class="list-group-item d-flex justify-content-between align-items-center{% if not n.read %} fw-bold{% endif %}">
+      <span>{{ n.message }}</span>
+      {% if not n.read %}
+      <button class="btn btn-sm btn-link" hx-post="{{ url_for('notifications_panel') }}"
+              hx-vals='{"id": {{ n.id }} }' hx-target="#notifications-panel" hx-swap="outerHTML">Mark read</button>
+      {% endif %}
+    </div>
+    {% endfor %}
+    {% if notifications|length == 0 %}
+    <div class="p-3 text-center text-muted">No notifications</div>
+    {% endif %}
+  </div>
+  {% if has_more %}
+  <div class="text-center mt-2">
+    <button class="btn btn-link" hx-get="{{ url_for('notifications_panel', page=page+1) }}"
+            hx-target="#notifications-panel" hx-swap="outerHTML">Load more</button>
+  </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary
- add Notification model and HTMX endpoint `/notifications/panel` for pagination and read tracking
- include offcanvas notifications panel triggered from header bell
- render notifications list with HTMX actions to mark items read

## Testing
- `python -m py_compile portal/app.py portal/models.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f9e977a58832b847fc9048f0598c0