### PR TITLE
Render DOCXF forms to DOCX/PDF and store in S3

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -36,7 +36,7 @@ from models import (
 from search import index_document
 from sqlalchemy import func, or_
 from ocr import extract_text
-from docxf_render import render_form_to_pdf
+from docxf_render import render_form_and_store
 from notifications import (
     notify_revision_time,
     notify_mandatory_read,
@@ -2253,7 +2253,7 @@ def submit_form(form_name):
     fields = payload.get("fields", {})
     if not user_id:
         return jsonify(error="user_id required"), 400
-    pdf = render_form_to_pdf(form_name, fields)
+    pdf = render_form_and_store(form_name, fields)
     session = get_session()
     try:
         session.add(


### PR DESCRIPTION
## Summary
- Generalize form rendering to support DOCX or PDF outputs
- Upload rendered form outputs to S3 with timestamped keys
- Update form submission endpoint to store documents while returning PDF

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a19af524ac832b84f051e411a2e931