### PR TITLE
Ensure asset manifest is present

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -93,11 +93,17 @@ auth_init(app)
 app.register_blueprint(auth_bp)
 
 manifest_path = os.path.join(app.static_folder, "manifest.json")
-if os.path.exists(manifest_path):
+try:
     with open(manifest_path) as f:
         _asset_manifest = json.load(f)
-else:
-    _asset_manifest = {}
+except FileNotFoundError:
+    raise RuntimeError(
+        "Asset manifest not found. Run portal/static/build.py to generate assets."
+    )
+if "base.js" not in _asset_manifest:
+    raise RuntimeError(
+        "base.js missing from asset manifest. Run portal/static/build.py to generate assets."
+    )
 
 
 def asset_url(name: str) -> str:

--- a/portal/static/build.py
+++ b/portal/static/build.py
@@ -1,7 +1,8 @@
 import hashlib, os, json, re
 
-SRC_DIR = 'src'
-DIST_DIR = 'dist'
+BASE_DIR = os.path.dirname(__file__)
+SRC_DIR = os.path.join(BASE_DIR, 'src')
+DIST_DIR = os.path.join(BASE_DIR, 'dist')
 
 def minify(content):
     """Basic minifier for JS/CSS files.
@@ -52,5 +53,7 @@ if __name__ == '__main__':
                 hash_name = rel_dir == '.' and fname != 'tokens.js'
                 key, out_rel = build_file(os.path.join(root, fname), rel_path, hash_name)
                 manifest[key] = out_rel
+    if 'base.js' not in manifest:
+        raise RuntimeError('base.js not found in manifest; ensure src/base.js exists')
     with open(os.path.join(DIST_DIR, 'manifest.json'), 'w') as f:
         json.dump(manifest, f, indent=2)


### PR DESCRIPTION
## Summary
- Fail fast if the asset manifest is missing or lacks the required `base.js` entry
- Make the static build script location-aware and verify `base.js` is built

## Testing
- `python portal/static/build.py`
- `curl -I http://127.0.0.1:5000/dist/base-05540251.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2d80d0c90832bae0a822c463fa9f1