### PR TITLE
Add quiz endpoints with TrainingResult tracking

### DIFF
--- a/portal/models.py
+++ b/portal/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Enum,
     UniqueConstraint,
     Boolean,
+    Float,
 )
 from sqlalchemy.orm import declarative_base, relationship, sessionmaker, scoped_session
 
@@ -160,10 +161,14 @@ class TrainingResult(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     score = Column(Integer, default=0)
     max_score = Column(Integer, default=0)
+    incorrect = Column(Integer, default=0)
+    success_rate = Column(Float, default=0.0)
     passed = Column(Boolean, default=False)
     completed_at = Column(DateTime, default=datetime.utcnow)
+    ack_id = Column(Integer, ForeignKey("acknowledgements.id"))
 
     user = relationship("User")
+    acknowledgement = relationship("Acknowledgement")
 
 
 class FormSubmission(Base):

--- a/portal/templates/training/quiz.html
+++ b/portal/templates/training/quiz.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>{{ doc.title }} Training Quiz</h1>
+{% if error %}
+<div class="alert alert-danger">{{ error }}</div>
+{% endif %}
+<form method="post" action="{{ url_for('training_submit', id=doc.id) }}">
+  {% for q in questions %}
+  <div class="mb-3">
+    <p>{{ q.text }}</p>
+    {% for val, label in q.options %}
+    <div class="form-check">
+      <input class="form-check-input" type="radio" name="{{ q.id }}" id="{{ q.id }}_{{ val }}" value="{{ val }}">
+      <label class="form-check-label" for="{{ q.id }}_{{ val }}">{{ label }}</label>
+    </div>
+    {% endfor %}
+  </div>
+  {% endfor %}
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- serve training quizzes at `/training/<id>`
- process quiz submissions and store results with success rate, linking to acknowledgements
- record training outcomes in audit logs and notify users

## Testing
- `python -m py_compile portal/app.py portal/models.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a080f760d0832baf21272513682bf3