### PR TITLE
Remove Content Security Policy implementation

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,7 +27,6 @@ http {
     listen 80;
     server_name _;
 
-    add_header Content-Security-Policy "default-src 'self'; frame-ancestors 'none'; style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'";
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options "DENY";
 
@@ -63,7 +62,6 @@ http {
       proxy_set_header X-Forwarded-Port $server_port;
       proxy_hide_header X-Frame-Options;
       add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header Content-Security-Policy "default-src 'self' blob: data:; frame-src 'self' blob: data:; connect-src 'self' ws: wss:; script-src 'self' 'unsafe-inline'; style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline';" always;
     }
 
     # WebSocket yolları (OnlyOffice)

--- a/portal/templates/admin/departments.html
+++ b/portal/templates/admin/departments.html
@@ -16,7 +16,7 @@
   <input class="form-control" name="name" placeholder="Department name">
   <button class="btn btn-primary mt-2" type="submit">Add</button>
 </form>
-<script nonce="{{ csp_nonce }}">
+<script>
 const form = document.getElementById('deptForm');
 form.addEventListener('submit', async (e) => {
   e.preventDefault();

--- a/portal/templates/admin/roles.html
+++ b/portal/templates/admin/roles.html
@@ -22,7 +22,7 @@
   </div>
   <button class="btn btn-primary" type="submit">Assign</button>
 </form>
-<script nonce="{{ csp_nonce }}">
+<script>
 const form = document.getElementById('roleForm');
 form.addEventListener('submit', async (e) => {
   e.preventDefault();

--- a/portal/templates/approval_queue.html
+++ b/portal/templates/approval_queue.html
@@ -67,7 +67,7 @@
   </div>
 </div>
 
-<script nonce="{{ csp_nonce }}">
+<script>
 (function(){
   const selectAll = document.getElementById('select-all');
   const bulkApprove = document.getElementById('bulk-approve');

--- a/portal/templates/approvals/detail.html
+++ b/portal/templates/approvals/detail.html
@@ -7,12 +7,12 @@
 <div id="editor-container" class="vh-100 overflow-auto">
   <iframe id="docEditor" class="w-100 h-100 border-0" title="Document preview" loading="lazy"></iframe>
 </div>
-<script nonce="{{ csp_nonce }}">
+<script>
   const editorConfig = {{ config | tojson }};
   const editorToken = {{ token | tojson }};
 </script>
 <script src="{{ editor_js }}"></script>
-<script nonce="{{ csp_nonce }}">
+<script>
   if (editorToken && window.DocsAPI && window.DocsAPI.setRequestHeaders) {
     window.DocsAPI.setRequestHeaders([{ header: '{{ token_header|default("Authorization") }}', value: editorToken }]);
   }

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -136,7 +136,7 @@
   </div>
 
   <script type="module" src="{{ asset_url('document_detail.js') }}"></script>
-  <script nonce="{{ csp_nonce }}" defer>
+  <script defer>
     document.getElementById('confirm-revise-btn').addEventListener('click', function (e) {
       if (!confirm('Revizyonu başlatmak istediğinize emin misiniz?')) {
         e.preventDefault();

--- a/portal/templates/document_edit.html
+++ b/portal/templates/document_edit.html
@@ -4,7 +4,7 @@
 <div id="editor-wrapper" style="height:80vh;">
   <div id="editor" style="height:100%;"></div>
 </div>
-<script nonce="{{ csp_nonce }}">
+<script>
   window.editorConfig = {{ config | tojson }};
   window.editorToken = {{ token | tojson }};
   window.editorTokenHeader = {{ token_header | tojson }};

--- a/portal/templates/documents/edit.html
+++ b/portal/templates/documents/edit.html
@@ -10,12 +10,12 @@
   <!-- OnlyOffice editor iframe placeholder -->
   <iframe id="docEditor" class="w-100 h-100 border-0" title="Document editor" loading="lazy"></iframe>
 </div>
-<script nonce="{{ csp_nonce }}">
+<script>
   const editorConfig = {{ config | tojson }};
   const editorToken = {{ token | tojson }};
 </script>
 <script src="{{ editor_js }}"></script>
-<script nonce="{{ csp_nonce }}">
+<script>
   if (editorToken && window.DocsAPI && window.DocsAPI.setRequestHeaders) {
     window.DocsAPI.setRequestHeaders([{ header: '{{ token_header|default('Authorization') }}', value: editorToken }]);
   }

--- a/portal/templates/forms/sample.html
+++ b/portal/templates/forms/sample.html
@@ -6,7 +6,7 @@
   <div id="form-container"></div>
   <button type="submit" class="btn btn-primary">Submit</button>
 </form>
-<script type="module" nonce="{{ csp_nonce }}">
+<script type="module">
   import { createInput, attachHelpText, attachValidation, attachTooltip } from '/static/src/forms/index.js';
   const container = document.getElementById('form-container');
   const emailField = createInput({ id: 'email', name: 'email', label: 'Email', type: 'email', required: true, copyable: true });

--- a/portal/templates/mandatory_reading.html
+++ b/portal/templates/mandatory_reading.html
@@ -43,7 +43,7 @@
   </tbody>
 </table>
 
-<script nonce="{{ csp_nonce }}">
+<script>
 (function(){
   const selectAll = document.getElementById('select-all');
   const bulkConfirm = document.getElementById('bulk-confirm');


### PR DESCRIPTION
## Summary
- drop Content Security Policy headers from Nginx configuration
- remove CSP header handling and nonce generation in Flask portal
- clean up templates to stop using CSP nonce attributes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'alembic.config')*
- `pip install alembic` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e29a0970832b83f2497fd1e78b9d