### PR TITLE
Add notification environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -41,3 +41,9 @@ LDAP_BASE_DN=dc=baylan,dc=local
 LDAP_SEARCH_FILTER=(&(objectClass=user)(objectCategory=person)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))
 SESSION_COOKIE_SECURE=false
 PORTAL_JWT_SECRET=<rastgele-güvenli-bir-anahtar>
+
+# Notifications
+SMTP_SERVER=smtp.example.com
+SMTP_PORT=587
+SMTP_SENDER=notifications@example.com
+WEBHOOK_URL_DEFAULT=https://hooks.example.com/default

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,8 @@
+# Notification Configuration
+
+The following environment variables control email and webhook notifications:
+
+- `SMTP_SERVER`: Hostname of the SMTP server used to send emails.
+- `SMTP_PORT`: Port number for the SMTP server (e.g., 587 for TLS).
+- `SMTP_SENDER`: Default `From` address for outgoing emails.
+- `WEBHOOK_URL_DEFAULT`: Fallback webhook URL used when no specific webhook is configured.


### PR DESCRIPTION
## Summary
- define SMTP and webhook defaults in `.env`
- document notification environment variables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0b75797a0832ba88fac1056c32f05