### PR TITLE
Add scheduler container for scheduled jobs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,19 @@ services:
     volumes:
       - portal_static:/app/portal/static/dist
 
+  scheduler:
+    image: python:3.12-slim
+    working_dir: /app
+    volumes:
+      - "./portal:/app"
+    command: >
+      sh -c "pip install -r requirements.txt &&
+             ( while :; do python archive_job.py; sleep 86400; done ) &
+             ( while :; do python periodic_review.py; sleep 31536000; done ) &
+             wait"
+    depends_on: [ portal ]
+    networks: [ qdms ]
+
   nginx:
     image: nginx:1.27-alpine
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add scheduler service running archive and annual review jobs

## Testing
- `docker compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ab3241e4832b859299de032258f2