### PR TITLE
Fix missing _tokens.scss import causing 404

### DIFF
--- a/portal/static/dist/tokens.js
+++ b/portal/static/dist/tokens.js
@@ -1,1 +1,1 @@
-import '../css/_tokens.scss';export function getToken(name) {return getComputedStyle(document.documentElement).getPropertyValue(`--${name}`).trim();}export default { getToken };
+export function getToken(name){return getComputedStyle(document.documentElement).getPropertyValue(`--${name}`).trim();}export default{getToken};

--- a/portal/static/src/tokens.js
+++ b/portal/static/src/tokens.js
@@ -1,5 +1,3 @@
-import '../css/_tokens.scss';
-
 export function getToken(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(`--${name}`).trim();
 }


### PR DESCRIPTION
## Summary
- remove direct import of `_tokens.scss` from tokens module to prevent browser 404 requests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'alembic.config')*


------
https://chatgpt.com/codex/tasks/task_e_68a0f24ff1d4832b9ba47ba83b576c21