### PR TITLE
refactor: add storage client helper

### DIFF
--- a/portal/docxf_render.py
+++ b/portal/docxf_render.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 import requests
 
-from storage import _s3, S3_BUCKET
+from storage import storage_client
 
 # Default OnlyOffice Document Server endpoint
 DOCUMENT_SERVER_URL = os.environ.get(
@@ -73,7 +73,7 @@ def render_form_and_store(form_name: str, data: dict | None = None) -> tuple[byt
     docx_key = f"{base_key}.docx"
     pdf_key = f"{base_key}.pdf"
 
-    _s3.put_object(Bucket=S3_BUCKET, Key=docx_key, Body=docx_bytes)
-    _s3.put_object(Bucket=S3_BUCKET, Key=pdf_key, Body=pdf_bytes)
+    storage_client.put_object(Key=docx_key, Body=docx_bytes)
+    storage_client.put_object(Key=pdf_key, Body=pdf_bytes)
 
     return pdf_bytes, docx_key, pdf_key

--- a/portal/ocr.py
+++ b/portal/ocr.py
@@ -2,7 +2,7 @@ import io
 import os
 from pdfminer.high_level import extract_text as pdf_extract_text
 from docx import Document
-from storage import _s3, S3_BUCKET
+from storage import storage_client
 
 
 def _detect_ext(data: bytes) -> str:
@@ -35,7 +35,7 @@ def extract_text(key_or_bytes: str | bytes) -> str:
                     doc = Document(key_or_bytes)
                     return "\n".join(p.text for p in doc.paragraphs)
                 return ""
-            obj = _s3.get_object(Bucket=S3_BUCKET, Key=key_or_bytes)
+            obj = storage_client.get_object(Key=key_or_bytes)
             data = obj["Body"].read()
             ext = os.path.splitext(key_or_bytes)[1].lower()
 

--- a/portal/storage.py
+++ b/portal/storage.py
@@ -1,55 +1,107 @@
 """Utility helpers for S3/MinIO archival storage."""
 
+from __future__ import annotations
+
 import os
 from datetime import datetime, timedelta
+
 import boto3
 from botocore.client import Config
 from botocore.exceptions import NoCredentialsError
 
-S3_ENDPOINT = os.getenv("S3_ENDPOINT")
-S3_ACCESS_KEY = os.getenv("S3_ACCESS_KEY") or os.getenv("S3_ACCESS_KEY_ID")
-S3_SECRET_KEY = os.getenv("S3_SECRET_KEY") or os.getenv("S3_SECRET_ACCESS_KEY")
-S3_BUCKET = os.getenv("S3_BUCKET") or os.getenv("S3_BUCKET_MAIN")
-ARCHIVE_PREFIX = os.getenv("ARCHIVE_PREFIX", "archive/")
-SIGNED_URL_EXPIRE_SECONDS = int(os.getenv("SIGNED_URL_EXPIRE_SECONDS", "3600"))
 
-_s3 = boto3.client(
-    "s3",
-    endpoint_url=S3_ENDPOINT,
-    aws_access_key_id=S3_ACCESS_KEY,
-    aws_secret_access_key=S3_SECRET_KEY,
-    config=Config(signature_version="s3v4"),
-)
+class StorageClient:
+    """Encapsulates interactions with S3/MinIO."""
+
+    def __init__(self) -> None:
+        self.endpoint = os.getenv("S3_ENDPOINT")
+        self.access_key = os.getenv("S3_ACCESS_KEY") or os.getenv(
+            "S3_ACCESS_KEY_ID"
+        )
+        self.secret_key = os.getenv("S3_SECRET_KEY") or os.getenv(
+            "S3_SECRET_ACCESS_KEY"
+        )
+        self.bucket_main = os.getenv("S3_BUCKET_MAIN") or os.getenv("S3_BUCKET")
+        self.bucket_archive = os.getenv("S3_BUCKET_ARCHIVE") or self.bucket_main
+        self.bucket_previews = os.getenv("S3_BUCKET_PREVIEWS") or self.bucket_main
+        self.archive_prefix = os.getenv("ARCHIVE_PREFIX", "archive/")
+        self.signed_url_expire_seconds = int(
+        
+            os.getenv("SIGNED_URL_EXPIRE_SECONDS", "3600")
+        )
+
+        self.client = boto3.client(
+            "s3",
+            endpoint_url=self.endpoint,
+            aws_access_key_id=self.access_key,
+            aws_secret_access_key=self.secret_key,
+            config=Config(signature_version="s3v4"),
+        )
+
+    # -- basic wrappers -------------------------------------------------
+    def put_object(self, Bucket: str | None = None, **kwargs):
+        return self.client.put_object(Bucket=Bucket or self.bucket_main, **kwargs)
+
+    def get_object(self, Bucket: str | None = None, **kwargs):
+        return self.client.get_object(Bucket=Bucket or self.bucket_main, **kwargs)
+
+    def copy_object(self, Bucket: str | None = None, **kwargs):
+        return self.client.copy_object(Bucket=Bucket or self.bucket_main, **kwargs)
+
+    def delete_object(self, Bucket: str | None = None, **kwargs):
+        return self.client.delete_object(Bucket=Bucket or self.bucket_main, **kwargs)
+
+    def head_object(self, Bucket: str | None = None, **kwargs):
+        return self.client.head_object(Bucket=Bucket or self.bucket_main, **kwargs)
+
+    def list_objects_v2(self, Bucket: str | None = None, **kwargs):
+        return self.client.list_objects_v2(Bucket=Bucket or self.bucket_main, **kwargs)
+
+    def generate_presigned_url(
+        self, key: str, expires_in: int | None = None, bucket: str | None = None
+    ) -> str | None:
+        try:
+            return self.client.generate_presigned_url(
+                "get_object",
+                Params={"Bucket": bucket or self.bucket_main, "Key": key},
+                ExpiresIn=expires_in or self.signed_url_expire_seconds,
+            )
+        except NoCredentialsError:
+            return None
+
+    # -- higher level helpers ------------------------------------------
+    def move_to_archive(self, object_key: str, retention_days: int) -> str:
+        """Copy an object to the archive prefix with a WORM lock and delete the original."""
+
+        dest_key = f"{self.archive_prefix}{object_key.split('/')[-1]}"
+        retain_until = datetime.utcnow() + timedelta(days=retention_days)
+        self.copy_object(
+            CopySource={"Bucket": self.bucket_main, "Key": object_key},
+            Key=dest_key,
+            ObjectLockMode="COMPLIANCE",
+            ObjectLockRetainUntilDate=retain_until,
+        )
+        self.delete_object(Key=object_key)
+        return dest_key
+
+    def list_archived(self) -> list[str]:
+        resp = self.list_objects_v2(Prefix=self.archive_prefix)
+        return [obj["Key"] for obj in resp.get("Contents", [])]
 
 
+# Global instance used throughout the app
+storage_client = StorageClient()
+
+
+# Backwards compatible module-level helpers ---------------------------------
 def move_to_archive(object_key: str, retention_days: int) -> str:
-    """Copy an object to the archive prefix with a WORM lock and delete the original."""
-    dest_key = f"{ARCHIVE_PREFIX}{object_key.split('/')[-1]}"
-    retain_until = datetime.utcnow() + timedelta(days=retention_days)
-    _s3.copy_object(
-        Bucket=S3_BUCKET,
-        CopySource={"Bucket": S3_BUCKET, "Key": object_key},
-        Key=dest_key,
-        ObjectLockMode="COMPLIANCE",
-        ObjectLockRetainUntilDate=retain_until,
-    )
-    _s3.delete_object(Bucket=S3_BUCKET, Key=object_key)
-    return dest_key
+    return storage_client.move_to_archive(object_key, retention_days)
 
 
 def list_archived() -> list[str]:
-    """Return keys of archived objects."""
-    resp = _s3.list_objects_v2(Bucket=S3_BUCKET, Prefix=ARCHIVE_PREFIX)
-    return [obj["Key"] for obj in resp.get("Contents", [])]
+    return storage_client.list_archived()
 
 
 def generate_presigned_url(key: str, expires_in: int | None = None) -> str | None:
-    """Generate a presigned download URL for an object."""
-    try:
-        return _s3.generate_presigned_url(
-            "get_object",
-            Params={"Bucket": S3_BUCKET, "Key": key},
-            ExpiresIn=expires_in or SIGNED_URL_EXPIRE_SECONDS,
-        )
-    except NoCredentialsError:
-        return None
+    return storage_client.generate_presigned_url(key, expires_in)
+

--- a/tests/test_document_upload_key_extension.py
+++ b/tests/test_document_upload_key_extension.py
@@ -40,7 +40,7 @@ def test_api_appends_extension_to_key():
             return {}
 
     dummy_s3 = DummyS3()
-    storage._s3 = dummy_s3
+    storage.storage_client.client = dummy_s3
 
     portal_app.extract_text = lambda key: "dummy"
     portal_app.notify_mandatory_read = lambda doc, users: None
@@ -66,6 +66,6 @@ def test_api_appends_extension_to_key():
     session_db.close()
 
     assert dummy_s3.called_with == {
-        "Bucket": storage.S3_BUCKET,
+        "Bucket": storage.storage_client.bucket_main,
         "Key": "abc123.txt",
     }

--- a/tests/test_docxf_creation.py
+++ b/tests/test_docxf_creation.py
@@ -72,21 +72,21 @@ def test_docxf_document_creation(client):
     stubber.add_response(
         "put_object",
         {},
-        {"Bucket": storage.S3_BUCKET, "Key": ANY, "Body": ANY},
+        {"Bucket": storage.storage_client.bucket_main, "Key": ANY, "Body": ANY},
     )
     stubber.add_response(
         "put_object",
         {},
-        {"Bucket": storage.S3_BUCKET, "Key": ANY, "Body": ANY},
+        {"Bucket": storage.storage_client.bucket_main, "Key": ANY, "Body": ANY},
     )
     stubber.activate()
 
-    storage._s3 = s3
-    docxf_render._s3 = s3
-    docxf_render_module._s3 = s3
-    storage.S3_BUCKET = "test-bucket"
-    docxf_render.S3_BUCKET = "test-bucket"
-    docxf_render_module.S3_BUCKET = "test-bucket"
+    storage.storage_client.client = s3
+    docxf_render.storage_client.client = s3
+    docxf_render_module.storage_client.client = s3
+    storage.storage_client.bucket_main = "test-bucket"
+    docxf_render.storage_client.bucket_main = "test-bucket"
+    docxf_render_module.storage_client.bucket_main = "test-bucket"
     storage.generate_presigned_url = (
         lambda key, expires_in=None: f"https://example.com/{key}"
     )


### PR DESCRIPTION
## Summary
- introduce `StorageClient` wrapper for MinIO/S3 that loads bucket settings from env
- switch storage consumers to use `storage_client` instance instead of `_s3`
- update tests for new storage helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a335be74ac832ba44e4e880d23fb53