### PR TITLE
Add migration for audit log endpoint column

### DIFF
--- a/alembic/versions/0005_add_endpoint_to_audit_logs.py
+++ b/alembic/versions/0005_add_endpoint_to_audit_logs.py
@@ -1,0 +1,25 @@
+"""Add endpoint column to audit_logs
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2025-08-18 05:55:11
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("audit_logs", sa.Column("endpoint", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("audit_logs", "endpoint")
+


### PR DESCRIPTION
## Summary
- add Alembic migration to include `endpoint` column on `audit_logs`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a383524a00832bbc1fb361f9887476