### PR TITLE
Add modal, drawer, and toast UI components

### DIFF
--- a/docs/modal-drawer-toast.md
+++ b/docs/modal-drawer-toast.md
@@ -1,0 +1,47 @@
+# Modal, Drawer & Toast Components
+
+Reusable UI elements available under `portal/static/src/components`.
+
+## Confirmation Modal
+
+```javascript
+import { confirmationModal } from './components';
+
+confirmationModal('Delete this item?', () => {
+  // run on confirm
+});
+```
+
+The modal traps focus while open and closes on **ESC** or overlay click.
+
+## XL Modal
+
+```javascript
+import { xlModal } from './components';
+
+const modal = xlModal('Large Modal', '<p>Content here</p>');
+// modal.close() to dismiss
+```
+
+Use the XL variant for wide content. It shares the same closing and focus behavior as the confirmation modal.
+
+## Right-side Drawer
+
+```javascript
+import { openDrawer } from './components';
+
+const drawer = openDrawer('<h2>Details</h2><p>Drawer content</p>');
+// drawer.close() to dismiss
+```
+
+The drawer slides in from the right, traps focus, and closes on **ESC** or overlay click.
+
+## Toast Notifications
+
+```javascript
+import { showToast } from './components';
+
+showToast('Saved successfully');
+```
+
+Toasts stack in the top-right corner and each includes a close button. Multiple toasts can appear simultaneously.

--- a/portal/static/src/components/drawer.css
+++ b/portal/static/src/components/drawer.css
@@ -1,0 +1,28 @@
+.drawer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: var(--z-modal);
+}
+
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 320px;
+  max-width: 90%;
+  background: var(--color-background);
+  box-shadow: var(--shadow-lg);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  overflow: auto;
+  padding: var(--spacing-md);
+}
+
+.drawer.open {
+  transform: translateX(0);
+}

--- a/portal/static/src/components/drawer.js
+++ b/portal/static/src/components/drawer.js
@@ -1,0 +1,63 @@
+// Right-side drawer component with focus trapping
+
+function trapFocus(container) {
+  const focusable = container.querySelectorAll(
+    'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  if (!focusable.length) return () => {};
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  function handle(e) {
+    if (e.key === 'Tab') {
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+  container.addEventListener('keydown', handle);
+  return () => container.removeEventListener('keydown', handle);
+}
+
+export function openDrawer(content) {
+  const overlay = document.createElement('div');
+  overlay.className = 'drawer-overlay';
+
+  const panel = document.createElement('div');
+  panel.className = 'drawer';
+  panel.innerHTML = content;
+  panel.setAttribute('tabindex', '-1');
+
+  overlay.appendChild(panel);
+  document.body.appendChild(overlay);
+
+  function close() {
+    removeTrap();
+    document.removeEventListener('keydown', onKey);
+    overlay.remove();
+    if (previous && previous.focus) previous.focus();
+  }
+
+  function onKey(e) {
+    if (e.key === 'Escape') close();
+  }
+
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) close();
+  });
+  document.addEventListener('keydown', onKey);
+
+  const removeTrap = trapFocus(panel);
+  const previous = document.activeElement;
+
+  // trigger animation
+  requestAnimationFrame(() => panel.classList.add('open'));
+  panel.focus();
+
+  return { close, overlay };
+}
+
+export default { openDrawer };

--- a/portal/static/src/components/index.js
+++ b/portal/static/src/components/index.js
@@ -1,0 +1,3 @@
+export { confirmationModal, xlModal } from './modal';
+export { openDrawer } from './drawer';
+export { showToast } from './toast';

--- a/portal/static/src/components/modal.css
+++ b/portal/static/src/components/modal.css
@@ -1,0 +1,56 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal);
+}
+
+.modal {
+  background: var(--color-background);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  max-width: 500px;
+  width: 90%;
+  max-height: 90%;
+  overflow: auto;
+}
+
+.modal.modal-xl {
+  max-width: 900px;
+}
+
+.modal-header,
+.modal-footer {
+  padding: var(--spacing-md);
+}
+
+.modal-body {
+  padding: var(--spacing-md);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #ddd;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  border-top: 1px solid #ddd;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: var(--font-size-lg);
+  cursor: pointer;
+}

