### PR TITLE
Add logout route to auth blueprint

### DIFF
--- a/portal/auth.py
+++ b/portal/auth.py
@@ -94,6 +94,16 @@ def login():
     return render_template('login.html', breadcrumbs=[{"title": "Login"}])
 
 
+@auth_bp.route('/logout')
+def logout():
+    """Clear the user session and redirect to login."""
+    session.clear()
+    resp = redirect(url_for('auth.login'))
+    resp.delete_cookie('access_token')
+    resp.delete_cookie('refresh_token')
+    return resp
+
+
 @auth_bp.post('/api/auth/login')
 def api_login():
     """Authenticate user via LDAP."""


### PR DESCRIPTION
## Summary
- add logout handler to authentication blueprint clearing session and auth cookies

## Testing
- `pytest`
- manual test client request to `/logout` returns 302 redirect to `/login`


------
https://chatgpt.com/codex/tasks/task_e_68a2d6c466c4832bb50eb6939f643de4