### PR TITLE
Run Alembic migrations automatically

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,9 @@ services:
     networks: [qdms]
 
   portal:
-    build: ./portal
+    build:
+      context: .
+      dockerfile: portal/Dockerfile
     restart: unless-stopped
     environment:
       FLASK_ENV: production

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -5,18 +5,13 @@ database schema changes.
 
 ## Running migrations
 
-1. Ensure the `DATABASE_URL` environment variable points to the target
-   database. For example:
+The application now executes pending migrations automatically during startup.
+For manual invocation (for example in development), ensure the `DATABASE_URL`
+environment variable points to the target database and run:
 
-   ```bash
-   export DATABASE_URL=sqlite:///portal.db
-   ```
-
-2. Apply all pending migrations:
-
-   ```bash
-   alembic upgrade head
-   ```
+```bash
+alembic upgrade head
+```
 
 ## Creating a new migration
 

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -6,9 +6,17 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends tesseract-ocr poppler-utils && \
     rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt .
+# copy portal requirements first to leverage Docker layer cache
+COPY portal/requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
-COPY . .
+
+# copy application source
+COPY portal/ ./
+COPY alembic.ini ./
+COPY alembic ./alembic
+
 RUN pip install libsass rcssmin jsmin
 RUN python static/build.py
-CMD ["python", "app.py"]
+
+# run database migrations before starting the app
+CMD ["sh", "-c", "alembic upgrade head && python app.py"]

--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -17,3 +17,4 @@ six==1.16.0
 PyJWT==2.8.0
 passlib
 pycryptodome
+alembic==1.13.1


### PR DESCRIPTION
## Summary
- copy Alembic configuration and migration scripts into the portal image and run `alembic upgrade head` before starting the app
- install Alembic dependency
- adjust docker-compose to use project root as build context and document automatic migrations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2c379e82c832bab847326f90150f5