### PR TITLE
Notify all workflow assignees

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -828,7 +828,7 @@ def api_start_workflow():
         db.add_all(steps)
         db.commit()
         log_action(user["id"], doc_id, "start_workflow")
-        notify_revision_time(doc, reviewer_ids)
+        notify_revision_time(doc, list(set(all_ids)))
         return jsonify(ok=True)
     finally:
         db.close()


### PR DESCRIPTION
## Summary
- ensure `/api/workflow/start` notifies every assigned reviewer and approver
- add regression test for workflow notifications

## Testing
- `pytest tests/test_zz_workflow_start_api.py::test_workflow_start_status_and_steps tests/test_zz_workflow_start_api.py::test_workflow_start_notifies_all_assignees -q`
- `pytest -q` *(fails: tests/test_document_search.py::test_get_documents_search_filters_by_q, tests/test_document_search.py::test_get_documents_search_pagination, tests/test_docxf_creation.py::test_docxf_document_creation, tests/test_pending_approvals.py::test_pending_approvals_for_assigned_user)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c5765c70832bbc0e0c687ad08df3