### PR TITLE
feat: add shared design tokens

### DIFF
--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -1,0 +1,70 @@
+# Design Tokens
+
+Design tokens centralize style values for colors, typography, spacing, and more. All tokens are defined in `portal/static/css/_tokens.scss` and exposed as CSS variables for JavaScript.
+
+## Usage
+
+### SCSS
+```scss
+@use '../css/tokens' as *;
+
+.button {
+  background-color: $color-primary;
+  padding: $spacing-sm;
+  border-radius: $radius-md;
+}
+```
+
+### JavaScript
+```javascript
+import { getToken } from './tokens';
+
+const primary = getToken('color-primary');
+```
+
+## Tokens
+
+### Colors
+- `$color-primary` / `--color-primary`
+- `$color-primary-dark` / `--color-primary-dark`
+- `$color-text` / `--color-text`
+- `$color-background` / `--color-background`
+
+### Typography
+- `$font-size-xxs` / `--font-size-xxs`
+- `$font-size-xs` / `--font-size-xs`
+- `$font-size-sm` / `--font-size-sm`
+- `$font-size-md` / `--font-size-md`
+- `$font-size-lg` / `--font-size-lg`
+- `$font-size-xl` / `--font-size-xl`
+
+### Border Radius
+- `$radius-sm` / `--radius-sm`
+- `$radius-md` / `--radius-md`
+- `$radius-lg` / `--radius-lg`
+
+### Shadows
+- `$shadow-sm` / `--shadow-sm`
+- `$shadow-md` / `--shadow-md`
+- `$shadow-lg` / `--shadow-lg`
+
+### Spacing
+- `$spacing-xs` / `--spacing-xs`
+- `$spacing-sm` / `--spacing-sm`
+- `$spacing-md` / `--spacing-md`
+- `$spacing-lg` / `--spacing-lg`
+- `$spacing-xl` / `--spacing-xl`
+
+### Z-Index
+- `$z-base` / `--z-base`
+- `$z-overlay` / `--z-overlay`
+- `$z-dropdown` / `--z-dropdown`
+- `$z-sticky` / `--z-sticky`
+- `$z-modal` / `--z-modal`
+- `$z-popover` / `--z-popover`
+- `$z-tooltip` / `--z-tooltip`
+
+### Breakpoints
+- `$breakpoint-sm` / `--breakpoint-sm`
+- `$breakpoint-md` / `--breakpoint-md`
+- `$breakpoint-lg` / `--breakpoint-lg`

--- a/portal/static/css/_tokens.scss
+++ b/portal/static/css/_tokens.scss
@@ -1,0 +1,86 @@
+// Design token definitions
+// Color palette
+$color-primary: #005ea2;
+$color-primary-dark: #003a75;
+$color-text: #1a1a1a;
+$color-background: #ffffff;
+
+// Typography scale
+$font-size-xxs: 0.75rem;
+$font-size-xs: 0.875rem;
+$font-size-sm: 1rem;
+$font-size-md: 1.25rem;
+$font-size-lg: 1.5rem;
+$font-size-xl: 2rem;
+
+// Border radius
+$radius-sm: 2px;
+$radius-md: 4px;
+$radius-lg: 8px;
+
+// Shadows
+$shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+$shadow-md: 0 4px 6px rgba(0,0,0,0.1);
+$shadow-lg: 0 10px 15px rgba(0,0,0,0.15);
+
+// Spacing scale
+$spacing-xs: 0.25rem;
+$spacing-sm: 0.5rem;
+$spacing-md: 1rem;
+$spacing-lg: 2rem;
+$spacing-xl: 3rem;
+
+// Z-index levels
+$z-base: 1;
+$z-overlay: 100;
+$z-dropdown: 1000;
+$z-sticky: 1020;
+$z-modal: 1050;
+$z-popover: 1060;
+$z-tooltip: 1070;
+
+// Breakpoints
+$breakpoint-sm: 600px;
+$breakpoint-md: 1024px;
+$breakpoint-lg: 1280px;
+
+// Export as CSS variables
+:root {
+  --color-primary: #{$color-primary};
+  --color-primary-dark: #{$color-primary-dark};
+  --color-text: #{$color-text};
+  --color-background: #{$color-background};
+
+  --font-size-xxs: #{$font-size-xxs};
+  --font-size-xs: #{$font-size-xs};
+  --font-size-sm: #{$font-size-sm};
+  --font-size-md: #{$font-size-md};
+  --font-size-lg: #{$font-size-lg};
+  --font-size-xl: #{$font-size-xl};
+
+  --radius-sm: #{$radius-sm};
+  --radius-md: #{$radius-md};
+  --radius-lg: #{$radius-lg};
+
+  --shadow-sm: #{$shadow-sm};
+  --shadow-md: #{$shadow-md};
+  --shadow-lg: #{$shadow-lg};
+
+  --spacing-xs: #{$spacing-xs};
+  --spacing-sm: #{$spacing-sm};
+  --spacing-md: #{$spacing-md};
+  --spacing-lg: #{$spacing-lg};
+  --spacing-xl: #{$spacing-xl};
+
+  --z-base: #{$z-base};
+  --z-overlay: #{$z-overlay};
+  --z-dropdown: #{$z-dropdown};
+  --z-sticky: #{$z-sticky};
+  --z-modal: #{$z-modal};
+  --z-popover: #{$z-popover};
+  --z-tooltip: #{$z-tooltip};
+
+  --breakpoint-sm: #{$breakpoint-sm};
+  --breakpoint-md: #{$breakpoint-md};
+  --breakpoint-lg: #{$breakpoint-lg};
+}

