### PR TITLE
Add approval detail view and workflow updates

### DIFF
--- a/portal/templates/approvals/detail.html
+++ b/portal/templates/approvals/detail.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Approval Detail{% endblock %}
+{% block page_actions %}
+<a class="btn btn-secondary" href="{{ url_for('approval_queue') }}">Back</a>
+{% endblock %}
+{% block content %}
+<div id="editor-container" class="vh-100 overflow-auto">
+  <iframe id="docEditor" class="w-100 h-100 border-0" title="Document preview" loading="lazy"></iframe>
+</div>
+<script>
+  const editorConfig = {{ config | tojson }};
+  const editorToken = {{ token | tojson }};
+</script>
+<script src="{{ editor_js }}"></script>
+<script>
+  if (editorToken && window.DocsAPI && window.DocsAPI.setRequestHeaders) {
+    window.DocsAPI.setRequestHeaders([{ header: '{{ token_header|default("Authorization") }}', value: editorToken }]);
+  }
+  window.docEditor = new DocsAPI.DocEditor('docEditor', editorConfig);
+</script>
+{% endblock %}

--- a/portal/templates/partials/approvals/_row.html
+++ b/portal/templates/partials/approvals/_row.html
@@ -1,5 +1,5 @@
 <tr id="step-{{ step.id }}">
-  <td>{{ step.document.title }}</td>
+  <td><a href="{{ url_for('approval_detail', id=step.id) }}">{{ step.document.title }}</a></td>
   <td>{{ step.step_order }}</td>
   <td>{{ step.status }}</td>
   <td>{{ step.comment or '' }}</td>


### PR DESCRIPTION
## Summary
- Serve document preview for approval steps
- Log and update workflow steps on approve or reject
- Notify next reviewer or document owner based on action

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07724b004832bb3f4701d294a18ff