### PR TITLE
Add API approval endpoints

### DIFF
--- a/tests/test_approvals_api.py
+++ b/tests/test_approvals_api.py
@@ -1,0 +1,97 @@
+import os
+import importlib
+from pathlib import Path
+import sys
+import pytest
+
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+_db_path = Path("test_approvals_api.db")
+if _db_path.exists():
+    _db_path.unlink()
+os.environ["DATABASE_URL"] = f"sqlite:///{_db_path}"
+
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+
+@pytest.fixture()
+def app_models():
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    return app_module.app, models_module
+
+
+@pytest.fixture()
+def client(app_models):
+    app, _ = app_models
+    return app.test_client()
+
+
+@pytest.fixture()
+def setup_data(app_models):
+    app, m = app_models
+    m.Base.metadata.drop_all(bind=m.engine)
+    m.Base.metadata.create_all(bind=m.engine)
+    session = m.SessionLocal()
+    approver = m.User(username="approver")
+    doc1 = m.Document(doc_key="doc1.docx", title="Doc1", status="Review")
+    doc2 = m.Document(doc_key="doc2.docx", title="Doc2", status="Review")
+    session.add_all([approver, doc1, doc2])
+    session.commit()
+    step1 = m.WorkflowStep(doc_id=doc1.id, step_order=1, user_id=approver.id, status="Pending", step_type="approval")
+    step2 = m.WorkflowStep(doc_id=doc2.id, step_order=1, user_id=approver.id, status="Pending", step_type="approval")
+    session.add_all([step1, step2])
+    session.commit()
+    ids = (approver.id, step1.id, step2.id)
+    session.close()
+    return m, ids
+
+
+def test_api_approve_step(client, setup_data):
+    m, ids = setup_data
+    approver_id, step_id, _ = ids
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": approver_id}
+        sess["roles"] = ["approver"]
+    resp = client.post(
+        f"/api/approvals/{step_id}/approve",
+        json={"comment": "looks good"},
+    )
+    assert resp.status_code == 200
+    assert "Approved" in resp.headers.get("HX-Trigger", "")
+    html = resp.get_data(as_text=True)
+    assert "looks good" in html
+    session = m.SessionLocal()
+    step = session.get(m.WorkflowStep, step_id)
+    assert step.status == "Approved"
+    assert step.comment == "looks good"
+    assert step.approved_at is not None
+    session.close()
+
+
+def test_api_reject_step(client, setup_data):
+    m, ids = setup_data
+    approver_id, _, step_id = ids
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": approver_id}
+        sess["roles"] = ["approver"]
+    resp = client.post(
+        f"/api/approvals/{step_id}/reject",
+        json={"comment": "needs work"},
+    )
+    assert resp.status_code == 200
+    assert "Rejected" in resp.headers.get("HX-Trigger", "")
+    html = resp.get_data(as_text=True)
+    assert "needs work" in html
+    session = m.SessionLocal()
+    step = session.get(m.WorkflowStep, step_id)
+    assert step.status == "Rejected"
+    assert step.comment == "needs work"
+    assert step.approved_at is not None
+    session.close()


### PR DESCRIPTION
## Summary
- add `/api/approvals/<step_id>/approve` and `/api/approvals/<step_id>/reject` routes
- parse JSON comments and return updated row HTML
- cover new API endpoints with tests

## Testing
- `pytest tests/test_approvals_api.py -q`
- `pytest -q` *(fails: When initializing mapper Mapper[User(users)], expression 'UserRole' failed to locate a name ('UserRole'); assert 'Assigned Approver Doc' in...)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ffc036cc832b88701a7378608ed2