### PR TITLE
Fallback to request host for callback URL

### DIFF
--- a/docs/onlyoffice.md
+++ b/docs/onlyoffice.md
@@ -1,0 +1,7 @@
+# OnlyOffice Integration
+
+The portal uses [OnlyOffice](https://www.onlyoffice.com/) for document editing. The callback URL provided to OnlyOffice is constructed from the `PORTAL_PUBLIC_BASE_URL` environment variable. When this variable is unset, the application falls back to the incoming request's host URL.
+
+## Environment Variables
+
+- `PORTAL_PUBLIC_BASE_URL`: Public base URL used to build OnlyOffice callback URLs. Defaults to the request's host URL when not defined.

--- a/portal/app.py
+++ b/portal/app.py
@@ -2158,6 +2158,10 @@ def edit_document(doc_id):
         db.close()
         return "Document not found", 404
     user = session.get("user") or {"id": "u1", "name": "Ibrahim H.", "email": "ih@baylan.local"}
+    public_base_url = os.environ.get(
+        "PORTAL_PUBLIC_BASE_URL", request.host_url.rstrip("/")
+    )
+    # Defaults to the incoming request's host when PORTAL_PUBLIC_BASE_URL is unset
     config = {
         "document": {
             "fileType": "docx",
@@ -2173,7 +2177,7 @@ def edit_document(doc_id):
         },
         "documentType": "text",
         "editorConfig": {
-            "callbackUrl": f"{os.environ['PORTAL_PUBLIC_BASE_URL']}/onlyoffice/callback/{doc.doc_key}",
+            "callbackUrl": f"{public_base_url}/onlyoffice/callback/{doc.doc_key}",
             "user": {"id": user["id"], "name": user["name"]},
             "mode": "edit",
         },

--- a/tests/test_edit_document_callback_url.py
+++ b/tests/test_edit_document_callback_url.py
@@ -1,0 +1,34 @@
+import os
+import importlib
+
+# Set required environment variables before importing the application
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+def test_edit_route_builds_callback_url_from_request_host():
+    """When PORTAL_PUBLIC_BASE_URL is unset, the host URL is used."""
+    # Ensure the environment variable is not defined
+    os.environ.pop("PORTAL_PUBLIC_BASE_URL", None)
+
+    app_module = importlib.reload(importlib.import_module("app"))
+    models = importlib.reload(importlib.import_module("models"))
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    client = app_module.app.test_client()
+
+    session = models.SessionLocal()
+    doc = models.Document(doc_key="doc.docx", title="Doc")
+    session.add(doc)
+    session.commit()
+    doc_id = doc.id
+    session.close()
+
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1, "name": "Tester"}
+        sess["roles"] = [models.RoleEnum.CONTRIBUTOR.value]
+
+    resp = client.get(f"/documents/{doc_id}/edit")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert f"callbackUrl\": \"http://localhost/onlyoffice/callback/{doc.doc_key}\"" in body


### PR DESCRIPTION
## Summary
- Build OnlyOffice callback URLs using `PORTAL_PUBLIC_BASE_URL` with a fallback to the request host
- Document `PORTAL_PUBLIC_BASE_URL` fallback behavior for OnlyOffice integration
- Add regression test verifying callback URL when `PORTAL_PUBLIC_BASE_URL` is unset

## Testing
- `pytest tests/test_edit_document_callback_url.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a391233228832bb6521ba316fb530e