### PR TITLE
Add standard code field and document standards table

### DIFF
--- a/alembic/versions/0006_add_standard_code_to_documents.py
+++ b/alembic/versions/0006_add_standard_code_to_documents.py
@@ -1,0 +1,30 @@
+"""Add standard_code to documents and create document_standards table
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2025-02-13 00:00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("documents", sa.Column("standard_code", sa.String(), nullable=True))
+    op.create_table(
+        "document_standards",
+        sa.Column("doc_id", sa.Integer(), sa.ForeignKey("documents.id"), primary_key=True),
+        sa.Column("standard_code", sa.String(), primary_key=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("document_standards")
+    op.drop_column("documents", "standard_code")

--- a/portal/models.py
+++ b/portal/models.py
@@ -43,6 +43,7 @@ class Document(Base):
     doc_key = Column(String, nullable=False, unique=True)
     title = Column(String, index=True)
     code = Column(String, index=True)
+    standard_code = Column(String, index=True)
     tags = Column(String, index=True)
     department = Column(String, index=True)
     process = Column(String, index=True)
@@ -84,6 +85,14 @@ class DocumentPermission(Base):
 
     role = relationship("Role", back_populates="permissions")
     document = relationship("Document")
+
+
+class DocumentStandard(Base):
+    __tablename__ = "document_standards"
+    doc_id = Column(Integer, ForeignKey("documents.id"), primary_key=True)
+    standard_code = Column(String, primary_key=True)
+
+    document = relationship("Document", back_populates="standards")
 
 
 user_roles = Table(
@@ -286,6 +295,9 @@ Document.workflow_steps = relationship(
 )
 Document.revisions = relationship(
     DocumentRevision, back_populates="document", cascade="all, delete-orphan"
+)
+Document.standards = relationship(
+    DocumentStandard, back_populates="document", cascade="all, delete-orphan"
 )
 
 # Database schema migrations are now managed via Alembic. Tables are created


### PR DESCRIPTION
## Summary
- add `standard_code` column and multi-standard relationship to `Document`
- create `document_standards` table for tagging
- generate Alembic migration for new schema

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a385b11978832b9236f2125be9073a