### PR TITLE
Handle missing asset manifest gracefully

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1,4 +1,4 @@
-import os, json, time, base64, hmac, hashlib, csv, io, secrets
+import os, json, time, base64, hmac, hashlib, csv, io, secrets, logging
 from pathlib import Path
 from flask import (
     Flask,
@@ -110,17 +110,21 @@ auth_init(app)
 app.register_blueprint(auth_bp)
 
 manifest_path = os.path.join(app.static_folder, "manifest.json")
+_asset_manifest: dict[str, str] = {}
+
 try:
     with open(manifest_path) as f:
         _asset_manifest = json.load(f)
 except FileNotFoundError:
-    raise RuntimeError(
+    logging.warning(
         "Asset manifest not found. Run portal/static/build.py to generate assets."
     )
+
 if "base.js" not in _asset_manifest:
-    raise RuntimeError(
+    logging.warning(
         "base.js missing from asset manifest. Run portal/static/build.py to generate assets."
     )
+    _asset_manifest.setdefault("base.js", "base.js")
 
 
 def asset_url(name: str) -> str:

--- a/tests/test_asset_manifest.py
+++ b/tests/test_asset_manifest.py
@@ -1,0 +1,24 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+
+def test_app_loads_when_base_js_missing():
+    manifest_path = Path("portal/static/dist/manifest.json")
+    original = manifest_path.read_text()
+    data = json.loads(original)
+    data.pop("base.js", None)
+    manifest_path.write_text(json.dumps(data))
+
+    try:
+        sys.modules.pop("portal.app", None)
+        import portal.app as appmodule
+        assert appmodule._asset_manifest["base.js"] == "base.js"
+    finally:
+        manifest_path.write_text(original)
+        sys.modules.pop("portal.app", None)
+        import portal.app  # restore original module


### PR DESCRIPTION
## Summary
- avoid runtime error when `manifest.json` or `base.js` is missing; log warning and fall back to default
- add regression test verifying app loads without `base.js` in manifest

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2decc59f0832bbfae75cc079faeb0