### PR TITLE
refactor tests for storage client

### DIFF
--- a/tests/test_document_versioning.py
+++ b/tests/test_document_versioning.py
@@ -11,7 +11,7 @@ os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
 os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
 os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
 os.environ.setdefault("S3_ENDPOINT", "http://s3")
-os.environ["S3_BUCKET"] = "local"
+os.environ["S3_BUCKET_MAIN"] = "local"
 
 # Make application modules importable
 repo_root = Path(__file__).resolve().parent.parent
@@ -21,7 +21,7 @@ sys.path.insert(0, str(repo_root / "portal"))
 
 @pytest.fixture()
 def app_models():
-    os.environ["S3_BUCKET"] = "local"
+    os.environ["S3_BUCKET_MAIN"] = "local"
     importlib.reload(importlib.import_module("storage"))
     importlib.reload(importlib.import_module("portal.storage"))
     app_module = importlib.reload(importlib.import_module("app"))


### PR DESCRIPTION
## Summary
- refactor tests to mock StorageClient instead of boto3
- update tests to use new S3_BUCKET_MAIN env var

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a33b7a6650832b9c56c7a6c28c8830