### PR TITLE
Allow Bootstrap styles via CSP

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,7 +27,7 @@ http {
     listen 80;
     server_name _;
 
-    add_header Content-Security-Policy "default-src 'self'; frame-ancestors 'none'";
+    add_header Content-Security-Policy "default-src 'self'; frame-ancestors 'none'; style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'";
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options "DENY";
 
@@ -63,7 +63,7 @@ http {
       proxy_set_header X-Forwarded-Port $server_port;
       proxy_hide_header X-Frame-Options;
       add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header Content-Security-Policy "default-src 'self' blob: data:; frame-src 'self' blob: data:; connect-src 'self' ws: wss:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" always;
+      add_header Content-Security-Policy "default-src 'self' blob: data:; frame-src 'self' blob: data:; connect-src 'self' ws: wss:; script-src 'self' 'unsafe-inline'; style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline';" always;
     }
 
     # WebSocket yolları (OnlyOffice)

--- a/portal/app.py
+++ b/portal/app.py
@@ -69,7 +69,10 @@ app.config["SESSION_COOKIE_SECURE"] = (
 
 @app.after_request
 def set_security_headers(response):
-    response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none'"
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'self'; frame-ancestors 'none'; "
+        "style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'"
+    )
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
     response.headers["X-Frame-Options"] = "DENY"
     return response


### PR DESCRIPTION
## Summary
- permit Bootstrap from jsdelivr and inline styles in Flask responses
- mirror CSP style-src rules in nginx

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'alembic.config')*


------
https://chatgpt.com/codex/tasks/task_e_68a0d32f908c832ba252d3a49aa57e6f