### PR TITLE
Capture document metadata in step 1

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -546,11 +546,19 @@ def new_document():
     data = session.get("new_doc", {})
 
     if request.method == "POST":
+        if step == "1":
+            data["code"] = request.form.get("code", "").strip()
+            data["title"] = request.form.get("title", "").strip()
+            data["type"] = request.form.get("type", "").strip()
+            data["department"] = request.form.get("department", "").strip()
+            tags = request.form.get("tags", "")
+            data["tags"] = ",".join([t.strip() for t in tags.split(",") if t.strip()])
+            session["new_doc"] = data
+            return redirect(url_for("new_document", step=2))
+
         data.update(request.form.to_dict())
         session["new_doc"] = data
 
-        if step == "1":
-            return redirect(url_for("new_document", step=2))
         if step == "2":
             return redirect(url_for("new_document", step=3))
         if step == "3":

--- a/portal/templates/documents/new_step1.html
+++ b/portal/templates/documents/new_step1.html
@@ -14,6 +14,21 @@
     <input type="text" class="form-control{% if errors.title %} is-invalid{% endif %}" id="title" name="title" value="{{ form.title or '' }}">
     {% if errors.title %}<div class="invalid-feedback">{{ errors.title }}</div>{% endif %}
   </div>
+  <div class="mb-3">
+    <label for="type" class="form-label">Type</label>
+    <input type="text" class="form-control{% if errors.type %} is-invalid{% endif %}" id="type" name="type" value="{{ form.type or '' }}">
+    {% if errors.type %}<div class="invalid-feedback">{{ errors.type }}</div>{% endif %}
+  </div>
+  <div class="mb-3">
+    <label for="department" class="form-label">Department</label>
+    <input type="text" class="form-control{% if errors.department %} is-invalid{% endif %}" id="department" name="department" value="{{ form.department or '' }}">
+    {% if errors.department %}<div class="invalid-feedback">{{ errors.department }}</div>{% endif %}
+  </div>
+  <div class="mb-3">
+    <label for="tags" class="form-label">Tags</label>
+    <input type="text" class="form-control{% if errors.tags %} is-invalid{% endif %}" id="tags" name="tags" value="{{ form.tags or '' }}" placeholder="tag1, tag2">
+    {% if errors.tags %}<div class="invalid-feedback">{{ errors.tags }}</div>{% endif %}
+  </div>
   <button type="submit" class="btn btn-primary">Next</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add inputs for code, title, type, department and tags to initial new document form
- save step 1 fields to `session['new_doc']`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a18854694c832b953df78e914bd05c