### PR TITLE
Add multi-step document creation flow

### DIFF
--- a/portal/templates/documents/new_step1.html
+++ b/portal/templates/documents/new_step1.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}New Document - Step 1{% endblock %}
+{% block content %}
+<h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">New Document - Step 1</h1>
+<form method="post" action="{{ url_for('new_document', step=1) }}">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <div class="mb-3">
+    <label for="code" class="form-label">Code</label>
+    <input type="text" class="form-control{% if errors.code %} is-invalid{% endif %}" id="code" name="code" value="{{ form.code or '' }}">
+    {% if errors.code %}<div class="invalid-feedback">{{ errors.code }}</div>{% endif %}
+  </div>
+  <div class="mb-3">
+    <label for="title" class="form-label">Title</label>
+    <input type="text" class="form-control{% if errors.title %} is-invalid{% endif %}" id="title" name="title" value="{{ form.title or '' }}">
+    {% if errors.title %}<div class="invalid-feedback">{{ errors.title }}</div>{% endif %}
+  </div>
+  <button type="submit" class="btn btn-primary">Next</button>
+</form>
+{% endblock %}

--- a/portal/templates/documents/new_step2.html
+++ b/portal/templates/documents/new_step2.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}New Document - Step 2{% endblock %}
+{% block content %}
+<h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">New Document - Step 2</h1>
+<form method="post" action="{{ url_for('new_document', step=2) }}">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <div class="mb-3">
+    <label for="department" class="form-label">Department</label>
+    <input type="text" class="form-control{% if errors.department %} is-invalid{% endif %}" id="department" name="department" value="{{ form.department or '' }}">
+    {% if errors.department %}<div class="invalid-feedback">{{ errors.department }}</div>{% endif %}
+  </div>
+  <div class="mb-3">
+    <label for="type" class="form-label">Type</label>
+    <input type="text" class="form-control{% if errors.type %} is-invalid{% endif %}" id="type" name="type" value="{{ form.type or '' }}">
+    {% if errors.type %}<div class="invalid-feedback">{{ errors.type }}</div>{% endif %}
+  </div>
+  <button type="submit" class="btn btn-primary">Next</button>
+</form>
+{% endblock %}

--- a/portal/templates/documents/new_step3.html
+++ b/portal/templates/documents/new_step3.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}New Document - Step 3{% endblock %}
+{% block content %}
+<h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">New Document - Step 3</h1>
+<form method="post" action="{{ url_for('new_document', step=3) }}">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <p><strong>Code:</strong> {{ form.code }}</p>
+  <p><strong>Title:</strong> {{ form.title }}</p>
+  <p><strong>Department:</strong> {{ form.department }}</p>
+  <p><strong>Type:</strong> {{ form.type }}</p>
+  <button type="submit" class="btn btn-primary">Create</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Implement three-step document creation wizard using `step` param with session storage
- Add dedicated templates for each step of the form
- Final step submits collected data via existing `create_document` logic

## Testing
- `python -m py_compile portal/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0c0ee0800832b82ae1b63f3b0ae20