### PR TITLE
refactor: isolate pending approvals test db

### DIFF
--- a/tests/test_pending_approvals.py
+++ b/tests/test_pending_approvals.py
@@ -1,6 +1,10 @@
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
+import importlib
+
+from flask import url_for
+import pytest
 
 # Ensure environment variables before importing application
 os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
@@ -8,78 +12,70 @@ os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
 os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
 os.environ.setdefault("S3_ENDPOINT", "http://s3")
 
-# Use a separate database for these tests
-_db_path = Path("test_pending.db")
-if _db_path.exists():
-    _db_path.unlink()
-os.environ["DATABASE_URL"] = f"sqlite:///{_db_path}"
 
-# Make application modules importable
-repo_root = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(repo_root))
-sys.path.insert(0, str(repo_root / "portal"))
-
-from flask import url_for
-import pytest
-import importlib
-import models as m
-import app as a
-importlib.reload(m)
-importlib.reload(a)
-SessionLocal = m.SessionLocal
-Document = m.Document
-WorkflowStep = m.WorkflowStep
-User = m.User
-Base = m.Base
-engine = m.engine
-app = a.app
-
-# Create database schema
-Base.metadata.create_all(bind=engine)
-
-# Populate sample data
-_session = SessionLocal()
-
-# Create users
-user1 = User(username="approver1")
-user2 = User(username="approver2")
-_session.add_all([user1, user2])
-_session.commit()
-
-assigned_doc = Document(doc_key="assigned.docx", title="Assigned Approver Doc", status="Review")
-unassigned_doc = Document(doc_key="unassigned.docx", title="Unassigned Approver Doc", status="Review")
-_session.add_all([assigned_doc, unassigned_doc])
-_session.commit()
-
-assigned_step = WorkflowStep(
-    doc_id=assigned_doc.id,
-    step_order=1,
-    user_id=user1.id,
-    status="Pending",
-    step_type="approval",
-)
-unassigned_step = WorkflowStep(
-    doc_id=unassigned_doc.id,
-    step_order=1,
-    user_id=None,
-    status="Pending",
-    step_type="approval",
-)
-_session.add_all([assigned_step, unassigned_step])
-_session.commit()
-assigned_step_id = assigned_step.id
-unassigned_step_id = unassigned_step.id
-_session.close()
+@pytest.fixture()
+def setup_data(tmp_path):
+    db_path = tmp_path / "test_pending.db"
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+    repo_root = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(repo_root))
+    sys.path.insert(0, str(repo_root / "portal"))
+    models = importlib.reload(importlib.import_module("models"))
+    app_module = importlib.reload(importlib.import_module("app"))
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    models.Base.metadata.create_all(bind=models.engine)
+    session = models.SessionLocal()
+    user1 = models.User(username="approver1")
+    user2 = models.User(username="approver2")
+    session.add_all([user1, user2])
+    session.commit()
+    assigned_doc = models.Document(
+        doc_key="assigned.docx", title="Assigned Approver Doc", status="Review"
+    )
+    unassigned_doc = models.Document(
+        doc_key="unassigned.docx", title="Unassigned Approver Doc", status="Review"
+    )
+    session.add_all([assigned_doc, unassigned_doc])
+    session.commit()
+    assigned_step = models.WorkflowStep(
+        doc_id=assigned_doc.id,
+        step_order=1,
+        user_id=user1.id,
+        status="Pending",
+        step_type="approval",
+    )
+    unassigned_step = models.WorkflowStep(
+        doc_id=unassigned_doc.id,
+        step_order=1,
+        user_id=None,
+        status="Pending",
+        step_type="approval",
+    )
+    session.add_all([assigned_step, unassigned_step])
+    session.commit()
+    ids = {
+        "user1": user1.id,
+        "user2": user2.id,
+        "assigned_step": assigned_step.id,
+        "unassigned_step": unassigned_step.id,
+    }
+    session.close()
+    yield app_module.app, ids
+    models.Base.metadata.drop_all(bind=models.engine)
+    if db_path.exists():
+        db_path.unlink()
 
 
 @pytest.fixture()
-def client():
+def client(setup_data):
+    app, _ = setup_data
     return app.test_client()
 
 
-def test_pending_approvals_for_assigned_user(client):
+def test_pending_approvals_for_assigned_user(client, setup_data):
+    app, ids = setup_data
     with client.session_transaction() as sess:
-        sess["user"] = {"id": 1, "name": "Tester"}
+        sess["user"] = {"id": ids["user1"], "name": "Tester"}
         sess["roles"] = []
     resp = client.get(
         "/api/dashboard/cards/pending", headers={"HX-Request": "true"}
@@ -87,17 +83,18 @@ def test_pending_approvals_for_assigned_user(client):
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     with app.test_request_context():
-        assigned_url = url_for("approval_detail", id=assigned_step_id)
-        unassigned_url = url_for("approval_detail", id=unassigned_step_id)
+        assigned_url = url_for("approval_detail", id=ids["assigned_step"])
+        unassigned_url = url_for("approval_detail", id=ids["unassigned_step"])
     assert "Assigned Approver Doc" in html
     assert assigned_url in html
     assert "Unassigned Approver Doc" not in html
     assert unassigned_url not in html
 
 
-def test_pending_approvals_other_user(client):
+def test_pending_approvals_other_user(client, setup_data):
+    app, ids = setup_data
     with client.session_transaction() as sess:
-        sess["user"] = {"id": 2, "name": "Tester2"}
+        sess["user"] = {"id": ids["user2"], "name": "Tester2"}
         sess["roles"] = []
     resp = client.get(
         "/api/dashboard/cards/pending", headers={"HX-Request": "true"}
@@ -105,9 +102,10 @@ def test_pending_approvals_other_user(client):
     assert resp.status_code == 200
     html = resp.get_data(as_text=True)
     with app.test_request_context():
-        assigned_url = url_for("approval_detail", id=assigned_step_id)
-        unassigned_url = url_for("approval_detail", id=unassigned_step_id)
+        assigned_url = url_for("approval_detail", id=ids["assigned_step"])
+        unassigned_url = url_for("approval_detail", id=ids["unassigned_step"])
     assert "Assigned Approver Doc" not in html
     assert assigned_url not in html
     assert "Unassigned Approver Doc" not in html
     assert unassigned_url not in html
+


### PR DESCRIPTION
## Summary
- use fixture to setup and teardown temporary DB for pending approvals tests
- reload app/models and seed sample data inside fixture
- update tests to rely on seeded IDs and clean DB after each run

## Testing
- `pytest tests/test_pending_approvals.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a23dfab27c832b9fc0c358cc046f7b