### PR TITLE
Add DOCXF creation test and expose version in response

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -999,15 +999,19 @@ def create_document_from_docxf():
         session_db.add(rev)
         session_db.commit()
         doc_id = doc.id
+        version = f"{doc.major_version}.{doc.minor_version}"
     finally:
         session_db.close()
 
-    return jsonify({
-        "id": doc_id,
-        "docx_key": docx_key,
-        "pdf_key": pdf_key,
-        "preview_url": preview_url,
-    }), 201
+    return jsonify(
+        {
+            "id": doc_id,
+            "docx_key": docx_key,
+            "pdf_key": pdf_key,
+            "preview_url": preview_url,
+            "version": version,
+        }
+    ), 201
 
 
 @app.post("/documents/<int:doc_id>/sign")

--- a/tests/test_docxf_creation.py
+++ b/tests/test_docxf_creation.py
@@ -1,0 +1,107 @@
+import os
+from pathlib import Path
+import sys
+
+# Set up environment variables before importing application
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+os.environ.setdefault("S3_BUCKET", "test-bucket")
+os.environ.setdefault("S3_ACCESS_KEY", "test")
+os.environ.setdefault("S3_SECRET_KEY", "test")
+
+db_path = Path("test_docxf.db")
+if db_path.exists():
+    db_path.unlink()
+os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+# Ensure modules can be imported
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+import boto3
+from botocore.stub import Stubber, ANY
+import pytest
+
+from portal.app import app
+from portal.models import Base, engine, SessionLocal, Document
+from portal import storage, docxf_render
+import portal.app as portal_app
+import docxf_render as docxf_render_module
+
+
+# Create database schema
+Base.metadata.create_all(bind=engine)
+app.config["WTF_CSRF_ENABLED"] = False
+
+
+@pytest.fixture()
+def client():
+    return app.test_client()
+
+
+def test_docxf_document_creation(client):
+    # Prepare session with contributor role
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1}
+        sess["roles"] = ["contributor"]
+
+    s3 = boto3.client(
+        "s3",
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+    stubber = Stubber(s3)
+    stubber.add_response(
+        "put_object",
+        {},
+        {"Bucket": storage.S3_BUCKET, "Key": ANY, "Body": ANY},
+    )
+    stubber.add_response(
+        "put_object",
+        {},
+        {"Bucket": storage.S3_BUCKET, "Key": ANY, "Body": ANY},
+    )
+    stubber.activate()
+
+    storage._s3 = s3
+    docxf_render._s3 = s3
+    docxf_render_module._s3 = s3
+    storage.S3_BUCKET = "test-bucket"
+    docxf_render.S3_BUCKET = "test-bucket"
+    docxf_render_module.S3_BUCKET = "test-bucket"
+    storage.generate_presigned_url = (
+        lambda key, expires_in=None: f"https://example.com/{key}"
+    )
+    portal_app.generate_presigned_url = storage.generate_presigned_url
+
+    # Avoid external requests
+    def fake_render_form(form_name, data=None, outputtype="pdf"):
+        return b"dummy"
+
+    docxf_render.render_form = fake_render_form
+    docxf_render_module.render_form = fake_render_form
+
+    payload = {"title": "Test Doc", "code": "T-001"}
+    resp = client.post(
+        "/api/documents/from-docxf",
+        json={"form_id": "my-form", "payload": payload},
+    )
+    assert resp.status_code == 201
+    data = resp.get_json()
+
+    # JSON validations
+    assert data.get("version") == "1.0"
+    assert data.get("preview_url")
+
+    # Ensure S3 interactions occurred
+    stubber.assert_no_pending_responses()
+
+    # Verify version in database
+    session_db = SessionLocal()
+    doc = session_db.query(Document).get(data["id"])
+    assert f"{doc.major_version}.{doc.minor_version}" == "1.0"
+    session_db.close()


### PR DESCRIPTION
## Summary
- include document version in `/api/documents/from-docxf` response
- test DOCXF document creation via the API, ensuring preview URL and S3 interactions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1a4bb95ac832baf859fd711c6bda7