### PR TITLE
Build portal static assets during Docker image creation

### DIFF
--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -9,4 +9,6 @@ RUN apt-get update && \
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 COPY . .
+RUN pip install libsass rcssmin jsmin
+RUN python static/build.py
 CMD ["python", "app.py"]


### PR DESCRIPTION
## Summary
- Install libsass, rcssmin, and jsmin during Docker build
- Build static assets with `python static/build.py` before container start

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a094c784b4832baf574b12ec1a53f3