### PR TITLE
Link new document button

### DIFF
--- a/portal/templates/documents/list.html
+++ b/portal/templates/documents/list.html
@@ -3,7 +3,7 @@
 {% block page_actions %}
 <link rel="stylesheet" href="{{ asset_url('toolbar/toolbar.css') }}">
 <div class="toolbar" data-component="toolbar" data-variant="icon-text">
-  <a href="#" class="btn btn-primary" data-action="new"><svg class="icon"><use xlink:href="#icon-plus"></use></svg><span>New</span></a>
+  <a href="/documents/new" class="btn btn-primary" data-action="new"><svg class="icon"><use xlink:href="#icon-plus"></use></svg><span>New</span></a>
   <a href="#" class="btn btn-outline-primary" data-action="import"><svg class="icon"><use xlink:href="#icon-upload"></use></svg><span>Import</span></a>
   <a href="#" class="btn btn-outline-primary" data-action="export"><svg class="icon"><use xlink:href="#icon-download"></use></svg><span>Export</span></a>
   <button type="button" class="btn btn-outline-secondary" data-action="filter"><svg class="icon"><use xlink:href="#icon-filter"></use></svg><span>Filter</span></button>


### PR DESCRIPTION
## Summary
- Link "New" document toolbar action directly to `/documents/new`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0c28b5660832bb1653f7b56326831