### PR TITLE
Add logging for 403 responses on document routes

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -112,6 +112,18 @@ CSRFProtect(app)
 auth_init(app)
 app.register_blueprint(auth_bp)
 
+
+@app.errorhandler(403)
+def handle_forbidden(error):
+    app.logger.warning(
+        "403 Forbidden: path=%s user=%s roles=%s reason=%s",
+        request.path,
+        session.get("user"),
+        session.get("roles"),
+        getattr(error, "description", ""),
+    )
+    return "Forbidden", 403
+
 manifest_path = os.path.join(app.static_folder, "manifest.json")
 _asset_manifest: dict[str, str] = {}
 


### PR DESCRIPTION
## Summary
- confirm `/documents/new` requires contributor role and CSRF protection
- add logging for 403 errors to aid debugging

## Testing
- `pytest tests/test_new_document_session.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a316bcd614832b918de772ff06adc8