--- a/portal/static/src/app.js
+++ b/portal/static/src/app.js
@@ -1,4 +1,6 @@
+import { getToken } from './tokens';
 import 'bootstrap';
+getToken('color-primary');
 
 function displayToast(message) {
   const toastEl = document.getElementById('action-toast');

--- a/portal/static/src/app.scss
+++ b/portal/static/src/app.scss
@@ -1,9 +1,11 @@
 @import "bootstrap/dist/css/bootstrap.css";
+@use "../css/tokens" as *;
+
 /* custom styles */
 body {
   padding-top: 60px;
-  color: #1a1a1a;
-  background-color: #fff;
+  color: $color-text;
+  background-color: $color-background;
 }
 
 /* Skip link for keyboard users */
@@ -11,10 +13,10 @@ body {
   position: absolute;
   top: -40px;
   left: 0;
-  background: #fff;
-  color: #005ea2;
-  padding: 8px;
-  z-index: 100;
+  background: $color-background;
+  color: $color-primary;
+  padding: $spacing-sm;
+  z-index: $z-overlay;
 }
 
 .skip-link:focus {
@@ -28,25 +30,25 @@ body {
 }
 
 /* Constrain container width on large displays */
-@media (min-width: 1280px) {
+@media (min-width: $breakpoint-lg) {
   .container {
-    max-width: 1280px;
+    max-width: $breakpoint-lg;
   }
 }
 
 /* High-contrast link styling */
 a {
-  color: #005ea2;
+  color: $color-primary;
 }
 
 a:hover,
 a:focus {
-  color: #003a75;
+  color: $color-primary-dark;
 }
 
 /* Consistent focus outlines */
 :focus {
-  outline: 2px solid #005ea2;
+  outline: 2px solid $color-primary;
   outline-offset: 2px;
 }
 
@@ -59,32 +61,32 @@ a:focus {
 }
 
 /* Responsive layout */
-@media (max-width: 599px) {
+@media (max-width: ($breakpoint-sm - 1)) {
   body {
     padding-top: 56px;
   }
   .container {
-    padding: 0 1rem;
+    padding: 0 $spacing-md;
   }
   .navbar-nav .nav-link {
-    padding: 0.5rem;
+    padding: $spacing-sm;
   }
 }
 
-@media (min-width: 600px) and (max-width: 1023px) {
+@media (min-width: $breakpoint-sm) and (max-width: ($breakpoint-md - 1)) {
   body {
     padding-top: 58px;
   }
   .container {
-    padding: 0 2rem;
+    padding: 0 $spacing-lg;
   }
 }
 
-@media (min-width: 1024px) {
+@media (min-width: $breakpoint-md) {
   body {
     padding-top: 60px;
   }
   .container {
-    padding: 0 3rem;
+    padding: 0 $spacing-xl;
   }
 }

--- a/portal/static/src/document_detail.js
+++ b/portal/static/src/document_detail.js
@@ -1,3 +1,6 @@
+import { getToken } from './tokens';
+getToken('color-primary');
+
 function initTabs() {
   const tabs = document.querySelectorAll('#document-tabs .nav-link');
   const panels = {

--- a/portal/static/src/document_edit.js
+++ b/portal/static/src/document_edit.js
@@ -1,3 +1,6 @@
+import { getToken } from './tokens';
+getToken('color-primary');
+
 document.addEventListener('DOMContentLoaded', () => {
   const cfg = Object.assign({}, window.editorConfig || {});
   cfg.events = {

--- a/portal/static/src/document_list.js
+++ b/portal/static/src/document_list.js
@@ -1,3 +1,6 @@
+import { getToken } from './tokens';
+getToken('color-primary');
+
 document.addEventListener('htmx:afterSwap', function (evt) {
   if (evt.target.id === 'document-table') {
     window.scrollTo(0, 0);

--- a/portal/static/src/reports.js
+++ b/portal/static/src/reports.js
@@ -1,3 +1,6 @@
+import { getToken } from './tokens';
+getToken('color-primary');
+
 async function fetchData(kind, startInput, endInput) {
   const params = new URLSearchParams();
   if (startInput.value) params.set('start', startInput.value);

--- a/portal/static/src/tokens.js
+++ b/portal/static/src/tokens.js
@@ -1,0 +1,7 @@
+import '../css/_tokens.scss';
+
+export function getToken(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(`--${name}`).trim();
+}
+
+export default { getToken };


### PR DESCRIPTION
## Summary
- centralize colors, spacing, and other design tokens in `_tokens.scss`
- ensure SCSS and JS modules import shared tokens
- document available design tokens and usage examples

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fa8aa547c832b8fa363cae0904b95