### PR TITLE
Use storage client for document URLs

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1018,7 +1018,7 @@ def api_compare_documents():
     def _get_version(maj, minr):
         if doc.major_version == maj and doc.minor_version == minr:
             return {
-                "url": f"{storage_client.endpoint}/{storage_client.bucket_main or 'local'}/{doc.doc_key}",
+                "url": storage_client.generate_presigned_url(doc.doc_key),
                 "key": f"{doc.doc_key}:{maj}.{minr}",
                 "title": doc.title or doc.doc_key.split('/')[-1],
             }
@@ -1492,7 +1492,7 @@ def approval_detail(id: int):
                 "fileType": "docx",
                 "key": f"{doc.doc_key}",
                 "title": doc.title or doc.doc_key.split("/")[-1],
-                "url": f"{storage_client.endpoint}/{storage_client.bucket_main or 'local'}/{doc.doc_key}",
+                "url": storage_client.generate_presigned_url(doc.doc_key),
                 "permissions": {"download": True},
             },
             "documentType": "text",
@@ -2110,7 +2110,7 @@ def edit_document(doc_id):
             "fileType": "docx",
             "key": f"{doc.doc_key}",
             "title": doc.title or doc.doc_key.split('/')[-1],
-            "url": f"{storage_client.endpoint}/{storage_client.bucket_main or 'local'}/{doc.doc_key}",
+            "url": storage_client.generate_presigned_url(doc.doc_key),
             "permissions": {
                 "edit": True,
                 "download": True,

--- a/portal/storage.py
+++ b/portal/storage.py
@@ -60,13 +60,16 @@ class StorageClient:
     def generate_presigned_url(
         self, key: str, expires_in: int | None = None, bucket: str | None = None
     ) -> str | None:
+        bucket_name = bucket or self.bucket_main or "local"
         try:
             return self.client.generate_presigned_url(
                 "get_object",
-                Params={"Bucket": bucket or self.bucket_main, "Key": key},
+                Params={"Bucket": bucket_name, "Key": key},
                 ExpiresIn=expires_in or self.signed_url_expire_seconds,
             )
         except NoCredentialsError:
+            if self.endpoint:
+                return f"{self.endpoint}/{bucket_name}/{key}"
             return None
 
     # -- higher level helpers ------------------------------------------

--- a/tests/test_document_versioning.py
+++ b/tests/test_document_versioning.py
@@ -97,7 +97,9 @@ def test_compare_config_returns_expected_fields(client, app_models):
     assert config["document"]["key"] == f"{doc_key}:1.0"
     assert config["document"]["url"] == "http://s3/old.docx"
     assert config["editorConfig"]["compareFile"]["key"] == f"{doc_key}:2.0"
-    assert config["editorConfig"]["compareFile"]["url"] == f"http://s3/local/{doc_key}"
+    assert config["editorConfig"]["compareFile"]["url"].startswith(
+        f"http://s3/local/{doc_key}"
+    )
     assert data["token"]
     assert data["token_header"] == "AuthorizationJwt"
 


### PR DESCRIPTION
## Summary
- Generate presigned URLs through the storage client instead of building S3 links manually
- Fall back to plain endpoint URLs when credentials are missing
- Relax versioning test to accept presigned URLs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3826adf90832b8f7698498d51ac80