--- a/portal/static/src/components/modal.js
+++ b/portal/static/src/components/modal.js
@@ -1,0 +1,118 @@
+// Basic modal utilities
+// Provides confirmation modal and XL modal support with focus trapping
+
+function trapFocus(container) {
+  const focusable = container.querySelectorAll(
+    'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  if (!focusable.length) return () => {};
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  function handle(e) {
+    if (e.key === 'Tab') {
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+  container.addEventListener('keydown', handle);
+  return () => container.removeEventListener('keydown', handle);
+}
+
+function createModal(options = {}) {
+  const { title, content, confirmText, cancelText, onConfirm, size } = options;
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+
+  const dialog = document.createElement('div');
+  dialog.className = 'modal';
+  if (size === 'xl') dialog.classList.add('modal-xl');
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+
+  dialog.innerHTML = `
+    <div class="modal-header">
+      <h2 class="modal-title">${title || ''}</h2>
+      <button class="modal-close" aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">${content || ''}</div>
+    ${confirmText || cancelText ? `<div class="modal-footer"></div>` : ''}
+  `;
+
+  overlay.appendChild(dialog);
+  document.body.appendChild(overlay);
+
+  const footer = dialog.querySelector('.modal-footer');
+  let confirmBtn, cancelBtn;
+  if (footer) {
+    if (cancelText) {
+      cancelBtn = document.createElement('button');
+      cancelBtn.className = 'btn btn-secondary';
+      cancelBtn.textContent = cancelText;
+      footer.appendChild(cancelBtn);
+    }
+    if (confirmText) {
+      confirmBtn = document.createElement('button');
+      confirmBtn.className = 'btn btn-primary';
+      confirmBtn.textContent = confirmText;
+      footer.appendChild(confirmBtn);
+    }
+  }
+
+  function close() {
+    removeTrap();
+    document.removeEventListener('keydown', onKey);
+    overlay.remove();
+    if (previous && previous.focus) previous.focus();
+  }
+
+  function onKey(e) {
+    if (e.key === 'Escape') close();
+  }
+
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) close();
+  });
+  document.addEventListener('keydown', onKey);
+
+  const removeTrap = trapFocus(dialog);
+  const previous = document.activeElement;
+
+  dialog.querySelector('.modal-close').addEventListener('click', close);
+  if (cancelBtn) cancelBtn.addEventListener('click', close);
+  if (confirmBtn)
+    confirmBtn.addEventListener('click', () => {
+      if (onConfirm) onConfirm();
+      close();
+    });
+
+  // Start focus
+  setTimeout(() => {
+    const focusEl = dialog.querySelector(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusEl) focusEl.focus();
+  });
+
+  return { close, overlay };
+}
+
+export function confirmationModal(message, onConfirm, title = 'Confirm') {
+  return createModal({
+    title,
+    content: `<p>${message}</p>`,
+    confirmText: 'Confirm',
+    cancelText: 'Cancel',
+    onConfirm,
+  });
+}
+
+export function xlModal(title, content) {
+  return createModal({ title, content, size: 'xl' });
+}
+
+export default { confirmationModal, xlModal };

--- a/portal/static/src/components/toast.css
+++ b/portal/static/src/components/toast.css
@@ -1,0 +1,29 @@
+.toast-container {
+  position: fixed;
+  top: var(--spacing-md);
+  right: var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  z-index: var(--z-modal);
+}
+
+.toast {
+  background: var(--color-text);
+  color: var(--color-background);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  min-width: 200px;
+}
+
+.toast-close {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: var(--font-size-lg);
+  cursor: pointer;
+}

--- a/portal/static/src/components/toast.js
+++ b/portal/static/src/components/toast.js
@@ -1,0 +1,40 @@
+// Stackable toast notifications
+
+let container;
+
+function getContainer() {
+  if (container) return container;
+  container = document.getElementById('toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'toast-container';
+    container.className = 'toast-container';
+    document.body.appendChild(container);
+  }
+  return container;
+}
+
+export function showToast(message, opts = {}) {
+  const { timeout = 4000 } = opts;
+  const wrap = getContainer();
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  toast.setAttribute('role', 'status');
+  toast.setAttribute('aria-live', 'polite');
+  toast.innerHTML = `
+    <span class="toast-message"></span>
+    <button class="toast-close" aria-label="Close">&times;</button>
+  `;
+  toast.querySelector('.toast-message').textContent = message;
+  wrap.prepend(toast);
+
+  const timer = setTimeout(close, timeout);
+  function close() {
+    clearTimeout(timer);
+    toast.remove();
+  }
+
+  toast.querySelector('.toast-close').addEventListener('click', close);
+}
+
+export default { showToast };


### PR DESCRIPTION
## Summary
- add reusable modal utilities with confirmation and XL variants
- introduce right-side drawer component
- support stackable toast notifications
- document modal, drawer, and toast usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a05112c1a4832b88771fcd6895d5e6