### PR TITLE
Add document workflow view and tests

### DIFF
--- a/portal/templates/document_workflow.html
+++ b/portal/templates/document_workflow.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Workflow{% endblock %}
+{% block content %}
+<h1>{{ doc.title }} - Workflow</h1>
+{% if steps %}
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Order</th>
+      <th>User</th>
+      <th>Type</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for step in steps %}
+    <tr>
+      <td>{{ step.step_order }}</td>
+      <td>{{ step.user.username if step.user else '' }}</td>
+      <td>{{ step.step_type }}</td>
+      <td>{{ step.status }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No workflow steps found.</p>
+{% endif %}
+{% endblock %}

--- a/portal/templates/documents/_table.html
+++ b/portal/templates/documents/_table.html
@@ -28,7 +28,7 @@
         <td class="actions">
           <a href="{{ url_for('document_detail', doc_id=doc.id) }}" class="btn btn-sm btn-outline-secondary">View</a>
           <a href="{{ url_for('edit_document', doc_id=doc.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
-          <a href="/documents/{{ doc.id }}/workflow" class="btn btn-sm btn-outline-secondary">Workflow</a>
+          <a href="{{ url_for('document_workflow', doc_id=doc.id) }}" class="btn btn-sm btn-outline-secondary">Workflow</a>
         </td>
       </tr>
       {% else %}

--- a/tests/test_document_workflow_page.py
+++ b/tests/test_document_workflow_page.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import uuid
+import importlib
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+os.environ["S3_BUCKET_MAIN"] = "local"
+
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+
+@pytest.fixture()
+def app_models():
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    return app_module.app, models_module
+
+
+@pytest.fixture()
+def client(app_models):
+    app, _ = app_models
+    return app.test_client()
+
+
+def test_document_workflow_returns_200(client, app_models):
+    app, m = app_models
+    session = m.SessionLocal()
+    uid = uuid.uuid4().hex
+    doc = m.Document(doc_key=f"doc_{uid}.docx", title="Doc", status="Review")
+    session.add(doc)
+    session.commit()
+    step = m.WorkflowStep(doc_id=doc.id, step_order=1, step_type="review")
+    session.add(step)
+    session.commit()
+    doc_id = doc.id
+    session.close()
+
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1}
+        sess["roles"] = ["reader"]
+
+    resp = client.get(f"/documents/{doc_id}/workflow")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Add `/documents/<id>/workflow` route to display workflow steps
- Include workflow template and link from document table
- Test workflow endpoint returns 200

## Testing
- `pytest tests/test_document_workflow_page.py -q`
- `pytest -q` *(fails: sqlalchemy.exc.OperationalError: no such table: documents in tests/test_approvals_api.py::test_api_approve_step)*

------
https://chatgpt.com/codex/tasks/task_e_68a393b6d458832b9f68225dfb767ef1