### PR TITLE
Add CSP nonce-based script policy

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -9,6 +9,7 @@ from flask import (
     Response,
     session,
     make_response,
+    g,
 )
 from flask_wtf.csrf import CSRFProtect
 from auth import auth_bp, init_app as auth_init, login_required, roles_required
@@ -67,11 +68,18 @@ app.config["SESSION_COOKIE_SECURE"] = (
 )
 
 
+@app.before_request
+def add_csp_nonce():
+    g.csp_nonce = secrets.token_urlsafe(16)
+
+
 @app.after_request
 def set_security_headers(response):
+    nonce = getattr(g, "csp_nonce", "")
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; frame-ancestors 'none'; "
-        "style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'"
+        "style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; "
+        f"script-src 'self' https://cdn.jsdelivr.net 'nonce-{nonce}'"
     )
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
     response.headers["X-Frame-Options"] = "DENY"
@@ -104,6 +112,11 @@ def inject_user():
     def has_role(role):
         return role in roles
     return {"current_user": user, "user_roles": roles, "has_role": has_role}
+
+
+@app.context_processor
+def inject_csp_nonce():
+    return {"csp_nonce": getattr(g, "csp_nonce", "")}
 
 ONLYOFFICE_INTERNAL_URL = os.environ["ONLYOFFICE_INTERNAL_URL"]  # http://onlyoffice
 ONLYOFFICE_PUBLIC_URL   = os.environ["ONLYOFFICE_PUBLIC_URL"]    # https://qdms.example.com/onlyoffice

--- a/portal/templates/admin/departments.html
+++ b/portal/templates/admin/departments.html
@@ -16,7 +16,7 @@
   <input class="form-control" name="name" placeholder="Department name">
   <button class="btn btn-primary mt-2" type="submit">Add</button>
 </form>
-<script>
+<script nonce="{{ csp_nonce }}">
 const form = document.getElementById('deptForm');
 form.addEventListener('submit', async (e) => {
   e.preventDefault();

--- a/portal/templates/admin/roles.html
+++ b/portal/templates/admin/roles.html
@@ -22,7 +22,7 @@
   </div>
   <button class="btn btn-primary" type="submit">Assign</button>
 </form>
-<script>
+<script nonce="{{ csp_nonce }}">
 const form = document.getElementById('roleForm');
 form.addEventListener('submit', async (e) => {
   e.preventDefault();

--- a/portal/templates/approval_queue.html
+++ b/portal/templates/approval_queue.html
@@ -67,7 +67,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 (function(){
   const selectAll = document.getElementById('select-all');
   const bulkApprove = document.getElementById('bulk-approve');

--- a/portal/templates/approvals/detail.html
+++ b/portal/templates/approvals/detail.html
@@ -7,12 +7,12 @@
 <div id="editor-container" class="vh-100 overflow-auto">
   <iframe id="docEditor" class="w-100 h-100 border-0" title="Document preview" loading="lazy"></iframe>
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
   const editorConfig = {{ config | tojson }};
   const editorToken = {{ token | tojson }};
 </script>
 <script src="{{ editor_js }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   if (editorToken && window.DocsAPI && window.DocsAPI.setRequestHeaders) {
     window.DocsAPI.setRequestHeaders([{ header: '{{ token_header|default("Authorization") }}', value: editorToken }]);
   }

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -136,7 +136,7 @@
   </div>
 
   <script type="module" src="{{ asset_url('document_detail.js') }}"></script>
-  <script defer>
+  <script nonce="{{ csp_nonce }}" defer>
     document.getElementById('confirm-revise-btn').addEventListener('click', function (e) {
       if (!confirm('Revizyonu başlatmak istediğinize emin misiniz?')) {
         e.preventDefault();

--- a/portal/templates/document_edit.html
+++ b/portal/templates/document_edit.html
@@ -4,7 +4,7 @@
 <div id="editor-wrapper" style="height:80vh;">
   <div id="editor" style="height:100%;"></div>
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
   window.editorConfig = {{ config | tojson }};
   window.editorToken = {{ token | tojson }};
   window.editorTokenHeader = {{ token_header | tojson }};

--- a/portal/templates/documents/edit.html
+++ b/portal/templates/documents/edit.html
@@ -10,12 +10,12 @@
   <!-- OnlyOffice editor iframe placeholder -->
   <iframe id="docEditor" class="w-100 h-100 border-0" title="Document editor" loading="lazy"></iframe>
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
   const editorConfig = {{ config | tojson }};
   const editorToken = {{ token | tojson }};
 </script>
 <script src="{{ editor_js }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
   if (editorToken && window.DocsAPI && window.DocsAPI.setRequestHeaders) {
     window.DocsAPI.setRequestHeaders([{ header: '{{ token_header|default('Authorization') }}', value: editorToken }]);
   }

--- a/portal/templates/forms/sample.html
+++ b/portal/templates/forms/sample.html
@@ -6,7 +6,7 @@
   <div id="form-container"></div>
   <button type="submit" class="btn btn-primary">Submit</button>
 </form>
-<script type="module">
+<script type="module" nonce="{{ csp_nonce }}">
   import { createInput, attachHelpText, attachValidation, attachTooltip } from '/static/src/forms/index.js';
   const container = document.getElementById('form-container');
   const emailField = createInput({ id: 'email', name: 'email', label: 'Email', type: 'email', required: true, copyable: true });

--- a/portal/templates/mandatory_reading.html
+++ b/portal/templates/mandatory_reading.html
@@ -43,7 +43,7 @@
   </tbody>
 </table>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 (function(){
   const selectAll = document.getElementById('select-all');
   const bulkConfirm = document.getElementById('bulk-confirm');


### PR DESCRIPTION
## Summary
- add per-request CSP nonce
- allow self and jsdelivr scripts via script-src
- apply nonces to inline scripts across templates

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'alembic.config')*

------
https://chatgpt.com/codex/tasks/task_e_68a0db1f7d00832ba20ebf4a7d77393a