### PR TITLE
Ensure acknowledgements target published documents

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1969,6 +1969,10 @@ def assign_acknowledgements_endpoint():
     db = get_session()
     try:
         doc = db.get(Document, doc_id)
+        if not doc:
+            return jsonify(error="document not found"), 404
+        if doc.status != "Published":
+            return jsonify(error="document not published"), 400
         user_ids = set()
         for tgt in targets:
             if isinstance(tgt, int) or (isinstance(tgt, str) and tgt.isdigit()):


### PR DESCRIPTION
## Summary
- validate document exists and is published before assigning acknowledgements
- add tests for missing and unpublished documents

## Testing
- `pytest tests/test_ack_assign_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a20f57ae48832b9ce4df82e819a3a8