### PR TITLE
Route S3 operations through StorageClient

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1018,7 +1018,7 @@ def api_compare_documents():
     def _get_version(maj, minr):
         if doc.major_version == maj and doc.minor_version == minr:
             return {
-                "url": f"{os.environ['S3_ENDPOINT']}/local/{doc.doc_key}",
+                "url": f"{storage_client.endpoint}/{storage_client.bucket_main or 'local'}/{doc.doc_key}",
                 "key": f"{doc.doc_key}:{maj}.{minr}",
                 "title": doc.title or doc.doc_key.split('/')[-1],
             }
@@ -1492,7 +1492,7 @@ def approval_detail(id: int):
                 "fileType": "docx",
                 "key": f"{doc.doc_key}",
                 "title": doc.title or doc.doc_key.split("/")[-1],
-                "url": f"{os.environ['S3_ENDPOINT']}/local/{doc.doc_key}",
+                "url": f"{storage_client.endpoint}/{storage_client.bucket_main or 'local'}/{doc.doc_key}",
                 "permissions": {"download": True},
             },
             "documentType": "text",
@@ -2110,7 +2110,7 @@ def edit_document(doc_id):
             "fileType": "docx",
             "key": f"{doc.doc_key}",
             "title": doc.title or doc.doc_key.split('/')[-1],
-            "url": f"{os.environ['S3_ENDPOINT']}/local/{doc.doc_key}",
+            "url": f"{storage_client.endpoint}/{storage_client.bucket_main or 'local'}/{doc.doc_key}",
             "permissions": {
                 "edit": True,
                 "download": True,

--- a/portal/archive_job.py
+++ b/portal/archive_job.py
@@ -1,7 +1,7 @@
 """Cron job to archive documents whose retention period has expired."""
 from datetime import datetime, timedelta
 from models import get_session, Document, User
-from storage import move_to_archive
+from storage import storage_client
 from app import log_action
 
 
@@ -21,7 +21,7 @@ def run() -> None:
         base = doc.created_at or now
         expire_at = base + timedelta(days=doc.retention_period)
         if expire_at <= now:
-            move_to_archive(doc.doc_key, doc.retention_period or 0)
+            storage_client.move_to_archive(doc.doc_key, doc.retention_period or 0)
             doc.status = "Archived"
             doc.archived_at = now
             log_action(system_user_id, doc.id, "archive_document")

--- a/portal/docxf_render.py
+++ b/portal/docxf_render.py
@@ -73,7 +73,11 @@ def render_form_and_store(form_name: str, data: dict | None = None) -> tuple[byt
     docx_key = f"{base_key}.docx"
     pdf_key = f"{base_key}.pdf"
 
-    storage_client.put_object(Key=docx_key, Body=docx_bytes)
-    storage_client.put_object(Key=pdf_key, Body=pdf_bytes)
+    storage_client.put_object(
+        Bucket=storage_client.bucket_main, Key=docx_key, Body=docx_bytes
+    )
+    storage_client.put_object(
+        Bucket=storage_client.bucket_main, Key=pdf_key, Body=pdf_bytes
+    )
 
     return pdf_bytes, docx_key, pdf_key

--- a/portal/ocr.py
+++ b/portal/ocr.py
@@ -35,7 +35,9 @@ def extract_text(key_or_bytes: str | bytes) -> str:
                     doc = Document(key_or_bytes)
                     return "\n".join(p.text for p in doc.paragraphs)
                 return ""
-            obj = storage_client.get_object(Key=key_or_bytes)
+            obj = storage_client.get_object(
+                Bucket=storage_client.bucket_main, Key=key_or_bytes
+            )
             data = obj["Body"].read()
             ext = os.path.splitext(key_or_bytes)[1].lower()
 

--- a/tests/test_document_versioning.py
+++ b/tests/test_document_versioning.py
@@ -11,6 +11,7 @@ os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
 os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
 os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
 os.environ.setdefault("S3_ENDPOINT", "http://s3")
+os.environ["S3_BUCKET"] = "local"
 
 # Make application modules importable
 repo_root = Path(__file__).resolve().parent.parent
@@ -20,6 +21,9 @@ sys.path.insert(0, str(repo_root / "portal"))
 
 @pytest.fixture()
 def app_models():
+    os.environ["S3_BUCKET"] = "local"
+    importlib.reload(importlib.import_module("storage"))
+    importlib.reload(importlib.import_module("portal.storage"))
     app_module = importlib.reload(importlib.import_module("app"))
     models_module = importlib.reload(importlib.import_module("models"))
     app_module.app.config["WTF_CSRF_ENABLED"] = False

--- a/tests/test_docxf_creation.py
+++ b/tests/test_docxf_creation.py
@@ -7,7 +7,7 @@ os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
 os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
 os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
 os.environ.setdefault("S3_ENDPOINT", "http://s3")
-os.environ.setdefault("S3_BUCKET", "test-bucket")
+os.environ["S3_BUCKET"] = "test-bucket"
 os.environ.setdefault("S3_ACCESS_KEY", "test")
 os.environ.setdefault("S3_SECRET_KEY", "test")
 
@@ -68,6 +68,12 @@ def test_docxf_document_creation(client):
         aws_access_key_id="test",
         aws_secret_access_key="test",
     )
+    storage.storage_client.client = s3
+    docxf_render.storage_client.client = s3
+    docxf_render_module.storage_client.client = s3
+    storage.storage_client.bucket_main = "test-bucket"
+    docxf_render.storage_client.bucket_main = "test-bucket"
+    docxf_render_module.storage_client.bucket_main = "test-bucket"
     stubber = Stubber(s3)
     stubber.add_response(
         "put_object",
@@ -80,13 +86,6 @@ def test_docxf_document_creation(client):
         {"Bucket": storage.storage_client.bucket_main, "Key": ANY, "Body": ANY},
     )
     stubber.activate()
-
-    storage.storage_client.client = s3
-    docxf_render.storage_client.client = s3
-    docxf_render_module.storage_client.client = s3
-    storage.storage_client.bucket_main = "test-bucket"
-    docxf_render.storage_client.bucket_main = "test-bucket"
-    docxf_render_module.storage_client.bucket_main = "test-bucket"
     storage.generate_presigned_url = (
         lambda key, expires_in=None: f"https://example.com/{key}"
     )


### PR DESCRIPTION
## Summary
- Route form rendering uploads through `StorageClient`'s bucket helpers
- Use `StorageClient` for OCR downloads and OnlyOffice document URLs
- Invoke archival logic via `StorageClient.move_to_archive`
- Stabilize tests by explicitly setting S3 bucket and reloading storage modules

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3379ddf3c832bb7941d4a5dc44384