### PR TITLE
Fix login redirect to dashboard

### DIFF
--- a/portal/auth.py
+++ b/portal/auth.py
@@ -129,7 +129,7 @@ def api_login():
     if wants_json:
         resp = jsonify(status='ok')
     else:
-        resp = redirect(url_for('index'))
+        resp = redirect(url_for('dashboard'))
     resp.set_cookie('access_token', access_token, httponly=True, samesite='Strict')
     resp.set_cookie('refresh_token', refresh_token, httponly=True, samesite='Strict')
     return resp


### PR DESCRIPTION
## Summary
- Fix login redirect to use existing dashboard endpoint instead of missing index

## Testing
- `pytest -q` *(fails: OperationalError no such table: documents)*

------
https://chatgpt.com/codex/tasks/task_e_68a23eebd834832b8f0cf9becbf4eaaf