### PR TITLE
Add Elasticsearch service and configure portal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,13 @@ services:
     # Eğer büyük dosyalar/çok kullanıcı planı varsa CPU/RAM artırın
     networks: [qdms]
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    networks: [qdms]
+
   portal:
     build: ./portal
     restart: unless-stopped
@@ -88,12 +95,14 @@ services:
       LDAP_PASSWORD: ${LDAP_PASSWORD}
       LDAP_SEARCH_FILTER: ${LDAP_SEARCH_FILTER}
       PORTAL_JWT_SECRET: ${PORTAL_JWT_SECRET}
+      ELASTIC_URL: ${ELASTIC_URL}
     depends_on:
       - postgres
       - redis
       - minio
       - minio-setup
       - onlyoffice
+      - elasticsearch
     networks: [qdms]
 
   nginx:


### PR DESCRIPTION
## Summary
- integrate Elasticsearch service into docker compose setup
- wire portal to Elasticsearch via environment variable and dependency

## Testing
- `docker compose config` *(fails: command not found)*
- `docker compose down` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a090edc3a4832b9c428a6b7ceb3bd0