### PR TITLE
Add standard column to document table

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -230,6 +230,11 @@ def _format_tags(value):
 
 
 ALLOWED_STANDARDS = {"ISO9001", "ISO27001", "ISO14001"}
+STANDARD_MAP = {
+    "ISO9001": "ISO 9001",
+    "ISO27001": "ISO 27001",
+    "ISO14001": "ISO 14001",
+}
 
 
 # -- Acknowledgement helpers -------------------------------------------------
@@ -705,6 +710,7 @@ def list_documents():
         ],
         "departments": departments,
         "standards": sorted(ALLOWED_STANDARDS),
+        "standard_map": STANDARD_MAP,
     }
     return render_template(template, **context)
 
@@ -721,6 +727,7 @@ def documents_table():
         "params": params,
         "facets": facets,
         "standards": sorted(ALLOWED_STANDARDS),
+        "standard_map": STANDARD_MAP,
     }
     return render_template("documents/_table.html", **context)
 

--- a/portal/templates/documents/_table.html
+++ b/portal/templates/documents/_table.html
@@ -1,15 +1,17 @@
 <table class="table table-striped table-sm document-table">
-    <colgroup>
+  <colgroup>
+      <col style="width:15%">
       <col style="width:15%">
       <col style="width:35%">
       <col style="width:15%">
       <col style="width:20%">
       <col style="width:15%">
       <col style="width:10%">
-    </colgroup>
-    <thead class="table-light">
+  </colgroup>
+  <thead class="table-light">
       <tr>
         <th style="position:sticky;top:0;">Code</th>
+        <th style="position:sticky;top:0;">Standard</th>
         <th style="position:sticky;top:0;">Title</th>
         <th style="position:sticky;top:0;">Status</th>
         <th style="position:sticky;top:0;">Department</th>
@@ -21,6 +23,7 @@
       {% for doc in documents %}
       <tr>
         <td>{{ doc.code }}</td>
+        <td>{{ standard_map.get(doc.standard_code, doc.standard_code) }}</td>
         <td>{{ doc.title }}</td>
         <td><span class="badge badge-status-{{ doc.status|lower }}">{{ doc.status }}</span></td>
         <td>{{ doc.department }}</td>
@@ -36,7 +39,7 @@
         </td>
       </tr>
       {% else %}
-      <tr><td colspan="6">No documents found.</td></tr>
+      <tr><td colspan="7">No documents found.</td></tr>
       {% endfor %}
     </tbody>
   </table>


### PR DESCRIPTION
## Summary
- display document standards in document tables
- provide human-readable labels for standards

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a423e60f7c832b8e4e847c84e91bb1