### PR TITLE
Add user_id column to workflow_steps

### DIFF
--- a/alembic/versions/0003_add_user_id_to_workflow_steps.py
+++ b/alembic/versions/0003_add_user_id_to_workflow_steps.py
@@ -1,0 +1,29 @@
+"""Add user_id to workflow steps
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2024-08-17 00:00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workflow_steps",
+        sa.Column("user_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(None, "workflow_steps", "users", ["user_id"], ["id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint(None, "workflow_steps", type_="foreignkey")
+    op.drop_column("workflow_steps", "user_id")


### PR DESCRIPTION
## Summary
- add alembic migration to introduce user_id column on workflow_steps table

## Testing
- `pytest tests/test_document_search.py::test_get_documents_search_filters_by_q -q`
- `pytest -q` *(fails: Mapper[User] relationship 'UserRole' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ccff4ec0832b8be9979647517d2b