### PR TITLE
feat: customize headers for onlyoffice

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -65,6 +65,14 @@ http {
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-Port $server_port;
+      proxy_hide_header X-Frame-Options;
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header Content-Security-Policy \
+        "default-src 'self' blob: data:; \
+         frame-src 'self' blob: data:; \
+         connect-src 'self' ws: wss:; \
+         script-src 'self' 'unsafe-inline'; \
+         style-src 'self' 'unsafe-inline'" always;
     }
 
     # WebSocket yolları (OnlyOffice)


### PR DESCRIPTION
## Summary
- customize OnlyOffice location to override X-Frame-Options and CSP

## Testing
- `nginx -t -c nginx/nginx.conf` *(fails: command not found)*
- `nginx -s reload` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a08ed875d0832baa67d44cc96d12da