### PR TITLE
fix: restore portal package layout in docker build

### DIFF
--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -10,13 +10,13 @@ RUN apt-get update && \
 COPY portal/requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
-# copy application source
-COPY portal/ ./
+# copy application source into /app/portal to preserve package structure
+COPY portal ./portal
 COPY alembic.ini ./
 COPY alembic ./alembic
 
 RUN pip install libsass rcssmin jsmin
-RUN python static/build.py
+RUN python portal/static/build.py
 
 # run database migrations before starting the app
-CMD ["sh", "-c", "alembic upgrade head && python app.py"]
+CMD ["sh", "-c", "alembic upgrade head && python portal/app.py"]


### PR DESCRIPTION
## Summary
- preserve `portal` package structure in Docker image to avoid missing `models`
- adjust build script and start command to run app from package directory

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2ce5d4834832ba761848fdcdf8f1a