### PR TITLE
Align dashboard card empty states with product copy

### DIFF
--- a/portal/templates/partials/dashboard/_cards.html
+++ b/portal/templates/partials/dashboard/_cards.html
@@ -25,10 +25,10 @@
 {% if card == 'pending' %}
   {{ render_items(pending_approvals, 'No pending approvals.') }}
 {% elif card == 'mandatory' %}
-  {{ render_items(mandatory_reading, 'No mandatory documents.') }}
+  {{ render_items(mandatory_reading, 'No mandatory reading.') }}
 {% elif card == 'recent' %}
   {{ render_items(recent_revisions, 'No recent changes.') }}
 {% elif card == 'shortcuts' %}
-  {{ render_items(search_shortcuts, 'No search shortcuts available.') }}
+  {{ render_items(search_shortcuts, 'No search shortcuts.') }}
 {% endif %}
 


### PR DESCRIPTION
## Summary
- Replace mismatched empty-state copy for Mandatory Reading and Search Shortcuts dashboard cards
- Ensure dashboard cards now show product-copy when no items are available

## Testing
- `pytest`
- Manual verification of `/api/dashboard/cards/*` endpoints with no data

------
https://chatgpt.com/codex/tasks/task_e_68a181daa69c832b8a6863b71cf6f2a1