### PR TITLE
Integrate Alembic migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///portal.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,60 @@
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+from portal import models  # noqa
+
+target_metadata = models.Base.metadata
+
+
+def get_url():
+    return os.getenv("DATABASE_URL", config.get_main_option("sqlalchemy.url"))
+
+
+def run_migrations_offline() -> None:
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    configuration = config.get_section(config.config_ini_section, {})
+    configuration["sqlalchemy.url"] = get_url()
+
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,27 @@
+"""Initial database schema
+
+Revision ID: 0001
+Revises: 
+Create Date: 2023-01-01 00:00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from portal.models import Base
+
+# revision identifiers, used by Alembic.
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    Base.metadata.create_all(bind)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    Base.metadata.drop_all(bind)

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,34 @@
+# Database Migrations
+
+This project uses [Alembic](https://alembic.sqlalchemy.org/) for managing
+database schema changes.
+
+## Running migrations
+
+1. Ensure the `DATABASE_URL` environment variable points to the target
+   database. For example:
+
+   ```bash
+   export DATABASE_URL=sqlite:///portal.db
+   ```
+
+2. Apply all pending migrations:
+
+   ```bash
+   alembic upgrade head
+   ```
+
+## Creating a new migration
+
+1. Update the SQLAlchemy models under `portal/models.py`.
+2. Generate a migration script:
+
+   ```bash
+   alembic revision --autogenerate -m "describe change"
+   ```
+
+3. Review the generated file in `alembic/versions/` and adjust as needed.
+4. Apply the migration with `alembic upgrade head`.
+
+Migrations replace any implicit `Base.metadata.create_all` calls. Developers
+must run the commands above to create or update the database schema.

--- a/portal/models.py
+++ b/portal/models.py
@@ -271,7 +271,8 @@ class DepartmentVisibility(Base):
     name = Column(String, unique=True, nullable=False)
     visible = Column(Boolean, default=True, nullable=False)
 
-Base.metadata.create_all(engine)
+# Database schema migrations are now managed via Alembic. Tables are created
+# through explicit migration scripts rather than automatic metadata creation.
 
 def get_session():
     return SessionLocal()
@@ -300,5 +301,4 @@ def seed_roles_and_users():
     finally:
         session.close()
 
-
-seed_roles_and_users()
+# Initial data seeding should be invoked manually after applying migrations.

--- a/tests/test_dashboard_cards.py
+++ b/tests/test_dashboard_cards.py
@@ -20,18 +20,19 @@ from flask import url_for
 import pytest
 
 from portal.models import (
-    Base,
-    engine,
     SessionLocal,
     Document,
     WorkflowStep,
     DocumentRevision,
 )
 from portal.app import app
+from alembic.config import Config
+from alembic import command
 
 
-# Create database schema
-Base.metadata.create_all(bind=engine)
+# Apply database migrations
+alembic_cfg = Config(str(Path(__file__).resolve().parent.parent / "alembic.ini"))
+command.upgrade(alembic_cfg, "head")
 
 # Populate sample data
 session = SessionLocal()


### PR DESCRIPTION
## Summary
- set up Alembic with configuration, env, and initial revision
- remove runtime `Base.metadata.create_all` and seed step
- document migration workflow and use Alembic in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alembic.config')*


------
https://chatgpt.com/codex/tasks/task_e_68a0ccb609c8832bbada211ca14d2738