### PR TITLE
Use database data for dashboard cards

### DIFF
--- a/tests/test_dashboard_cards.py
+++ b/tests/test_dashboard_cards.py
@@ -1,0 +1,103 @@
+import os
+from pathlib import Path
+import sys
+
+# Ensure environment variables before importing application
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+db_path = Path("test.db")
+if db_path.exists():
+    db_path.unlink()
+os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "portal"))
+
+from flask import url_for
+import pytest
+
+from portal.models import (
+    Base,
+    engine,
+    SessionLocal,
+    Document,
+    WorkflowStep,
+    DocumentRevision,
+)
+from portal.app import app
+
+
+# Create database schema
+Base.metadata.create_all(bind=engine)
+
+# Populate sample data
+session = SessionLocal()
+
+# Document needing approval
+pending_doc = Document(doc_key="pending.docx", title="Pending Doc", status="Review")
+# Document for mandatory reading
+mandatory_doc = Document(doc_key="mandatory.docx", title="Mandatory Doc", status="Published")
+# Document with recent revision
+recent_doc = Document(doc_key="recent.docx", title="Recent Doc", status="Published")
+
+session.add_all([pending_doc, mandatory_doc, recent_doc])
+session.commit()
+
+step = WorkflowStep(doc_id=pending_doc.id, step_order=1, approver="approver", status="Pending")
+revision = DocumentRevision(doc_id=recent_doc.id, major_version=1, minor_version=0)
+
+session.add_all([step, revision])
+session.commit()
+step_id = step.id
+revision_id = revision.id
+pending_doc_id = pending_doc.id
+mandatory_doc_id = mandatory_doc.id
+recent_doc_id = recent_doc.id
+session.close()
+
+
+@pytest.fixture()
+def client():
+    return app.test_client()
+
+
+def test_dashboard_card_endpoints(client):
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1, "name": "Tester"}
+        sess["roles"] = ["approver", "reader"]
+
+    # Pending approvals
+    resp = client.get("/dashboard/cards/pending")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    with app.test_request_context():
+        pending_url = url_for("approval_detail", id=step_id)
+    assert "Pending Doc" in html
+    assert pending_url in html
+
+    # Mandatory reading
+    resp = client.get("/dashboard/cards/mandatory")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    with app.test_request_context():
+        mandatory_url = url_for("document_detail", doc_id=mandatory_doc_id)
+    assert "Mandatory Doc" in html
+    assert mandatory_url in html
+
+    # Recent revisions
+    resp = client.get("/dashboard/cards/recent")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    with app.test_request_context():
+        recent_url = url_for(
+            "document_detail", doc_id=recent_doc_id, revision_id=revision_id
+        )
+    assert "Recent Doc" in html
+    assert recent_url in html
+
+    # Dashboard main page loads successfully
+    resp = client.get("/")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Query pending approvals, mandatory documents and recent revisions from the database
- Show dashboard cards as links to real resources
- Add tests covering dashboard card endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c8d82d48832bb3e1d6f3814417ae