### PR TITLE
Fix document notification detachment bug

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -33,9 +33,11 @@ from models import (
     WorkflowStep,
     get_session,
     RoleEnum,
+    engine,
 )
 from search import index_document, search_documents
 from sqlalchemy import func, or_, and_, inspect
+from sqlalchemy.orm import sessionmaker
 from ocr import extract_text
 from docxf_render import render_form_and_store
 from notifications import (
@@ -176,7 +178,8 @@ def sign_payload(payload: dict) -> str:
 
 def log_action(user_id, doc_id, action, endpoint=None):
     """Persist an audit log entry."""
-    session = get_session()
+    Session = sessionmaker(bind=engine)
+    session = Session()
     try:
         session.add(AuditLog(user_id=user_id, doc_id=doc_id, action=action, endpoint=endpoint))
         session.commit()

--- a/tests/test_mandatory_read_notifications.py
+++ b/tests/test_mandatory_read_notifications.py
@@ -1,0 +1,40 @@
+import os
+import importlib
+from unittest.mock import MagicMock
+
+# Set required environment variables before importing the app
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+def test_mandatory_read_notification_does_not_detach():
+    app_module = importlib.reload(importlib.import_module("app"))
+    notifications = importlib.reload(importlib.import_module("notifications"))
+    storage = importlib.import_module("storage")
+
+    # Avoid external calls
+    storage.storage_client.head_object = MagicMock(return_value={})
+    app_module.extract_text = lambda key: "dummy"
+    app_module.index_document = lambda doc, content: None
+    notifications.notify_user = MagicMock()
+
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    client = app_module.app.test_client()
+
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1}
+        sess["roles"] = [app_module.RoleEnum.CONTRIBUTOR.value]
+
+    payload = {
+        "code": "DOC1",
+        "title": "My Doc",
+        "type": "T",
+        "department": "Dept",
+        "tags": "tag1,tag2",
+        "uploaded_file_key": "abc123",
+        "uploaded_file_name": "file.txt",
+    }
+
+    resp = client.post("/api/documents", json=payload)
+    assert resp.status_code == 201


### PR DESCRIPTION
## Summary
- ensure `log_action` uses a dedicated SQLAlchemy session so calling it doesn't close the caller's session
- add regression test for mandatory-read notification during document creation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a387014e9c832bb454291c13e9d9c1