### PR TITLE
Fix Nginx add_header directive syntax

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -63,12 +63,7 @@ http {
       proxy_set_header X-Forwarded-Port $server_port;
       proxy_hide_header X-Frame-Options;
       add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header Content-Security-Policy \
-        "default-src 'self' blob: data:; \
-         frame-src 'self' blob: data:; \
-         connect-src 'self' ws: wss:; \
-         script-src 'self' 'unsafe-inline'; \
-         style-src 'self' 'unsafe-inline'" always;
+      add_header Content-Security-Policy "default-src 'self' blob: data:; frame-src 'self' blob: data:; connect-src 'self' ws: wss:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" always;
     }
 
     # WebSocket yolları (OnlyOffice)


### PR DESCRIPTION
## Summary
- fix invalid add_header configuration in Nginx config

## Testing
- `nginx -t -c $(pwd)/nginx/nginx.conf` *(fails: command not found)*
- `cd portal && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a09953cafc832baeea3540e049f571