### PR TITLE
Gracefully handle email delivery failures

### DIFF
--- a/tests/test_email_failures.py
+++ b/tests/test_email_failures.py
@@ -1,0 +1,9 @@
+from unittest.mock import patch
+
+import notifications
+
+
+def test_send_email_connection_error_suppressed():
+    with patch('notifications.smtplib.SMTP', side_effect=ConnectionRefusedError):
+        notifications.send_email('user@example.com', 'Subject', 'Body')
+


### PR DESCRIPTION
## Summary
- avoid crashing when SMTP server is unreachable by logging email delivery failures
- add regression test ensuring connection errors are suppressed

## Testing
- `pytest` *(fails: tests/test_approvals_api.py::test_api_approve_step - sqlite3.OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_68a38a593e18832b9caae93e65723fef