### PR TITLE
Add draft document creation via API

### DIFF
--- a/portal/templates/documents/new_step3.html
+++ b/portal/templates/documents/new_step3.html
@@ -9,5 +9,33 @@
   <p><strong>Department:</strong> {{ form.department }}</p>
   <p><strong>Type:</strong> {{ form.type }}</p>
   <button type="submit" class="btn btn-primary">Create</button>
+  <button type="button" id="save-draft" class="btn btn-secondary ms-2">Taslak olarak kaydet</button>
 </form>
+<script>
+document.getElementById('save-draft').addEventListener('click', async () => {
+  const data = {
+    code: "{{ form.code }}",
+    title: "{{ form.title }}",
+    department: "{{ form.department }}",
+    process: "{{ form.type }}",
+    tags: "{{ form.tags }}".split(',').map(t => t.trim()).filter(Boolean),
+    template: "{{ form.template }}",
+    uploaded_file_name: "{{ form.uploaded_file_name }}",
+    uploaded_file_data: "{{ form.uploaded_file_data }}",
+    generate_docxf: {{ 'true' if form.generate_docxf else 'false' }}
+  };
+  const response = await fetch('/api/documents', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': '{{ csrf_token() }}'
+    },
+    body: JSON.stringify(data)
+  });
+  const result = await response.json();
+  if (result.id) {
+    window.location = `/documents/${result.id}`;
+  }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add Save as Draft button that posts to document API and redirects to new document
- send step 3 data to API on submit and redirect to created document
- expose create_document on /api/documents

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a18b3e3ce8832b8fb6987d67d7ef6e