### PR TITLE
Add standard selection to new document workflow

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -739,6 +739,7 @@ def new_document():
             data["title"] = request.form.get("title", "").strip()
             data["type"] = request.form.get("type", "").strip()
             data["department"] = request.form.get("department", "").strip()
+            data["standard"] = request.form.get("standard", "").strip()
             tags = request.form.get("tags", "")
             data["tags"] = ",".join([t.strip() for t in tags.split(",") if t.strip()])
             DOCUMENT_DRAFTS[draft_id] = data
@@ -795,6 +796,8 @@ def new_document():
         "form": data,
         "step": int(step),
     }
+    if step == "1":
+        context["standards"] = sorted(ALLOWED_STANDARDS)
     if step == "2":
         base_templates = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "templates"))
         template_options = {}

--- a/portal/templates/documents/new_step1.html
+++ b/portal/templates/documents/new_step1.html
@@ -24,6 +24,11 @@
     <input type="text" class="form-control{% if errors.department %} is-invalid{% endif %}" id="department" name="department" value="{{ form.department or '' }}">
     {% if errors.department %}<div class="invalid-feedback">{{ errors.department }}</div>{% endif %}
   </div>
+  <select name="standard" class="form-select mb-3">
+    <option value="ISO9001"{% if form.standard == 'ISO9001' %} selected{% endif %}>ISO 9001</option>
+    <option value="ISO27001"{% if form.standard == 'ISO27001' %} selected{% endif %}>ISO 27001</option>
+    <option value="ISO14001"{% if form.standard == 'ISO14001' %} selected{% endif %}>ISO 14001</option>
+  </select>
   <div class="mb-3">
     <label for="tags" class="form-label">Tags</label>
     <input type="text" class="form-control{% if errors.tags %} is-invalid{% endif %}" id="tags" name="tags" value="{{ form.tags or '' }}" placeholder="tag1, tag2">

--- a/portal/templates/documents/new_step3.html
+++ b/portal/templates/documents/new_step3.html
@@ -13,6 +13,7 @@
   <p><strong>Title:</strong> {{ form.title }}</p>
   <p><strong>Department:</strong> {{ form.department }}</p>
   <p><strong>Type:</strong> {{ form.type }}</p>
+  <p><strong>Standard:</strong> {{ form.standard }}</p>
   <button type="submit" class="btn btn-primary">Create</button>
   <button type="button" id="save-draft" class="btn btn-secondary ms-2">Taslak olarak kaydet</button>
 </form>
@@ -23,6 +24,7 @@ document.getElementById('save-draft').addEventListener('click', async () => {
     title: "{{ form.title }}",
     department: "{{ form.department }}",
     process: "{{ form.type }}",
+    standard: "{{ form.standard }}",
     tags: "{{ form.tags }}".split(',').map(t => t.trim()).filter(Boolean),
     template: "{{ form.template }}",
     uploaded_file_key: "{{ form.uploaded_file_key }}",


### PR DESCRIPTION
## Summary
- store chosen standard during document creation
- allow selecting ISO standards in step 1 form
- show and persist standard in final review step

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a421050728832b81b643ccfcc8ef74