### PR TITLE
Add standard filter to documents list

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -704,6 +704,7 @@ def list_documents():
             {"title": "Documents"},
         ],
         "departments": departments,
+        "standards": sorted(ALLOWED_STANDARDS),
     }
     return render_template(template, **context)
 
@@ -719,6 +720,7 @@ def documents_table():
         "filters": filters,
         "params": params,
         "facets": facets,
+        "standards": sorted(ALLOWED_STANDARDS),
     }
     return render_template("documents/_table.html", **context)
 

--- a/portal/templates/documents/list.html
+++ b/portal/templates/documents/list.html
@@ -39,6 +39,16 @@
       </select>
     </div>
     <div class="col-md-3">
+      <select class="form-select" name="standard" data-filter="select">
+        <option value="">Any standard</option>
+        {% for s in standards %}
+        <option value="{{ s }}" {% if filters.standard == s %}selected{% endif %}>
+          {{ s }}{% if facets.standard %} ({{ facets.standard.get(s, 0) }}){% endif %}
+        </option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-md-3">
       <select class="form-select" multiple name="tags" data-filter="multi-tag">
         {% for t in filters.tags or [] %}
         <option value="{{ t }}" selected>{{ t }}</option>


### PR DESCRIPTION
## Summary
- expose allowed standards in document list and table views
- add standard filter select to documents listing page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4228b60e4832b89a398e7d1858e3a