### PR TITLE
feat: add accessible form components and sample template

### DIFF
--- a/portal/static/src/forms/help-text.js
+++ b/portal/static/src/forms/help-text.js
@@ -1,0 +1,12 @@
+export function attachHelpText(input, text) {
+  const id = `${input.id || input.name}-help`;
+  const div = document.createElement('div');
+  div.id = id;
+  div.className = 'form-text';
+  div.textContent = text;
+  input.setAttribute('aria-describedby', id);
+  input.parentNode.appendChild(div);
+  return div;
+}
+
+export default { attachHelpText };

--- a/portal/static/src/forms/index.js
+++ b/portal/static/src/forms/index.js
@@ -1,0 +1,4 @@
+export { createInput } from './input.js';
+export { attachHelpText } from './help-text.js';
+export { attachValidation } from './validation.js';
+export { attachTooltip } from './tooltip.js';

--- a/portal/static/src/forms/input.js
+++ b/portal/static/src/forms/input.js
@@ -1,0 +1,65 @@
+export function createInput({
+  id,
+  name,
+  label,
+  type = 'text',
+  value = '',
+  required = false,
+  copyable = false
+}) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'mb-3';
+
+  const labelEl = document.createElement('label');
+  labelEl.className = 'form-label';
+  labelEl.htmlFor = id;
+  labelEl.textContent = label;
+  if (required) {
+    const star = document.createElement('span');
+    star.className = 'text-danger ms-1';
+    star.textContent = '*';
+    star.setAttribute('aria-hidden', 'true');
+    labelEl.appendChild(star);
+    const sr = document.createElement('span');
+    sr.className = 'visually-hidden';
+    sr.textContent = 'required';
+    labelEl.appendChild(sr);
+  }
+  wrapper.appendChild(labelEl);
+
+  let inputContainer = wrapper;
+  if (copyable) {
+    const group = document.createElement('div');
+    group.className = 'input-group';
+    wrapper.appendChild(group);
+    inputContainer = group;
+  }
+
+  const input = document.createElement('input');
+  input.id = id;
+  input.name = name;
+  input.type = type;
+  input.value = value;
+  input.className = 'form-control';
+  if (required) {
+    input.required = true;
+    input.setAttribute('aria-required', 'true');
+  }
+  inputContainer.appendChild(input);
+
+  if (copyable) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'btn btn-outline-secondary';
+    btn.textContent = 'Copy';
+    btn.setAttribute('aria-label', `Copy value of ${label}`);
+    btn.addEventListener('click', () => {
+      navigator.clipboard.writeText(input.value);
+    });
+    inputContainer.appendChild(btn);
+  }
+
+  return { wrapper, input, label: labelEl };
+}
+
+export default { createInput };

--- a/portal/static/src/forms/tooltip.js
+++ b/portal/static/src/forms/tooltip.js
@@ -1,0 +1,8 @@
+export function attachTooltip(element, text) {
+  element.setAttribute('title', text);
+  element.setAttribute('aria-label', text);
+  element.setAttribute('data-bs-toggle', 'tooltip');
+  return element;
+}
+
+export default { attachTooltip };

--- a/portal/static/src/forms/validation.js
+++ b/portal/static/src/forms/validation.js
@@ -1,0 +1,45 @@
+export function attachValidation(input, validator) {
+  const errorId = `${input.id || input.name}-error`;
+  let errorEl = null;
+
+  function showError(message) {
+    if (!errorEl) {
+      errorEl = document.createElement('div');
+      errorEl.id = errorId;
+      errorEl.className = 'invalid-feedback';
+      input.parentNode.appendChild(errorEl);
+    }
+    errorEl.textContent = message;
+    input.classList.add('is-invalid');
+  }
+
+  function clearError() {
+    if (errorEl) {
+      errorEl.textContent = '';
+    }
+    input.classList.remove('is-invalid');
+  }
+
+  input.addEventListener('input', () => {
+    const message = validator(input.value);
+    if (message) {
+      showError(message);
+    } else {
+      clearError();
+    }
+  });
+
+  return {
+    validate() {
+      const message = validator(input.value);
+      if (message) {
+        showError(message);
+        return false;
+      }
+      clearError();
+      return true;
+    }
+  };
+}
+
+export default { attachValidation };

--- a/portal/templates/forms/sample.html
+++ b/portal/templates/forms/sample.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}Sample Form{% endblock %}
+{% block content %}
+<h1>Sample Form</h1>
+<form id="sample-form" novalidate>
+  <div id="form-container"></div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+<script type="module">
+  import { createInput, attachHelpText, attachValidation, attachTooltip } from '/static/src/forms/index.js';
+  const container = document.getElementById('form-container');
+  const emailField = createInput({ id: 'email', name: 'email', label: 'Email', type: 'email', required: true, copyable: true });
+  container.appendChild(emailField.wrapper);
+  attachHelpText(emailField.input, "We'll never share your email.");
+  attachTooltip(emailField.input, 'Enter a valid email address');
+  const emailValidator = attachValidation(emailField.input, (value) => {
+    if (!value) return 'Email is required.';
+    if (!/^[^@]+@[^@]+\.[^@]+$/.test(value)) return 'Must be a valid email.';
+    return '';
+  });
+  document.getElementById('sample-form').addEventListener('submit', (e) => {
+    e.preventDefault();
+    if (emailValidator.validate()) {
+      alert(`Submitted: ${emailField.input.value}`);
+    }
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add modular form components with required indicators, help text, tooltips, validation, and copy support
- demonstrate usage with a sample template including validation flow

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a04f8d68cc832ba997aef1342ca143