### PR TITLE
Add standard code field and export models

### DIFF
--- a/portal/models.py
+++ b/portal/models.py
@@ -43,7 +43,7 @@ class Document(Base):
     doc_key = Column(String, nullable=False, unique=True)
     title = Column(String, index=True)
     code = Column(String, index=True)
-    standard_code = Column(String, index=True)
+    standard_code = Column(String, index=True, nullable=True)
     tags = Column(String, index=True)
     department = Column(String, index=True)
     process = Column(String, index=True)
@@ -330,3 +330,26 @@ def seed_roles_and_users():
         session.close()
 
 # Initial data seeding should be invoked manually after applying migrations.
+
+__all__ = [
+    "Base",
+    "SessionLocal",
+    "get_session",
+    "seed_roles_and_users",
+    "RoleEnum",
+    "Document",
+    "DocumentRevision",
+    "DocumentPermission",
+    "DocumentStandard",
+    "Role",
+    "User",
+    "WorkflowStep",
+    "Acknowledgement",
+    "Notification",
+    "TrainingResult",
+    "FormSubmission",
+    "SignatureLog",
+    "AuditLog",
+    "PersonalAccessToken",
+    "DepartmentVisibility",
+]


### PR DESCRIPTION
## Summary
- add nullable `standard_code` column to document model
- expose model classes via `__all__`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a388c748a8832bba8bb053cb678011