### PR TITLE
Handle HTMX redirects for document publishing

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1396,6 +1396,11 @@ def publish_document(id: int):
         if publisher:
             log_action(publisher["id"], doc.id, "publish_document")
         broadcast_counts()
+        if request.headers.get("HX-Request"):
+            resp = make_response("", 204)
+            resp.headers["HX-Redirect"] = url_for("document_detail", doc_id=doc.id)
+            resp.headers["HX-Trigger"] = json.dumps({"showToast": "Saved"})
+            return resp
         return redirect(url_for("list_documents", status="Published"))
     finally:
         db.close()
@@ -1416,6 +1421,11 @@ def republish_document(doc_id: int):
         if publisher:
             log_action(publisher["id"], doc.id, "republish_document")
         broadcast_counts()
+        if request.headers.get("HX-Request"):
+            resp = make_response("", 204)
+            resp.headers["HX-Redirect"] = url_for("document_detail", doc_id=doc.id)
+            resp.headers["HX-Trigger"] = json.dumps({"showToast": "Saved"})
+            return resp
         return redirect(url_for("list_documents", status="archived"))
     finally:
         db.close()


### PR DESCRIPTION
## Summary
- Update document publish and republish endpoints to return HX-aware 204 responses
- Preserve existing redirects for non-HTMX clients

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09ee4a7e0832b932269b099d8aa05