### PR TITLE
Serve static assets under /dist

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -74,7 +74,7 @@ def _run_migrations() -> None:
 
 _run_migrations()
 
-app = Flask(__name__, static_folder="static/dist")
+app = Flask(__name__, static_folder="static/dist", static_url_path="/dist")
 app.secret_key = os.environ.get("SECRET_KEY", "dev")
 app.config.update(
     SESSION_COOKIE_HTTPONLY=True,


### PR DESCRIPTION
## Summary
- configure Flask to serve built static assets from `/dist`

## Testing
- `ONLYOFFICE_INTERNAL_URL=http://dummy ONLYOFFICE_PUBLIC_URL=http://dummy ONLYOFFICE_JWT_SECRET=dummy pytest`
- `ONLYOFFICE_INTERNAL_URL=http://dummy ONLYOFFICE_PUBLIC_URL=http://dummy ONLYOFFICE_JWT_SECRET=dummy DATABASE_URL=sqlite:// python - <<'PY'
from app import app
from flask import url_for
with app.test_request_context():
    print('static_url_path:', app.static_url_path)
    print('url_for:', url_for('static', filename='base.js'))
PY
`

------
https://chatgpt.com/codex/tasks/task_e_68a2f7b6b490832bb828db270e6b0556