### PR TITLE
Add document rollback endpoint

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -541,6 +541,46 @@ def revert_document(doc_id: int, revision_id: int):
     return redirect(url_for("document_detail", doc_id=doc_id))
 
 
+@app.post("/documents/<int:doc_id>/rollback")
+@roles_required(RoleEnum.REVIEWER.value)
+def rollback_document(doc_id: int):
+    """Rollback document to a specific version."""
+    version_str = request.form.get("version") or ""
+    try:
+        major, minor = map(int, version_str.split("."))
+    except ValueError:
+        return "Invalid version", 400
+    db = get_session()
+    doc = db.get(Document, doc_id)
+    if not doc:
+        db.close()
+        return "Document not found", 404
+    rev = (
+        db.query(DocumentRevision)
+        .filter_by(doc_id=doc_id, major_version=major, minor_version=minor)
+        .first()
+    )
+    if not rev:
+        db.close()
+        return "Revision not found", 404
+    current_rev = DocumentRevision(
+        doc_id=doc.id,
+        major_version=doc.major_version,
+        minor_version=doc.minor_version,
+        revision_notes=doc.revision_notes,
+    )
+    db.add(current_rev)
+    doc.major_version = rev.major_version
+    doc.minor_version = rev.minor_version
+    doc.revision_notes = rev.revision_notes
+    db.delete(rev)
+    db.commit()
+    user = session.get("user") or {}
+    log_action(user.get("id"), doc.id, "rollback_document")
+    db.close()
+    return redirect(url_for("document_detail", doc_id=doc_id))
+
+
 @app.post("/documents/<int:id>/revise")
 @roles_required(RoleEnum.CONTRIBUTOR.value)
 def revise_document(id: int):

--- a/portal/templates/partials/documents/_versions.html
+++ b/portal/templates/partials/documents/_versions.html
@@ -4,20 +4,22 @@
   <p>{{ revision.revision_notes or 'No revision notes.' }}</p>
   <div class="d-flex gap-2">
     <button class="btn btn-secondary" hx-get="{{ url_for('document_detail', doc_id=doc.id) }}" hx-target="#tab-versions" hx-push-url="false">Back</button>
-    <button class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#revertModal">Revert to previous version</button>
+    <button class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#rollbackModal">Bu sürüme dön</button>
   </div>
-  <div class="modal fade" id="revertModal" tabindex="-1" aria-hidden="true">
+  <div class="modal fade" id="rollbackModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title">Revert to version {{ revision.major_version }}.{{ revision.minor_version }}?</h5>
+          <h5 class="modal-title">{{ revision.major_version }}.{{ revision.minor_version }} sürümüne dönülsün mü?</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
-        <div class="modal-body">Are you sure you want to revert to this version?</div>
+        <div class="modal-body">Bu sürüme dönmek istediğinizden emin misiniz?</div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <form hx-post="{{ url_for('revert_document', doc_id=doc.id, revision_id=revision.id) }}" hx-target="#tab-versions" hx-swap="innerHTML">
-            <button type="submit" class="btn btn-danger" data-bs-dismiss="modal">Revert</button>
+          <form method="post" action="{{ url_for('rollback_document', doc_id=doc.id) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="version" value="{{ revision.major_version }}.{{ revision.minor_version }}">
+            <button type="submit" class="btn btn-danger">Bu sürüme dön</button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add rollback endpoint to promote a selected revision as the active document
- archive current version before rollback and log the action
- wire version history modal button to rollback endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a07cc94280832b8aa23c6b6504b214