### PR TITLE
Add dynamic dashboard card routes

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -363,60 +363,27 @@ def profile_view():
     )
 
 
-@app.get("/api/dashboard/cards/pending")
+@app.get("/api/dashboard/cards/<card>")
 @login_required
-def dashboard_cards_pending():
-    db = get_session()
-    try:
-        pending = _get_pending_approvals(db)
-        return render_template(
-            "partials/dashboard/_cards.html",
-            card="pending",
-            pending_approvals=pending,
-        )
-    finally:
-        db.close()
-
-
-@app.get("/api/dashboard/cards/mandatory")
-@login_required
-def dashboard_cards_mandatory():
+def dashboard_cards(card):
     db = get_session()
     try:
         user = session.get("user") or {}
-        mandatory = _get_mandatory_reading(db, user.get("id"))
-        return render_template(
-            "partials/dashboard/_cards.html",
-            card="mandatory",
-            mandatory_reading=mandatory,
-        )
+        user_id = user.get("id")
+        context = {"card": card}
+        if card == "pending":
+            context["pending_approvals"] = _get_pending_approvals(db)
+        elif card == "mandatory":
+            context["mandatory_reading"] = _get_mandatory_reading(db, user_id)
+        elif card == "recent":
+            context["recent_revisions"] = _get_recent_revisions(db)
+        elif card == "shortcuts":
+            context["search_shortcuts"] = _get_search_shortcuts()
+        else:
+            return ("", 404)
+        return render_template("partials/dashboard/_cards.html", **context)
     finally:
         db.close()
-
-
-@app.get("/api/dashboard/cards/recent")
-@login_required
-def dashboard_cards_recent():
-    db = get_session()
-    try:
-        recent = _get_recent_revisions(db)
-        return render_template(
-            "partials/dashboard/_cards.html",
-            card="recent",
-            recent_revisions=recent,
-        )
-    finally:
-        db.close()
-
-
-@app.get("/api/dashboard/cards/shortcuts")
-@login_required
-def dashboard_cards_shortcuts():
-    return render_template(
-        "partials/dashboard/_cards.html",
-        card="shortcuts",
-        search_shortcuts=_get_search_shortcuts(),
-    )
 
 
 @app.get("/api/dashboard/pending-approvals")

--- a/portal/templates/dashboard.html
+++ b/portal/templates/dashboard.html
@@ -6,7 +6,10 @@
   <div class="col">
     <div class="card h-100">
       <div class="card-header">Pending Approvals</div>
-      <div class="card-body">
+      <div class="card-body"
+           hx-get="/api/dashboard/cards/pending"
+           hx-trigger="load, every 10s"
+           hx-swap="innerHTML">
         {% with card='pending' %}
           {% include 'partials/dashboard/_cards.html' %}
         {% endwith %}
@@ -17,7 +20,10 @@
   <div class="col">
     <div class="card h-100">
       <div class="card-header">Mandatory Reading</div>
-      <div class="card-body">
+      <div class="card-body"
+           hx-get="/api/dashboard/cards/mandatory"
+           hx-trigger="load, every 10s"
+           hx-swap="innerHTML">
         {% with card='mandatory' %}
           {% include 'partials/dashboard/_cards.html' %}
         {% endwith %}
@@ -28,7 +34,10 @@
   <div class="col">
     <div class="card h-100">
       <div class="card-header">Recent Changes</div>
-      <div class="card-body">
+      <div class="card-body"
+           hx-get="/api/dashboard/cards/recent"
+           hx-trigger="load, every 10s"
+           hx-swap="innerHTML">
         {% with card='recent' %}
           {% include 'partials/dashboard/_cards.html' %}
         {% endwith %}
@@ -39,7 +48,10 @@
   <div class="col">
     <div class="card h-100">
       <div class="card-header">Search Shortcuts</div>
-      <div class="card-body">
+      <div class="card-body"
+           hx-get="/api/dashboard/cards/shortcuts"
+           hx-trigger="load, every 10s"
+           hx-swap="innerHTML">
         {% with card='shortcuts' %}
           {% include 'partials/dashboard/_cards.html' %}
         {% endwith %}

--- a/portal/templates/partials/dashboard/_cards.html
+++ b/portal/templates/partials/dashboard/_cards.html
@@ -14,27 +14,13 @@
   {% endif %}
 {% endmacro %}
 
-{% if request.headers.get('HX-Request') %}
-  {% if card == 'pending' %}
-    {{ render_items(pending_approvals, 'No pending approvals.') }}
-  {% elif card == 'mandatory' %}
-    {{ render_items(mandatory_reading, 'No mandatory documents.') }}
-  {% elif card == 'recent' %}
-    {{ render_items(recent_revisions, 'No recent changes.') }}
-  {% elif card == 'shortcuts' %}
-    {{ render_items(search_shortcuts, 'No search shortcuts available.') }}
-  {% endif %}
-{% else %}
-  <div
-    hx-get="/api/dashboard/cards/{{ card }}"
-    hx-trigger="load, every 10s"
-    hx-swap="innerHTML"
-  >
-    <div class="placeholder-glow">
-      <span class="placeholder col-12 mb-2"></span>
-      <span class="placeholder col-12 mb-2"></span>
-      <span class="placeholder col-12 mb-2"></span>
-    </div>
-  </div>
+{% if card == 'pending' %}
+  {{ render_items(pending_approvals, 'No pending approvals.') }}
+{% elif card == 'mandatory' %}
+  {{ render_items(mandatory_reading, 'No mandatory documents.') }}
+{% elif card == 'recent' %}
+  {{ render_items(recent_revisions, 'No recent changes.') }}
+{% elif card == 'shortcuts' %}
+  {{ render_items(search_shortcuts, 'No search shortcuts available.') }}
 {% endif %}
 


### PR DESCRIPTION
## Summary
- combine dashboard card endpoints into single dynamic route
- point dashboard htmx requests to `/api/dashboard/cards/<card>` and simplify card partial

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17ebc1e6c832b89d55b9e2b4c8cde