### PR TITLE
Avoid storing large document drafts in cookies

### DIFF
--- a/tests/test_new_document_session.py
+++ b/tests/test_new_document_session.py
@@ -1,0 +1,42 @@
+import io
+import os
+import importlib
+
+
+# Provide required environment variables before importing the app
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+
+def test_upload_does_not_bloat_cookie():
+    """Uploading a file stores data server-side and keeps cookies small."""
+    app_module = importlib.reload(importlib.import_module("app"))
+    app_module.app.config.update(WTF_CSRF_ENABLED=False)
+    client = app_module.app.test_client()
+
+    # Grant contributor role for access to the route
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1, "username": "tester"}
+        sess["roles"] = [app_module.RoleEnum.CONTRIBUTOR.value]
+
+    step1_data = {
+        "code": "DOC-1",
+        "title": "My Doc",
+        "type": "T",
+        "department": "Dept",
+        "tags": "",
+    }
+    resp = client.post("/documents/new?step=1", data=step1_data)
+    assert resp.status_code == 302
+
+    big_file = (io.BytesIO(b"a" * 5000), "big.txt")
+    resp = client.post(
+        "/documents/new?step=2",
+        data={"upload_file": big_file},
+        content_type="multipart/form-data",
+    )
+
+    cookie = resp.headers.get("Set-Cookie", "")
+    assert len(cookie) < 4093


### PR DESCRIPTION
## Summary
- keep document draft data in server memory and track only a draft id in the session
- add regression test ensuring file uploads no longer bloat the session cookie

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3025b205c832baab1d7d366d902f2