### PR TITLE
Add archived document management

### DIFF
--- a/portal/archive_job.py
+++ b/portal/archive_job.py
@@ -1,7 +1,8 @@
 """Cron job to archive documents whose retention period has expired."""
 from datetime import datetime, timedelta
-from models import get_session, Document
+from models import get_session, Document, User
 from storage import move_to_archive
+from app import log_action
 
 
 def run() -> None:
@@ -13,6 +14,9 @@ def run() -> None:
         .filter(Document.status != "Archived")
         .all()
     )
+    # pick the first user as the acting user for audit logging
+    system_user = session.query(User.id).order_by(User.id).first()
+    system_user_id = system_user[0] if system_user else 0
     for doc in docs:
         base = doc.created_at or now
         expire_at = base + timedelta(days=doc.retention_period)
@@ -20,6 +24,7 @@ def run() -> None:
             move_to_archive(doc.doc_key, doc.retention_period or 0)
             doc.status = "Archived"
             doc.archived_at = now
+            log_action(system_user_id, doc.id, "archive_document")
     session.commit()
     session.close()
 

--- a/portal/templates/documents/archived.html
+++ b/portal/templates/documents/archived.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Archived Documents{% endblock %}
+{% block content %}
+<h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">Archived Documents</h1>
+<table class="table table-striped table-sm">
+  <thead class="table-light">
+    <tr>
+      <th>Code</th>
+      <th>Title</th>
+      <th>Archived At</th>
+      <th class="text-end">Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for doc in documents %}
+    <tr>
+      <td>{{ doc.code }}</td>
+      <td>{{ doc.title }}</td>
+      <td>{{ doc.archived_at }}</td>
+      <td class="text-end">
+        <form hx-post="{{ url_for('republish_document', doc_id=doc.id) }}"
+              hx-target="closest tr" hx-swap="delete">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" class="btn btn-sm btn-outline-primary">Yeniden Yayınla</button>
+        </form>
+      </td>
+    </tr>
+    {% else %}
+    <tr><td colspan="4">No archived documents.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- archive job logs and archives expired documents
- render archived documents list via `/documents?status=archived`
- allow republishing archived documents with audit logging

## Testing
- `python -m py_compile portal/archive_job.py portal/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a07ddad918832b8f74ffd31c6c722c