### PR TITLE
Serve static files directly from Nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,8 @@ services:
       - onlyoffice
       - elasticsearch
     networks: [qdms]
+    volumes:
+      - portal_static:/app/static/dist
 
   nginx:
     image: nginx:1.27-alpine
@@ -113,6 +115,7 @@ services:
       - onlyoffice
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - portal_static:/app/static/dist:ro
       - nginx_cache:/var/cache/nginx
       # SSL sertifikası kullanacaksanız aşağıyı açın ve dosyaları koyun
       # - ./nginx/certs:/etc/nginx/certs:ro
@@ -126,6 +129,8 @@ volumes:
   redisdata:
   miniodata:
   nginx_cache:
+
+  portal_static:
 
 networks:
   qdms:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -46,11 +46,7 @@ http {
     }
 
     location /static/ {
-      proxy_pass http://portal_up/static/;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
+      alias /app/static/dist/;
       expires 1y;
       add_header Cache-Control "public, max-age=31536000, immutable";
     }


### PR DESCRIPTION
## Summary
- serve portal static files directly via Nginx alias and cache headers
- mount built static directory into both portal and Nginx containers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `nginx -t -c nginx/nginx.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09704f344832b8c43b07562b4665a