### PR TITLE
Add presigned preview URLs for DOCXF documents

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -52,6 +52,7 @@ from reports import (
     pending_approvals_report,
 )
 from signing import create_signed_pdf
+from storage import generate_presigned_url
 from datetime import datetime
 from queue import Queue
 
@@ -975,6 +976,8 @@ def create_document_from_docxf():
         return jsonify(error="form_id and payload required"), 400
 
     _, docx_key, pdf_key = render_form_and_store(form_id, payload)
+    preview_key = pdf_key or docx_key
+    preview_url = generate_presigned_url(preview_key) if preview_key else None
 
     session_db = get_session()
     try:
@@ -999,7 +1002,12 @@ def create_document_from_docxf():
     finally:
         session_db.close()
 
-    return jsonify({"id": doc_id, "docx_key": docx_key, "pdf_key": pdf_key}), 201
+    return jsonify({
+        "id": doc_id,
+        "docx_key": docx_key,
+        "pdf_key": pdf_key,
+        "preview_url": preview_url,
+    }), 201
 
 
 @app.post("/documents/<int:doc_id>/sign")

--- a/portal/storage.py
+++ b/portal/storage.py
@@ -4,12 +4,14 @@ import os
 from datetime import datetime, timedelta
 import boto3
 from botocore.client import Config
+from botocore.exceptions import NoCredentialsError
 
 S3_ENDPOINT = os.getenv("S3_ENDPOINT")
 S3_ACCESS_KEY = os.getenv("S3_ACCESS_KEY") or os.getenv("S3_ACCESS_KEY_ID")
 S3_SECRET_KEY = os.getenv("S3_SECRET_KEY") or os.getenv("S3_SECRET_ACCESS_KEY")
 S3_BUCKET = os.getenv("S3_BUCKET") or os.getenv("S3_BUCKET_MAIN")
 ARCHIVE_PREFIX = os.getenv("ARCHIVE_PREFIX", "archive/")
+SIGNED_URL_EXPIRE_SECONDS = int(os.getenv("SIGNED_URL_EXPIRE_SECONDS", "3600"))
 
 _s3 = boto3.client(
     "s3",
@@ -39,3 +41,15 @@ def list_archived() -> list[str]:
     """Return keys of archived objects."""
     resp = _s3.list_objects_v2(Bucket=S3_BUCKET, Prefix=ARCHIVE_PREFIX)
     return [obj["Key"] for obj in resp.get("Contents", [])]
+
+
+def generate_presigned_url(key: str, expires_in: int | None = None) -> str | None:
+    """Generate a presigned download URL for an object."""
+    try:
+        return _s3.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": S3_BUCKET, "Key": key},
+            ExpiresIn=expires_in or SIGNED_URL_EXPIRE_SECONDS,
+        )
+    except NoCredentialsError:
+        return None


### PR DESCRIPTION
## Summary
- add helper to create presigned S3 URLs with configurable expiry
- include `preview_url` in `/api/documents/from-docxf` response

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a19d78d530832ba1904ad1570a79c5