### PR TITLE
feat: add dashboard cards with skeleton states

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -193,7 +193,7 @@ def dashboard():
         "pending_approvals": [],
         "mandatory_reading": [],
         "recent_revisions": [],
-        "quick_access": [],
+        "search_shortcuts": [],
     }
     return render_template("dashboard.html", **context)
 
@@ -237,13 +237,13 @@ def dashboard_cards_recent():
     )
 
 
-@app.get("/dashboard/cards/quick")
+@app.get("/dashboard/cards/shortcuts")
 @login_required
-def dashboard_cards_quick():
+def dashboard_cards_shortcuts():
     return render_template(
         "partials/dashboard/_cards.html",
-        card="quick",
-        quick_access=[],
+        card="shortcuts",
+        search_shortcuts=[],
     )
 
 

--- a/portal/templates/dashboard.html
+++ b/portal/templates/dashboard.html
@@ -1,5 +1,66 @@
 {% extends "base.html" %}
 {% block title %}Dashboard{% endblock %}
+
 {% block content %}
-  {% include 'partials/dashboard/_cards.html' %}
+<div class="row row-cols-1 row-cols-md-2 g-3">
+  <div class="col">
+    <div class="card h-100">
+      <div class="card-header">Pending Approvals</div>
+      <div class="card-body"
+           hx-get="{{ url_for('dashboard_cards_pending') }}"
+           hx-trigger="load, every 10s">
+        <div class="placeholder-glow">
+          <span class="placeholder col-12 mb-2"></span>
+          <span class="placeholder col-12 mb-2"></span>
+          <span class="placeholder col-12 mb-2"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="card h-100">
+      <div class="card-header">Mandatory Reading</div>
+      <div class="card-body"
+           hx-get="{{ url_for('dashboard_cards_mandatory') }}"
+           hx-trigger="load, every 10s">
+        <div class="placeholder-glow">
+          <span class="placeholder col-12 mb-2"></span>
+          <span class="placeholder col-12 mb-2"></span>
+          <span class="placeholder col-12 mb-2"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="card h-100">
+      <div class="card-header">Recent Changes</div>
+      <div class="card-body"
+           hx-get="{{ url_for('dashboard_cards_recent') }}"
+           hx-trigger="load, every 10s">
+        <div class="placeholder-glow">
+          <span class="placeholder col-12 mb-2"></span>
+          <span class="placeholder col-12 mb-2"></span>
+          <span class="placeholder col-12 mb-2"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col">
+    <div class="card h-100">
+      <div class="card-header">Search Shortcuts</div>
+      <div class="card-body"
+           hx-get="{{ url_for('dashboard_cards_shortcuts') }}"
+           hx-trigger="load, every 10s">
+        <div class="placeholder-glow">
+          <span class="placeholder col-12 mb-2"></span>
+          <span class="placeholder col-12 mb-2"></span>
+          <span class="placeholder col-12 mb-2"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/portal/templates/partials/dashboard/_cards.html
+++ b/portal/templates/partials/dashboard/_cards.html
@@ -1,35 +1,22 @@
-{% macro render_card(title, items, empty_text, endpoint) %}
-<div class="col-md-6 mb-3">
-  <div class="card" hx-get="{{ endpoint }}" hx-trigger="load, every 10s" hx-target="this">
-    <div class="card-header">{{ title }}</div>
-    <div class="card-body">
-      {% if items %}
-        <ul class="list-unstyled mb-0">
-        {% for item in items %}
-          <li>{{ item }}</li>
-        {% endfor %}
-        </ul>
-      {% else %}
-        <p class="text-muted mb-0">{{ empty_text }}</p>
-      {% endif %}
-    </div>
-  </div>
-</div>
+{% macro render_items(items, empty_text) %}
+  {% if items %}
+    <ul class="list-unstyled mb-0">
+    {% for item in items %}
+      <li>{{ item }}</li>
+    {% endfor %}
+    </ul>
+  {% else %}
+    <p class="text-muted mb-0">{{ empty_text }}</p>
+  {% endif %}
 {% endmacro %}
 
 {% if card == 'pending' %}
-  {{ render_card('Pending Approvals', pending_approvals, 'No pending approvals.', url_for('dashboard_cards_pending')) }}
+  {{ render_items(pending_approvals, 'No pending approvals.') }}
 {% elif card == 'mandatory' %}
-  {{ render_card('Mandatory Reading', mandatory_reading, 'No mandatory documents.', url_for('dashboard_cards_mandatory')) }}
+  {{ render_items(mandatory_reading, 'No mandatory documents.') }}
 {% elif card == 'recent' %}
-  {{ render_card('Recent Revisions', recent_revisions, 'No recent revisions.', url_for('dashboard_cards_recent')) }}
-{% elif card == 'quick' %}
-  {{ render_card('Quick Access', quick_access, 'No quick links available.', url_for('dashboard_cards_quick')) }}
-{% else %}
-<div class="row">
-  {{ render_card('Pending Approvals', pending_approvals, 'No pending approvals.', url_for('dashboard_cards_pending')) }}
-  {{ render_card('Mandatory Reading', mandatory_reading, 'No mandatory documents.', url_for('dashboard_cards_mandatory')) }}
-  {{ render_card('Recent Revisions', recent_revisions, 'No recent revisions.', url_for('dashboard_cards_recent')) }}
-  {{ render_card('Quick Access', quick_access, 'No quick links available.', url_for('dashboard_cards_quick')) }}
-</div>
+  {{ render_items(recent_revisions, 'No recent changes.') }}
+{% elif card == 'shortcuts' %}
+  {{ render_items(search_shortcuts, 'No search shortcuts available.') }}
 {% endif %}
+


### PR DESCRIPTION
## Summary
- add responsive cards to dashboard for approvals, reading, changes, and shortcuts
- show skeleton loading and empty states for card content
- wire up Flask routes for new cards

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a05e51a0d8832bb268028b27b1ca51