### PR TITLE
Group documents by standard

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -671,6 +671,9 @@ def _get_documents():
             .all()
         )
 
+    # Sort documents by standard_code to ensure grouped display in templates
+    docs = sorted(docs, key=lambda d: (d.standard_code or "", d.id))
+
     session.close()
 
     params = request.args.to_dict()

--- a/portal/templates/documents/_table.html
+++ b/portal/templates/documents/_table.html
@@ -20,7 +20,11 @@
       </tr>
     </thead>
     <tbody>
-      {% for doc in documents %}
+      {% for standard_code, docs in documents|groupby('standard_code') %}
+      <tr class="table-secondary">
+        <th colspan="7">{{ standard_map.get(standard_code, standard_code or 'No Standard') }}</th>
+      </tr>
+      {% for doc in docs %}
       <tr>
         <td>{{ doc.code }}</td>
         <td>{{ standard_map.get(doc.standard_code, doc.standard_code) }}</td>
@@ -38,6 +42,7 @@
           {% endif %}
         </td>
       </tr>
+      {% endfor %}
       {% else %}
       <tr><td colspan="7">No documents found.</td></tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- sort documents in _get_documents by standard code for consistent grouping
- organize document table by standard using Jinja2 groupby

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4cdd2bff0832b8560d1e1096188c0