### PR TITLE
Restrict workflow link based on document status

### DIFF
--- a/portal/templates/documents/_table.html
+++ b/portal/templates/documents/_table.html
@@ -28,7 +28,11 @@
         <td class="actions">
           <a href="{{ url_for('document_detail', doc_id=doc.id) }}" class="btn btn-sm btn-outline-secondary">View</a>
           <a href="{{ url_for('edit_document', doc_id=doc.id) }}" class="btn btn-sm btn-outline-primary">Edit</a>
+          {% if doc.status in ['Review', 'Approved'] %}
           <a href="{{ url_for('document_workflow', doc_id=doc.id) }}" class="btn btn-sm btn-outline-secondary">Workflow</a>
+          {% else %}
+          <span class="btn btn-sm btn-outline-secondary disabled">Workflow</span>
+          {% endif %}
         </td>
       </tr>
       {% else %}


### PR DESCRIPTION
## Summary
- Only show the Workflow action when a document is in Review or Approved status
- Render a disabled Workflow indicator for other statuses to avoid unintended navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a39a6dd6d8832b961f0a11b17bfcfe