### PR TITLE
Add polling container for dashboard cards

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -363,7 +363,7 @@ def profile_view():
     )
 
 
-@app.get("/dashboard/cards/pending")
+@app.get("/api/dashboard/cards/pending")
 @login_required
 def dashboard_cards_pending():
     db = get_session()
@@ -378,7 +378,7 @@ def dashboard_cards_pending():
         db.close()
 
 
-@app.get("/dashboard/cards/mandatory")
+@app.get("/api/dashboard/cards/mandatory")
 @login_required
 def dashboard_cards_mandatory():
     db = get_session()
@@ -394,7 +394,7 @@ def dashboard_cards_mandatory():
         db.close()
 
 
-@app.get("/dashboard/cards/recent")
+@app.get("/api/dashboard/cards/recent")
 @login_required
 def dashboard_cards_recent():
     db = get_session()
@@ -409,7 +409,7 @@ def dashboard_cards_recent():
         db.close()
 
 
-@app.get("/dashboard/cards/shortcuts")
+@app.get("/api/dashboard/cards/shortcuts")
 @login_required
 def dashboard_cards_shortcuts():
     return render_template(

--- a/portal/templates/dashboard.html
+++ b/portal/templates/dashboard.html
@@ -6,14 +6,10 @@
   <div class="col">
     <div class="card h-100">
       <div class="card-header">Pending Approvals</div>
-      <div class="card-body"
-           hx-get="{{ url_for('dashboard_cards_pending') }}"
-           hx-trigger="load, every 10s">
-        <div class="placeholder-glow">
-          <span class="placeholder col-12 mb-2"></span>
-          <span class="placeholder col-12 mb-2"></span>
-          <span class="placeholder col-12 mb-2"></span>
-        </div>
+      <div class="card-body">
+        {% with card='pending' %}
+          {% include 'partials/dashboard/_cards.html' %}
+        {% endwith %}
       </div>
     </div>
   </div>
@@ -21,14 +17,10 @@
   <div class="col">
     <div class="card h-100">
       <div class="card-header">Mandatory Reading</div>
-      <div class="card-body"
-           hx-get="{{ url_for('dashboard_cards_mandatory') }}"
-           hx-trigger="load, every 10s">
-        <div class="placeholder-glow">
-          <span class="placeholder col-12 mb-2"></span>
-          <span class="placeholder col-12 mb-2"></span>
-          <span class="placeholder col-12 mb-2"></span>
-        </div>
+      <div class="card-body">
+        {% with card='mandatory' %}
+          {% include 'partials/dashboard/_cards.html' %}
+        {% endwith %}
       </div>
     </div>
   </div>
@@ -36,14 +28,10 @@
   <div class="col">
     <div class="card h-100">
       <div class="card-header">Recent Changes</div>
-      <div class="card-body"
-           hx-get="{{ url_for('dashboard_cards_recent') }}"
-           hx-trigger="load, every 10s">
-        <div class="placeholder-glow">
-          <span class="placeholder col-12 mb-2"></span>
-          <span class="placeholder col-12 mb-2"></span>
-          <span class="placeholder col-12 mb-2"></span>
-        </div>
+      <div class="card-body">
+        {% with card='recent' %}
+          {% include 'partials/dashboard/_cards.html' %}
+        {% endwith %}
       </div>
     </div>
   </div>
@@ -51,14 +39,10 @@
   <div class="col">
     <div class="card h-100">
       <div class="card-header">Search Shortcuts</div>
-      <div class="card-body"
-           hx-get="{{ url_for('dashboard_cards_shortcuts') }}"
-           hx-trigger="load, every 10s">
-        <div class="placeholder-glow">
-          <span class="placeholder col-12 mb-2"></span>
-          <span class="placeholder col-12 mb-2"></span>
-          <span class="placeholder col-12 mb-2"></span>
-        </div>
+      <div class="card-body">
+        {% with card='shortcuts' %}
+          {% include 'partials/dashboard/_cards.html' %}
+        {% endwith %}
       </div>
     </div>
   </div>

--- a/portal/templates/partials/dashboard/_cards.html
+++ b/portal/templates/partials/dashboard/_cards.html
@@ -14,13 +14,27 @@
   {% endif %}
 {% endmacro %}
 
-{% if card == 'pending' %}
-  {{ render_items(pending_approvals, 'No pending approvals.') }}
-{% elif card == 'mandatory' %}
-  {{ render_items(mandatory_reading, 'No mandatory documents.') }}
-{% elif card == 'recent' %}
-  {{ render_items(recent_revisions, 'No recent changes.') }}
-{% elif card == 'shortcuts' %}
-  {{ render_items(search_shortcuts, 'No search shortcuts available.') }}
+{% if request.headers.get('HX-Request') %}
+  {% if card == 'pending' %}
+    {{ render_items(pending_approvals, 'No pending approvals.') }}
+  {% elif card == 'mandatory' %}
+    {{ render_items(mandatory_reading, 'No mandatory documents.') }}
+  {% elif card == 'recent' %}
+    {{ render_items(recent_revisions, 'No recent changes.') }}
+  {% elif card == 'shortcuts' %}
+    {{ render_items(search_shortcuts, 'No search shortcuts available.') }}
+  {% endif %}
+{% else %}
+  <div
+    hx-get="/api/dashboard/cards/{{ card }}"
+    hx-trigger="load, every 10s"
+    hx-swap="innerHTML"
+  >
+    <div class="placeholder-glow">
+      <span class="placeholder col-12 mb-2"></span>
+      <span class="placeholder col-12 mb-2"></span>
+      <span class="placeholder col-12 mb-2"></span>
+    </div>
+  </div>
 {% endif %}
 

--- a/tests/test_dashboard_cards.py
+++ b/tests/test_dashboard_cards.py
@@ -70,7 +70,9 @@ def test_dashboard_card_endpoints(client):
         sess["roles"] = ["approver", "reader"]
 
     # Pending approvals
-    resp = client.get("/dashboard/cards/pending")
+    resp = client.get(
+        "/api/dashboard/cards/pending", headers={"HX-Request": "true"}
+    )
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     with app.test_request_context():
@@ -79,7 +81,9 @@ def test_dashboard_card_endpoints(client):
     assert pending_url in html
 
     # Mandatory reading
-    resp = client.get("/dashboard/cards/mandatory")
+    resp = client.get(
+        "/api/dashboard/cards/mandatory", headers={"HX-Request": "true"}
+    )
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     with app.test_request_context():
@@ -88,7 +92,9 @@ def test_dashboard_card_endpoints(client):
     assert mandatory_url in html
 
     # Recent revisions
-    resp = client.get("/dashboard/cards/recent")
+    resp = client.get(
+        "/api/dashboard/cards/recent", headers={"HX-Request": "true"}
+    )
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     with app.test_request_context():

--- a/tests/test_pending_approvals.py
+++ b/tests/test_pending_approvals.py
@@ -53,7 +53,9 @@ def test_pending_approvals_with_roles(client):
     with client.session_transaction() as sess:
         sess["user"] = {"id": 1, "name": "Tester"}
         sess["roles"] = ["approver"]
-    resp = client.get("/dashboard/cards/pending")
+    resp = client.get(
+        "/api/dashboard/cards/pending", headers={"HX-Request": "true"}
+    )
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     with app.test_request_context():
@@ -69,7 +71,9 @@ def test_pending_approvals_no_roles(client):
     with client.session_transaction() as sess:
         sess["user"] = {"id": 1, "name": "Tester"}
         sess["roles"] = []
-    resp = client.get("/dashboard/cards/pending")
+    resp = client.get(
+        "/api/dashboard/cards/pending", headers={"HX-Request": "true"}
+    )
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     with app.test_request_context():


### PR DESCRIPTION
## Summary
- wrap dashboard card content in HTMX polling container
- expose card endpoints under `/api/dashboard/cards/*`
- load card partials directly in `dashboard.html`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a17cfd0d84832bac4acb09c288a53d