### PR TITLE
Add step type field to workflow steps

### DIFF
--- a/alembic/versions/0002_add_step_type.py
+++ b/alembic/versions/0002_add_step_type.py
@@ -1,0 +1,31 @@
+"""Add step_type to workflow steps
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2024-05-27 00:00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    step_type = sa.Enum("review", "approval", name="workflow_step_type")
+    step_type.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        "workflow_steps",
+        sa.Column("step_type", step_type, nullable=False, server_default="review"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workflow_steps", "step_type")
+    step_type = sa.Enum("review", "approval", name="workflow_step_type")
+    step_type.drop(op.get_bind(), checkfirst=True)

--- a/portal/services.py
+++ b/portal/services.py
@@ -41,7 +41,12 @@ def submit_for_approval(doc_id: int, user_ids: list[int]) -> Document:
         raise ValueError("Document not found")
     doc.status = "Review"
     steps = [
-        WorkflowStep(doc_id=doc_id, step_order=i, user_id=uid)
+        WorkflowStep(
+            doc_id=doc_id,
+            step_order=i,
+            user_id=uid,
+            step_type="approval",
+        )
         for i, uid in enumerate(user_ids, start=1)
     ]
     session.add_all(steps)

--- a/portal/templates/approval_queue.html
+++ b/portal/templates/approval_queue.html
@@ -23,6 +23,7 @@
       <th><input type="checkbox" id="select-all" class="form-check-input"></th>
       <th>Document</th>
       <th>Step</th>
+      <th>Type</th>
       <th>Status</th>
       <th>Actions</th>
     </tr>
@@ -33,6 +34,7 @@
       <td><input type="checkbox" class="form-check-input step-checkbox" value="{{ step.id }}"></td>
       <td>{{ step.document.title }}</td>
       <td>{{ step.step_order }}</td>
+      <td>{{ step.step_type.title() }}</td>
       <td class="status">{{ step.status }}</td>
       <td>
         {% if step.status == 'Pending' %}

--- a/portal/templates/partials/approvals/_row.html
+++ b/portal/templates/partials/approvals/_row.html
@@ -1,6 +1,7 @@
 <tr id="step-{{ step.id }}">
   <td><a href="{{ url_for('approval_detail', id=step.id) }}">{{ step.document.title }}</a></td>
   <td>{{ step.step_order }}</td>
+  <td>{{ step.step_type.title() }}</td>
   <td>{{ step.status }}</td>
   <td>{{ step.comment or '' }}</td>
   <td>

--- a/portal/templates/partials/approvals/_table.html
+++ b/portal/templates/partials/approvals/_table.html
@@ -3,6 +3,7 @@
     <tr>
       <th>Document</th>
       <th>Step</th>
+      <th>Type</th>
       <th>Status</th>
       <th>Comment</th>
       <th>Actions</th>
@@ -12,7 +13,7 @@
     {% for step in steps %}
       {% include 'partials/approvals/_row.html' %}
     {% else %}
-    <tr><td colspan="5">No pending approvals.</td></tr>
+    <tr><td colspan="6">No pending approvals.</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/tests/test_dashboard_cards.py
+++ b/tests/test_dashboard_cards.py
@@ -55,7 +55,13 @@ recent_doc = Document(doc_key="recent.docx", title="Recent Doc", status="Publish
 session.add_all([pending_doc, mandatory_doc, recent_doc])
 session.commit()
 
-step = WorkflowStep(doc_id=pending_doc.id, step_order=1, user_id=user.id, status="Pending")
+step = WorkflowStep(
+    doc_id=pending_doc.id,
+    step_order=1,
+    user_id=user.id,
+    status="Pending",
+    step_type="approval",
+)
 revision = DocumentRevision(doc_id=recent_doc.id, major_version=1, minor_version=0)
 
 session.add_all([step, revision])
@@ -98,7 +104,13 @@ def test_dashboard_card_endpoints(client):
     recent_doc = Document(doc_key="recent.docx", title="Recent Doc", status="Published")
     session.add_all([pending_doc, mandatory_doc, recent_doc])
     session.commit()
-    step = WorkflowStep(doc_id=pending_doc.id, step_order=1, user_id=user.id, status="Pending")
+    step = WorkflowStep(
+        doc_id=pending_doc.id,
+        step_order=1,
+        user_id=user.id,
+        status="Pending",
+        step_type="approval",
+    )
     revision = DocumentRevision(doc_id=recent_doc.id, major_version=1, minor_version=0)
     session.add_all([step, revision])
     session.commit()

--- a/tests/test_pending_approvals.py
+++ b/tests/test_pending_approvals.py
@@ -51,8 +51,20 @@ unassigned_doc = Document(doc_key="unassigned.docx", title="Unassigned Approver 
 _session.add_all([assigned_doc, unassigned_doc])
 _session.commit()
 
-assigned_step = WorkflowStep(doc_id=assigned_doc.id, step_order=1, user_id=user1.id, status="Pending")
-unassigned_step = WorkflowStep(doc_id=unassigned_doc.id, step_order=1, user_id=None, status="Pending")
+assigned_step = WorkflowStep(
+    doc_id=assigned_doc.id,
+    step_order=1,
+    user_id=user1.id,
+    status="Pending",
+    step_type="approval",
+)
+unassigned_step = WorkflowStep(
+    doc_id=unassigned_doc.id,
+    step_order=1,
+    user_id=None,
+    status="Pending",
+    step_type="approval",
+)
 _session.add_all([assigned_step, unassigned_step])
 _session.commit()
 assigned_step_id = assigned_step.id

--- a/tests/test_z_dashboard_api.py
+++ b/tests/test_z_dashboard_api.py
@@ -62,9 +62,9 @@ def models():
     session.add_all([assigned_doc1, assigned_doc2, unassigned_doc, mandatory_doc1, mandatory_doc2])
     session.commit()
 
-    step1 = WorkflowStep(doc_id=assigned_doc1.id, step_order=1, user_id=user.id, status="Pending")
-    step2 = WorkflowStep(doc_id=assigned_doc2.id, step_order=1, user_id=user.id, status="Pending")
-    step3 = WorkflowStep(doc_id=unassigned_doc.id, step_order=1, user_id=None, status="Pending")
+    step1 = WorkflowStep(doc_id=assigned_doc1.id, step_order=1, user_id=user.id, status="Pending", step_type="approval")
+    step2 = WorkflowStep(doc_id=assigned_doc2.id, step_order=1, user_id=user.id, status="Pending", step_type="approval")
+    step3 = WorkflowStep(doc_id=unassigned_doc.id, step_order=1, user_id=None, status="Pending", step_type="approval")
     session.add_all([step1, step2, step3])
     session.commit()
 

--- a/tests/test_zz_workflow_start_api.py
+++ b/tests/test_zz_workflow_start_api.py
@@ -73,6 +73,7 @@ def test_workflow_start_status_and_steps(client):
     )
     assert [s.user_id for s in steps] == [reviewer_id, approver_id]
     assert [s.step_order for s in steps] == [1, 2]
+    assert [s.step_type for s in steps] == ["review", "approval"]
     session.close()
 
 


### PR DESCRIPTION
## Summary
- add `step_type` enum to workflow steps
- mark reviewer/approver steps in workflow creation APIs
- show step type in approval queue tables

## Testing
- `pytest -q` *(fails: When initializing mapper Mapper[User(users)], expression 'UserRole' failed to locate a name ('UserRole'). If this is a class name, consider adding this relationship() to the <class 'models.User'> class after both dependent classes have been defined.)*


------
https://chatgpt.com/codex/tasks/task_e_68a1c94ba7d0832bbbc1856a885c3da0