### PR TITLE
Add document standard filter test and seeding helper

### DIFF
--- a/portal/models.py
+++ b/portal/models.py
@@ -329,6 +329,40 @@ def seed_roles_and_users():
     finally:
         session.close()
 
+def seed_documents():
+    """Seed sample documents demonstrating standard usage."""
+    session = get_session()
+    try:
+        if session.query(Document).count() == 0:
+            doc1 = Document(
+                doc_key="seed_doc1.docx",
+                title="Seeded Document 1",
+                code="SD1",
+                standard_code="ISO9001",
+                standards=[DocumentStandard(standard_code="ISO9001")],
+            )
+            doc2 = Document(
+                doc_key="seed_doc2.docx",
+                title="Seeded Document 2",
+                code="SD2",
+                standard_code="ISO9001",
+                standards=[
+                    DocumentStandard(standard_code="ISO9001"),
+                    DocumentStandard(standard_code="ISO14001"),
+                ],
+            )
+            doc3 = Document(
+                doc_key="seed_doc3.docx",
+                title="Seeded Document 3",
+                code="SD3",
+                standard_code="ISO14001",
+                standards=[DocumentStandard(standard_code="ISO14001")],
+            )
+            session.add_all([doc1, doc2, doc3])
+            session.commit()
+    finally:
+        session.close()
+
 # Initial data seeding should be invoked manually after applying migrations.
 
 __all__ = [
@@ -336,6 +370,7 @@ __all__ = [
     "SessionLocal",
     "get_session",
     "seed_roles_and_users",
+    "seed_documents",
     "RoleEnum",
     "Document",
     "DocumentRevision",

--- a/tests/test_document_standard_api.py
+++ b/tests/test_document_standard_api.py
@@ -33,7 +33,7 @@ def client(app_models):
     client = app_module.app.test_client()
     with client.session_transaction() as sess:
         sess["user"] = {"id": 1}
-        sess["roles"] = ["contributor"]
+        sess["roles"] = ["contributor", "reader"]
     return client
 
 
@@ -119,4 +119,16 @@ def test_update_document_standard(app_models, client):
     doc = session_db.get(models.Document, doc_id)
     assert doc.standard_code == "ISO14001"
     session_db.close()
+
+
+def test_filter_documents_by_standard(app_models, client):
+    _, models = app_models
+    models.seed_documents()
+
+    resp = client.get("/documents?standard=ISO9001")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Seeded Document 1" in body
+    assert "Seeded Document 2" in body
+    assert "Seeded Document 3" not in body
 


### PR DESCRIPTION
## Summary
- seed documents with ISO standard codes, including multiple standard relationships
- test filtering documents by standard via `/documents` endpoint
- ensure test client has reader permissions for document listing

## Testing
- `pytest tests/test_document_standard_api.py -q`
- `pytest tests/test_document_search.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3982081b0832b9c68dcad7e6603fd