### PR TITLE
Validate document approval before publishing

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1856,6 +1856,8 @@ def publish_document(id: int):
         doc = db.get(Document, id)
         if not doc:
             return "Not found", 404
+        if doc.status != "Approved":
+            return "Document not approved", 400
         doc.status = "Published"
         user_ids = set()
         for uid in request.form.getlist("users"):


### PR DESCRIPTION
## Summary
- Require documents to be in Approved status before publishing
- Add test ensuring unapproved documents cannot be published

## Testing
- `pytest -q` *(fails: When initializing mapper Mapper[User(users)], expression 'UserRole' failed to locate a name)*
- `pytest tests/test_publish_document.py::test_publish_rejects_unapproved_document -q`
- `pytest tests/test_publish_document.py::test_publish_assigns_acknowledgements -q`


------
https://chatgpt.com/codex/tasks/task_e_68a209794b60832bbca2d923f49da1c2