### PR TITLE
Render dashboard skeleton while HTMX loads

### DIFF
--- a/portal/templates/dashboard.html
+++ b/portal/templates/dashboard.html
@@ -10,9 +10,8 @@
            hx-get="/api/dashboard/cards/pending"
            hx-trigger="load, every 10s"
            hx-swap="innerHTML">
-        {% with card='pending' %}
-          {% include 'partials/dashboard/_cards.html' %}
-        {% endwith %}
+        {% set card = 'pending' %}
+        {% include 'partials/dashboard/_cards.html' %}
       </div>
     </div>
   </div>
@@ -24,9 +23,8 @@
            hx-get="/api/dashboard/cards/mandatory"
            hx-trigger="load, every 10s"
            hx-swap="innerHTML">
-        {% with card='mandatory' %}
-          {% include 'partials/dashboard/_cards.html' %}
-        {% endwith %}
+        {% set card = 'mandatory' %}
+        {% include 'partials/dashboard/_cards.html' %}
       </div>
     </div>
   </div>
@@ -38,9 +36,8 @@
            hx-get="/api/dashboard/cards/recent"
            hx-trigger="load, every 10s"
            hx-swap="innerHTML">
-        {% with card='recent' %}
-          {% include 'partials/dashboard/_cards.html' %}
-        {% endwith %}
+        {% set card = 'recent' %}
+        {% include 'partials/dashboard/_cards.html' %}
       </div>
     </div>
   </div>
@@ -52,9 +49,8 @@
            hx-get="/api/dashboard/cards/shortcuts"
            hx-trigger="load, every 10s"
            hx-swap="innerHTML">
-        {% with card='shortcuts' %}
-          {% include 'partials/dashboard/_cards.html' %}
-        {% endwith %}
+        {% set card = 'shortcuts' %}
+        {% include 'partials/dashboard/_cards.html' %}
       </div>
     </div>
   </div>

--- a/portal/templates/partials/dashboard/_cards.html
+++ b/portal/templates/partials/dashboard/_cards.html
@@ -1,16 +1,24 @@
 {% macro render_items(items, empty_text) %}
-  {% if items %}
-    <ul class="list-unstyled mb-0">
-    {% for item in items %}
-      {% if item[1] is defined %}
-        <li><a href="{{ item[1] }}">{{ item[0] }}</a></li>
-      {% else %}
-        <li>{{ item }}</li>
-      {% endif %}
-    {% endfor %}
-    </ul>
+  {% if items is defined and items is not none %}
+    {% if items %}
+      <ul class="list-unstyled mb-0">
+      {% for item in items %}
+        {% if item[1] is defined %}
+          <li><a href="{{ item[1] }}">{{ item[0] }}</a></li>
+        {% else %}
+          <li>{{ item }}</li>
+        {% endif %}
+      {% endfor %}
+      </ul>
+    {% else %}
+      <p class="text-muted mb-0">{{ empty_text }}</p>
+    {% endif %}
   {% else %}
-    <p class="text-muted mb-0">{{ empty_text }}</p>
+    <div class="placeholder-glow">
+      <span class="placeholder col-12 mb-2"></span>
+      <span class="placeholder col-12 mb-2"></span>
+      <span class="placeholder col-12 mb-2"></span>
+    </div>
   {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
## Summary
- Show placeholder skeletons when dashboard cards load or data is absent
- Simplify dashboard template by including card partials directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1805cc9b8832b833bcadf9c5a4b33