### PR TITLE
Add new document shortcut to dashboard

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -279,8 +279,9 @@ def dashboard():
             "Form ABC revised",
         ],
         "search_shortcuts": [
-            "All Documents",
-            "My Approvals",
+            ("All Documents", "/documents"),
+            ("My Approvals", "/approvals"),
+            ("Yeni Doküman", "/documents/new"),
         ],
     }
     return render_template("dashboard.html", **context)
@@ -341,8 +342,9 @@ def dashboard_cards_shortcuts():
         "partials/dashboard/_cards.html",
         card="shortcuts",
         search_shortcuts=[
-            "All Documents",
-            "My Approvals",
+            ("All Documents", "/documents"),
+            ("My Approvals", "/approvals"),
+            ("Yeni Doküman", "/documents/new"),
         ],
     )
 

--- a/portal/templates/partials/dashboard/_cards.html
+++ b/portal/templates/partials/dashboard/_cards.html
@@ -2,7 +2,11 @@
   {% if items %}
     <ul class="list-unstyled mb-0">
     {% for item in items %}
-      <li>{{ item }}</li>
+      {% if item[1] is defined %}
+        <li><a href="{{ item[1] }}">{{ item[0] }}</a></li>
+      {% else %}
+        <li>{{ item }}</li>
+      {% endif %}
     {% endfor %}
     </ul>
   {% else %}


### PR DESCRIPTION
## Summary
- add new document shortcut and convert dashboard shortcuts to title/url pairs
- render dashboard card items as links when given a URL

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0c3cab5cc832b9c4ca29efe0ffb29