### PR TITLE
Add user profile page with preference controls

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -198,6 +198,15 @@ def dashboard():
     return render_template("dashboard.html", **context)
 
 
+@app.get("/profile")
+@login_required
+def profile_view():
+    return render_template(
+        "profile/index.html",
+        breadcrumbs=[{"title": "Profile"}]
+    )
+
+
 @app.get("/dashboard/cards/pending")
 @login_required
 def dashboard_cards_pending():

--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="light" data-density="comfortable">
 <head>
   <meta charset="utf-8">
   <title>{% block title %}Portal{% endblock %}</title>
@@ -8,6 +8,16 @@
   <link rel="stylesheet" href="{{ asset_url('app.css') }}">
 </head>
 <body>
+<script>
+  (function() {
+    const lang = localStorage.getItem('pref-language');
+    if (lang) document.documentElement.lang = lang;
+    const theme = localStorage.getItem('pref-theme');
+    if (theme) document.documentElement.setAttribute('data-bs-theme', theme);
+    const density = localStorage.getItem('pref-density');
+    if (density) document.documentElement.setAttribute('data-density', density);
+  })();
+</script>
 <header>
   {% block header %}
   {% include 'partials/_header.html' %}

--- a/portal/templates/partials/_header.html
+++ b/portal/templates/partials/_header.html
@@ -24,8 +24,7 @@
           {{ current_user.username }}
         </a>
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
-          <li><a class="dropdown-item" href="/profile">Profile</a></li>
-          <li><a class="dropdown-item" href="/language">Language</a></li>
+          <li><a class="dropdown-item" href="{{ url_for('profile_view') }}">Profile</a></li>
           <li><hr class="dropdown-divider"></li>
           <li><a class="dropdown-item" href="/logout">Logout</a></li>
         </ul>

--- a/portal/templates/profile/index.html
+++ b/portal/templates/profile/index.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% block title %}Profile{% endblock %}
+{% block content %}
+<h3>Profile</h3>
+<div class="mb-4">
+  <p><strong>Username:</strong> {{ current_user.username }}</p>
+  <p><strong>User ID:</strong> {{ current_user.id }}</p>
+</div>
+<form id="preferences-form" class="" onsubmit="return false;">
+  <div class="mb-3">
+    <label for="pref-language" class="form-label">Language</label>
+    <select id="pref-language" class="form-select">
+      <option value="en">English</option>
+      <option value="tr">Türkçe</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label for="pref-theme" class="form-label">Theme</label>
+    <select id="pref-theme" class="form-select">
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label for="pref-density" class="form-label">Table Density</label>
+    <select id="pref-density" class="form-select">
+      <option value="comfortable">Comfortable</option>
+      <option value="compact">Compact</option>
+    </select>
+  </div>
+</form>
+<script>
+(function() {
+  function setPref(key, value) {
+    localStorage.setItem(key, value);
+    document.cookie = key + '=' + value + ';path=/;max-age=31536000';
+  }
+  const langSel = document.getElementById('pref-language');
+  const themeSel = document.getElementById('pref-theme');
+  const densitySel = document.getElementById('pref-density');
+  const initLang = localStorage.getItem('pref-language') || 'en';
+  const initTheme = localStorage.getItem('pref-theme') || 'light';
+  const initDensity = localStorage.getItem('pref-density') || 'comfortable';
+  langSel.value = initLang;
+  themeSel.value = initTheme;
+  densitySel.value = initDensity;
+  langSel.addEventListener('change', (e) => {
+    setPref('pref-language', e.target.value);
+    document.documentElement.lang = e.target.value;
+  });
+  themeSel.addEventListener('change', (e) => {
+    setPref('pref-theme', e.target.value);
+    document.documentElement.setAttribute('data-bs-theme', e.target.value);
+  });
+  densitySel.addEventListener('change', (e) => {
+    setPref('pref-density', e.target.value);
+    document.documentElement.setAttribute('data-density', e.target.value);
+  });
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/profile` route and page to display user info and manage language, theme, and table density preferences
- persist UI preferences in localStorage/cookies and apply them on load
- link profile page from header dropdown

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fa01debe4832ba531479e242b45e1