### PR TITLE
Add acknowledgement listing and confirmation routes

### DIFF
--- a/portal/templates/partials/ack/_table.html
+++ b/portal/templates/partials/ack/_table.html
@@ -16,7 +16,7 @@
       <td>{{ item.status }}</td>
       <td>{{ item.due_date }}</td>
       <td>
-        <form hx-post="{{ url_for('acknowledge_document', doc_id=item.id) }}"
+        <form hx-post="{{ url_for('ack.confirm', id=item.id) }}"
               hx-target="closest tr"
               hx-swap="delete"
               hx-on="htmx:afterRequest: document.getElementById('ack-count').innerText = parseInt(document.getElementById('ack-count').innerText) - 1">


### PR DESCRIPTION
## Summary
- Add `/ack` GET route to list pending document acknowledgements
- Add `/ack/<id>/confirm` POST endpoint to mark acknowledgements, award badges, log actions, and update training results
- Update acknowledgement table partial to use new confirmation endpoint

## Testing
- `python -m py_compile portal/app.py && echo 'py_compile success'`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07fadde84832b80f5da2124d09d57