### PR TITLE
Support case-insensitive document search by query string

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -502,6 +502,13 @@ def _get_documents():
     if tag:
         query = query.filter(Document.tags.contains(tag))
         filters["tag"] = tag
+    q = request.args.get("q")
+    if q:
+        like = f"%{q}%"
+        query = query.filter(
+            or_(Document.title.ilike(like), Document.code.ilike(like))
+        )
+        filters["q"] = q
 
     page = int(request.args.get("page", 1))
     page_size = int(request.args.get("page_size", 20))

--- a/tests/test_document_search.py
+++ b/tests/test_document_search.py
@@ -1,0 +1,52 @@
+import os
+from pathlib import Path
+import sys
+
+# Ensure environment variables before importing application
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+_db_path = Path("test_search.db")
+if _db_path.exists():
+    _db_path.unlink()
+os.environ["DATABASE_URL"] = f"sqlite:///{_db_path}"
+
+# Make application modules importable
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+import pytest
+from portal.models import SessionLocal, Document, Base, engine
+from portal.app import app, _get_documents
+
+# Create database schema and populate sample data
+Base.metadata.create_all(bind=engine)
+session = SessionLocal()
+
+session.add_all([
+    Document(doc_key="doc1.docx", title="Safety Procedure", code="DOC-001", status="Published"),
+    Document(doc_key="doc2.docx", title="Quality Manual", code="MAN-002", status="Published"),
+    Document(doc_key="doc3.docx", title="Operations Guide", code="OPS-100", status="Published"),
+])
+session.commit()
+session.close()
+
+
+def test_get_documents_search_filters_by_q():
+    """Documents can be filtered by title or code using the q parameter."""
+    # Search by title, case-insensitive
+    with app.test_request_context("/documents", query_string={"q": "manual"}):
+        docs, _, _, filters, params = _get_documents()
+    titles = {d.title for d in docs}
+    assert titles == {"Quality Manual"}
+    assert filters["q"] == "manual"
+    assert params["q"] == "manual"
+
+    # Search by code, case-insensitive
+    with app.test_request_context("/documents", query_string={"q": "doc-001"}):
+        docs, _, _, _, _ = _get_documents()
+    codes = {d.code for d in docs}
+    assert codes == {"DOC-001"}


### PR DESCRIPTION
## Summary
- Allow filtering documents by title or code using `q` parameter
- Preserve search term in rendered filters
- Test query filtering behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1a807cf00832bbedf5c7845d4260c