### PR TITLE
feat: prefix document and ack routes with api

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1848,7 +1848,8 @@ def save_revision(doc_id):
     return jsonify(ok=True, version=f"{doc.major_version}.{doc.minor_version}")
 
 
-@app.post("/documents/<int:id>/publish")
+@app.post("/api/documents/<int:id>/publish")
+@app.post("/documents/<int:id>/publish")  # Backward compatibility
 @roles_required(RoleEnum.PUBLISHER.value)
 def publish_document(id: int):
     db = get_session()
@@ -1950,7 +1951,8 @@ def acknowledge_document(doc_id):
         session.close()
 
 
-@app.post("/ack/assign")
+@app.post("/api/ack/assign")
+@app.post("/ack/assign")  # Backward compatibility
 @roles_required(RoleEnum.PUBLISHER.value)
 def assign_acknowledgements_endpoint():
     """Assign acknowledgements for the given document.

--- a/tests/test_ack_assign_api.py
+++ b/tests/test_ack_assign_api.py
@@ -71,7 +71,7 @@ def test_assign_acknowledgements_role_targets(client, app_models):
     ) as notify_mock:
         notify_mock.return_value = None
         resp = client.post(
-            "/ack/assign",
+            "/api/ack/assign",
             json={"doc_id": doc_id, "targets": ["ack_reader"]},
         )
         broadcast_mock.assert_called_once()
@@ -106,7 +106,7 @@ def test_assign_acknowledgements_nonexistent_doc(client, app_models):
         "app.notify_mandatory_read"
     ) as notify_mock:
         resp = client.post(
-            "/ack/assign", json={"doc_id": 999, "targets": [target_id]}
+            "/api/ack/assign", json={"doc_id": 999, "targets": [target_id]}
         )
         broadcast_mock.assert_not_called()
         notify_mock.assert_not_called()
@@ -142,7 +142,7 @@ def test_assign_acknowledgements_unpublished_doc(client, app_models):
         "app.notify_mandatory_read"
     ) as notify_mock:
         resp = client.post(
-            "/ack/assign", json={"doc_id": doc_id, "targets": [target_id]}
+            "/api/ack/assign", json={"doc_id": doc_id, "targets": [target_id]}
         )
         broadcast_mock.assert_not_called()
         notify_mock.assert_not_called()
@@ -180,7 +180,7 @@ def test_assign_acknowledgements_user_targets(client, app_models):
     ) as notify_mock:
         notify_mock.return_value = None
         resp = client.post(
-            "/ack/assign", json={"doc_id": doc_id, "targets": [user1_id, user2_id]}
+            "/api/ack/assign", json={"doc_id": doc_id, "targets": [user1_id, user2_id]}
         )
         broadcast_mock.assert_called_once()
         notify_mock.assert_called_once()
@@ -214,7 +214,7 @@ def test_assign_acknowledgements_missing_doc_id(client, app_models):
     with patch("app.broadcast_counts") as broadcast_mock, patch(
         "app.notify_mandatory_read"
     ) as notify_mock:
-        resp = client.post("/ack/assign", json={"targets": [user_id]})
+        resp = client.post("/api/ack/assign", json={"targets": [user_id]})
         broadcast_mock.assert_not_called()
         notify_mock.assert_not_called()
 
@@ -247,7 +247,7 @@ def test_assign_acknowledgements_invalid_targets(client, app_models):
         "app.notify_mandatory_read"
     ) as notify_mock:
         resp = client.post(
-            "/ack/assign", json={"doc_id": doc_id, "targets": ["bogus_role"]}
+            "/api/ack/assign", json={"doc_id": doc_id, "targets": ["bogus_role"]}
         )
         broadcast_mock.assert_called_once()
         notify_mock.assert_not_called()

--- a/tests/test_publish_document.py
+++ b/tests/test_publish_document.py
@@ -67,7 +67,7 @@ def test_publish_assigns_acknowledgements(client, app_models):
     ) as notify_mock:
         notify_mock.return_value = None
         resp = client.post(
-            f"/documents/{doc_id}/publish",
+            f"/api/documents/{doc_id}/publish",
             data={"users": [str(user1_id)], "roles": ["reader"]},
         )
         broadcast_mock.assert_called_once()
@@ -99,7 +99,7 @@ def test_publish_rejects_unapproved_document(client, app_models):
         sess["user"] = {"id": publisher_id}
         sess["roles"] = ["publisher"]
 
-    resp = client.post(f"/documents/{doc_id}/publish", data={})
+    resp = client.post(f"/api/documents/{doc_id}/publish", data={})
     assert resp.status_code == 400
     session = m.SessionLocal()
     doc = session.get(m.Document, doc_id)


### PR DESCRIPTION
## Summary
- add /api prefix to document publish and acknowledgement assignment routes
- update tests for new API paths
- keep legacy endpoints as backwards-compatible aliases

## Testing
- `pytest tests/test_ack_assign_api.py -q`
- `pytest tests/test_publish_document.py -q`
- `pytest -q` *(fails: mapping 'UserRole' and other unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a218429c40832b8179e115e8362675