### PR TITLE
Integrate search with facets and pagination

### DIFF
--- a/portal/search.py
+++ b/portal/search.py
@@ -93,9 +93,10 @@ def _cached_search(query_json: str):
 def search_documents(keyword: str, filters: dict, page: int = 1, per_page: int = 10):
     """Search for documents matching the given keyword and filters.
 
-    Returns a tuple of ``(results, facets)`` where ``results`` is a list of
-    matching documents and ``facets`` contains aggregation counts for the
-    ``department``, ``status`` and ``type`` fields.
+    Returns a tuple of ``(results, facets, total)`` where ``results`` is a list
+    of matching documents, ``facets`` contains aggregation counts for the
+    ``department``, ``status`` and ``type`` fields and ``total`` is the overall
+    number of hits.
     """
 
     if es is None:
@@ -131,7 +132,9 @@ def search_documents(keyword: str, filters: dict, page: int = 1, per_page: int =
         buckets = resp.get("aggregations", {}).get(facet, {}).get("buckets", [])
         aggs[facet] = {b["key"]: b["doc_count"] for b in buckets}
 
-    return results, aggs
+    total = resp.get("hits", {}).get("total", {}).get("value", 0)
+
+    return results, aggs, total
 
 
 create_index()

--- a/portal/templates/documents/list.html
+++ b/portal/templates/documents/list.html
@@ -17,16 +17,24 @@
     <div class="col-md-3">
       <select class="form-select" name="status" data-filter="select">
         <option value="">Any status</option>
-        <option value="Draft" {% if filters.status=='Draft' %}selected{% endif %}>Draft</option>
-        <option value="Approved" {% if filters.status=='Approved' %}selected{% endif %}>Approved</option>
-        <option value="Published" {% if filters.status=='Published' %}selected{% endif %}>Published</option>
+        <option value="Draft" {% if filters.status=='Draft' %}selected{% endif %}>
+          Draft{% if facets.status %} ({{ facets.status.get('Draft', 0) }}){% endif %}
+        </option>
+        <option value="Approved" {% if filters.status=='Approved' %}selected{% endif %}>
+          Approved{% if facets.status %} ({{ facets.status.get('Approved', 0) }}){% endif %}
+        </option>
+        <option value="Published" {% if filters.status=='Published' %}selected{% endif %}>
+          Published{% if facets.status %} ({{ facets.status.get('Published', 0) }}){% endif %}
+        </option>
       </select>
     </div>
     <div class="col-md-3">
       <select class="form-select" name="department" data-filter="select">
         <option value="">Any department</option>
         {% for d in departments %}
-        <option value="{{ d }}" {% if filters.department == d %}selected{% endif %}>{{ d }}</option>
+        <option value="{{ d }}" {% if filters.department == d %}selected{% endif %}>
+          {{ d }}{% if facets.department %} ({{ facets.department.get(d, 0) }}){% endif %}
+        </option>
         {% endfor %}
       </select>
     </div>


### PR DESCRIPTION
## Summary
- query Elasticsearch when keywords or filters are provided
- expose facet counts to filter UI
- handle search result pagination

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1add3df1c832b9c2fc84dbd2dc7fe