### PR TITLE
test: centralize database setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_database():
+    repo_root = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(repo_root))
+    sys.path.insert(0, str(repo_root / "portal"))
+
+    db_path = repo_root / "test.db"
+    if db_path.exists():
+        db_path.unlink()
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+    models = importlib.import_module("models")
+    models.Base.metadata.create_all(bind=models.engine)
+
+    yield
+
+    models.Base.metadata.drop_all(bind=models.engine)
+
+
+@pytest.fixture(autouse=True)
+def reset_database():
+    m = importlib.import_module("models")
+    m.Base.metadata.drop_all(bind=m.engine)
+    m.Base.metadata.create_all(bind=m.engine)
+    yield

--- a/tests/test_approvals_api.py
+++ b/tests/test_approvals_api.py
@@ -10,11 +10,6 @@ os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
 os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
 os.environ.setdefault("S3_ENDPOINT", "http://s3")
 
-_db_path = Path("test_approvals_api.db")
-if _db_path.exists():
-    _db_path.unlink()
-os.environ["DATABASE_URL"] = f"sqlite:///{_db_path}"
-
 repo_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(repo_root))
 sys.path.insert(0, str(repo_root / "portal"))
@@ -37,8 +32,6 @@ def client(app_models):
 @pytest.fixture()
 def setup_data(app_models):
     app, m = app_models
-    m.Base.metadata.drop_all(bind=m.engine)
-    m.Base.metadata.create_all(bind=m.engine)
     session = m.SessionLocal()
     approver = m.User(username="approver")
     doc1 = m.Document(doc_key="doc1.docx", title="Doc1", status="Review")

--- a/tests/test_pending_approvals.py
+++ b/tests/test_pending_approvals.py
@@ -14,16 +14,13 @@ os.environ.setdefault("S3_ENDPOINT", "http://s3")
 
 
 @pytest.fixture()
-def setup_data(tmp_path):
-    db_path = tmp_path / "test_pending.db"
-    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+def setup_data():
     repo_root = Path(__file__).resolve().parent.parent
     sys.path.insert(0, str(repo_root))
     sys.path.insert(0, str(repo_root / "portal"))
-    models = importlib.reload(importlib.import_module("models"))
-    app_module = importlib.reload(importlib.import_module("app"))
+    models = importlib.import_module("models")
+    app_module = importlib.import_module("app")
     app_module.app.config["WTF_CSRF_ENABLED"] = False
-    models.Base.metadata.create_all(bind=models.engine)
     session = models.SessionLocal()
     user1 = models.User(username="approver1")
     user2 = models.User(username="approver2")
@@ -61,9 +58,6 @@ def setup_data(tmp_path):
     }
     session.close()
     yield app_module.app, ids
-    models.Base.metadata.drop_all(bind=models.engine)
-    if db_path.exists():
-        db_path.unlink()
 
 
 @pytest.fixture()

--- a/tests/test_publish_document.py
+++ b/tests/test_publish_document.py
@@ -10,11 +10,6 @@ os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
 os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
 os.environ.setdefault("S3_ENDPOINT", "http://s3")
 
-_db_path = Path("test_publish_document.db")
-if _db_path.exists():
-    _db_path.unlink()
-os.environ["DATABASE_URL"] = f"sqlite:///{_db_path}"
-
 repo_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(repo_root))
 sys.path.insert(0, str(repo_root / "portal"))
@@ -36,8 +31,6 @@ def client(app_models):
 
 def test_publish_assigns_acknowledgements(client, app_models):
     app, m = app_models
-    m.Base.metadata.drop_all(bind=m.engine)
-    m.Base.metadata.create_all(bind=m.engine)
     session = m.SessionLocal()
     publisher = m.User(username="publisher")
     user1 = m.User(username="user1")
@@ -82,8 +75,6 @@ def test_publish_assigns_acknowledgements(client, app_models):
 
 def test_publish_rejects_unapproved_document(client, app_models):
     app, m = app_models
-    m.Base.metadata.drop_all(bind=m.engine)
-    m.Base.metadata.create_all(bind=m.engine)
     session = m.SessionLocal()
     publisher = m.User(username="publisher")
     doc = m.Document(doc_key="doc.docx", title="Doc", status="Draft")

--- a/tests/test_user_role_mapping.py
+++ b/tests/test_user_role_mapping.py
@@ -6,12 +6,6 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-# Ensure a dedicated database for this test
-_db_path = Path("test_user_role_mapping.db")
-if _db_path.exists():
-    _db_path.unlink()
-os.environ["DATABASE_URL"] = f"sqlite:///{_db_path}"
-
 # Make application modules importable
 repo_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(repo_root))
@@ -21,8 +15,6 @@ sys.path.insert(0, str(repo_root / "portal"))
 @pytest.fixture()
 def models():
     m = importlib.reload(importlib.import_module("models"))
-    m.Base.metadata.drop_all(bind=m.engine)
-    m.Base.metadata.create_all(bind=m.engine)
     yield m
     # ensure session registry is cleaned
     m.SessionLocal.remove()

--- a/tests/test_workflow_start_approvals.py
+++ b/tests/test_workflow_start_approvals.py
@@ -34,7 +34,6 @@ def client(app_models):
 @pytest.fixture()
 def workflow_data(app_models):
     app, m = app_models
-    m.Base.metadata.create_all(bind=m.engine)
     session = m.SessionLocal()
     uid = uuid.uuid4().hex
     contributor = m.User(username=f"contrib_{uid}")

--- a/tests/test_z_dashboard_api.py
+++ b/tests/test_z_dashboard_api.py
@@ -2,8 +2,6 @@ import os
 from pathlib import Path
 import sys
 from datetime import datetime
-import importlib
-
 # Ensure environment variables before importing application
 os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
 os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
@@ -20,25 +18,17 @@ import pytest
 
 def get_models():
     import models as m
-    importlib.reload(m)
     return m
 
 
 def get_app_module():
     import app as a
-    importlib.reload(a)
     return a
 
 
 @pytest.fixture(autouse=True)
-def models():
-    _db_path = Path("test_dashboard_api.db")
-    if _db_path.exists():
-        _db_path.unlink()
-    os.environ["DATABASE_URL"] = f"sqlite:///{_db_path}"
+def models(reset_database):
     m = get_models()
-    Base = m.Base
-    engine = m.engine
     SessionLocal = m.SessionLocal
     Document = m.Document
     WorkflowStep = m.WorkflowStep
@@ -46,8 +36,6 @@ def models():
     Acknowledgement = m.Acknowledgement
     User = m.User
 
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
     session = SessionLocal()
 
     user = User(username="tester", email="tester@example.com")

--- a/tests/test_zz_workflow_start_api.py
+++ b/tests/test_zz_workflow_start_api.py
@@ -24,7 +24,6 @@ def _get_app_models():
 def _prepare_data(suffix: str = ""):
     a, m = _get_app_models()
     app = a.app
-    m.Base.metadata.create_all(bind=m.engine)
     session = m.SessionLocal()
     uid = uuid.uuid4().hex
     contributor = m.User(username=f"contrib_{suffix}_{uid}")


### PR DESCRIPTION
## Summary
- add session-wide fixture configuring a SQLite database and managing schema creation/teardown
- refactor tests to rely on shared fixture and remove duplicated metadata setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a24146444c832b93a5c08f71673a24