### PR TITLE
Mark ES module scripts

### DIFF
--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -61,8 +61,8 @@
 {% include 'partials/_toasts.html' %}
 {% include 'partials/_skeleton.html' %}
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-<script src="{{ asset_url('app.js') }}" defer></script>
-<script src="{{ asset_url('quick_search.js') }}" defer></script>
+<script type="module" src="{{ asset_url('app.js') }}"></script>
+<script type="module" src="{{ asset_url('quick_search.js') }}"></script>
 <script src="{{ asset_url('base.js') }}" defer></script>
 </body>
 </html>

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -16,7 +16,7 @@
   {% endif %}
   <a class="btn btn-outline-secondary" href="{{ url_for('compare_document_versions', doc_id=doc.id) }}">Karşılaştır</a>
 </div>
-<script src="{{ asset_url('toolbar/toolbar.js') }}" defer></script>
+<script type="module" src="{{ asset_url('toolbar/toolbar.js') }}"></script>
 {% endblock %}
 {% block content %}
 <header class="mb-4">
@@ -135,7 +135,7 @@
     </div>
   </div>
 
-  <script src="{{ asset_url('document_detail.js') }}" defer></script>
+  <script type="module" src="{{ asset_url('document_detail.js') }}"></script>
   <script defer>
     document.getElementById('confirm-revise-btn').addEventListener('click', function (e) {
       if (!confirm('Revizyonu başlatmak istediğinize emin misiniz?')) {

--- a/portal/templates/document_edit.html
+++ b/portal/templates/document_edit.html
@@ -10,5 +10,5 @@
   window.editorTokenHeader = {{ token_header | tojson }};
 </script>
 <script src="{{ editor_js }}"></script>
-<script src="{{ asset_url('document_edit.js') }}" defer></script>
+<script type="module" src="{{ asset_url('document_edit.js') }}"></script>
 {% endblock %}

--- a/portal/templates/documents/list.html
+++ b/portal/templates/documents/list.html
@@ -8,7 +8,7 @@
   <a href="#" class="btn btn-outline-primary" data-action="export"><svg class="icon"><use xlink:href="#icon-download"></use></svg><span>Export</span></a>
   <button type="button" class="btn btn-outline-secondary" data-action="filter"><svg class="icon"><use xlink:href="#icon-filter"></use></svg><span>Filter</span></button>
 </div>
-<script src="{{ asset_url('toolbar/toolbar.js') }}" defer></script>
+<script type="module" src="{{ asset_url('toolbar/toolbar.js') }}"></script>
 {% endblock %}
 {% block content %}
   <h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">Documents</h1>
@@ -42,5 +42,5 @@
 <div id="document-table">
   {% include 'documents/_table.html' %}
 </div>
-<script src="{{ asset_url('document_list.js') }}" defer></script>
+<script type="module" src="{{ asset_url('document_list.js') }}"></script>
 {% endblock %}

--- a/portal/templates/reports/index.html
+++ b/portal/templates/reports/index.html
@@ -38,5 +38,5 @@
   </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
-<script src="{{ asset_url('reports.js') }}" defer></script>
+<script type="module" src="{{ asset_url('reports.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Load app bundle as an ES module
- Mark other module-based assets as `type="module"`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'alembic.config')*

------
https://chatgpt.com/codex/tasks/task_e_68a0d842f31c832b8f1281f883f4a9b0