### PR TITLE
Use SQLAlchemy secondary table for user-role mapping

### DIFF
--- a/tests/test_ack_assign_api.py
+++ b/tests/test_ack_assign_api.py
@@ -50,10 +50,8 @@ def test_assign_acknowledgements_role_targets(client, app_models):
     role = m.Role(name="ack_reader")
     session.add_all([publisher, user1, user2, role])
     session.commit()
-    session.add_all([
-        m.UserRole(user_id=user1.id, role_id=role.id),
-        m.UserRole(user_id=user2.id, role_id=role.id),
-    ])
+    user1.roles.append(role)
+    user2.roles.append(role)
     doc = m.Document(doc_key="ack_doc.docx", title="Ack Doc", status="Published")
     session.add(doc)
     session.commit()

--- a/tests/test_publish_document.py
+++ b/tests/test_publish_document.py
@@ -46,10 +46,8 @@ def test_publish_assigns_acknowledgements(client, app_models):
     role = m.Role(name="reader")
     session.add_all([publisher, user1, user2, user3, role])
     session.commit()
-    session.add_all([
-        m.UserRole(user_id=user2.id, role_id=role.id),
-        m.UserRole(user_id=user3.id, role_id=role.id),
-    ])
+    user2.roles.append(role)
+    user3.roles.append(role)
     doc = m.Document(doc_key="doc.docx", title="Doc", status="Approved")
     session.add(doc)
     session.commit()


### PR DESCRIPTION
## Summary
- Replace UserRole model with pure `user_roles` association table and wire `Role.users` and `User.roles` through `secondary`
- Update role assignment utilities and seeding to work with direct `Role`/`User` objects
- Adjust tests to attach roles via relationships instead of UserRole objects

## Testing
- `pytest -q` *(fails: tests/test_document_search.py::test_get_documents_search_filters_by_q, tests/test_docxf_creation.py::test_docxf_document_creation, tests/test_pending_approvals.py::test_pending_approvals_for_assigned_user)*

------
https://chatgpt.com/codex/tasks/task_e_68a22be0c778832b82b8626c6773ab48