### PR TITLE
Add permission management interface

### DIFF
--- a/portal/models.py
+++ b/portal/models.py
@@ -80,6 +80,7 @@ class DocumentPermission(Base):
     role_id = Column(Integer, ForeignKey("roles.id"), nullable=False)
     doc_id = Column(Integer, ForeignKey("documents.id"))
     folder = Column(String)
+    can_download = Column(Boolean, default=True)
 
     role = relationship("Role", back_populates="permissions")
     document = relationship("Document")

--- a/portal/templates/partials/_sidebar.html
+++ b/portal/templates/partials/_sidebar.html
@@ -20,6 +20,7 @@
     <li class="nav-item"><a class="nav-link {% if p.startswith('/reports') %}active{% endif %}" href="/reports">Reports</a></li>
     {% endif %}
     {% if has_role('quality_admin') %}
+    <li class="nav-item"><a class="nav-link {% if p.startswith('/permissions') %}active{% endif %}" href="/permissions">Permissions</a></li>
     <li class="nav-item"><a class="nav-link {% if p.startswith('/settings') %}active{% endif %}" href="/settings">Settings</a></li>
     {% endif %}
   </ul>

--- a/portal/templates/permissions.html
+++ b/portal/templates/permissions.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Permissions{% endblock %}
+{% block content %}
+<h3>Permissions</h3>
+<form method="get" class="mb-3">
+  <input type="text" class="form-control" name="q" placeholder="Search document or folder" value="{{ search }}">
+</form>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Role</th>
+      <th>Document</th>
+      <th>Folder</th>
+      <th>Download</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for perm in permissions %}
+    <tr>
+      <td>{{ perm.role.name }}</td>
+      <td>{{ perm.document.title if perm.document else '' }}</td>
+      <td>{{ perm.folder or '' }}</td>
+      <td>
+        <form method="post">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <input type="hidden" name="perm_id" value="{{ perm.id }}">
+          {% if search %}<input type="hidden" name="q" value="{{ search }}">{% endif %}
+          <input class="form-check-input" type="checkbox" name="can_download" value="1" {% if perm.can_download %}checked{% endif %} onchange="this.form.submit()">
+        </form>
+      </td>
+    </tr>
+  {% else %}
+    <tr><td colspan="4">No permissions found.</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Allow toggling document download rights per role
- Introduce permission administration page with search filtering
- Expose permission tab in sidebar for quality admins

## Testing
- `pytest -q` *(fails: test_get_documents_search_filters_by_q, test_docxf_document_creation, test_pending_approvals_for_assigned_user)*

------
https://chatgpt.com/codex/tasks/task_e_68a2365c79d4832bbae6ebf4f2d8d4fb