### PR TITLE
Make ISO standards configurable

### DIFF
--- a/portal/templates/documents/_table.html
+++ b/portal/templates/documents/_table.html
@@ -22,12 +22,12 @@
     {% for standard_code, docs in documents|groupby('standard_code') %}
     <tbody data-group="{{ standard_code or 'no-standard' }}">
       <tr class="table-secondary group-toggle">
-        <th colspan="7">{{ standard_map.get(standard_code, standard_code or 'No Standard') }}</th>
+        <th colspan="7">{{ standard_map.get(standard_code) or standard_code or 'No Standard' }}</th>
       </tr>
       {% for doc in docs %}
       <tr>
         <td>{{ doc.code }}</td>
-        <td>{{ standard_map.get(doc.standard_code, doc.standard_code) }}</td>
+        <td>{{ standard_map.get(doc.standard_code) or doc.standard_code }}</td>
         <td>{{ doc.title }}</td>
         <td><span class="badge badge-status-{{ doc.status|lower }}">{{ doc.status }}</span></td>
         <td>{{ doc.department }}</td>

--- a/portal/templates/documents/new_step1.html
+++ b/portal/templates/documents/new_step1.html
@@ -25,9 +25,9 @@
     {% if errors.department %}<div class="invalid-feedback">{{ errors.department }}</div>{% endif %}
   </div>
   <select name="standard" class="form-select mb-3">
-    <option value="ISO9001"{% if form.standard == 'ISO9001' %} selected{% endif %}>ISO 9001</option>
-    <option value="ISO27001"{% if form.standard == 'ISO27001' %} selected{% endif %}>ISO 27001</option>
-    <option value="ISO14001"{% if form.standard == 'ISO14001' %} selected{% endif %}>ISO 14001</option>
+    {% for code, label in standard_map|dictsort %}
+    <option value="{{ code }}"{% if form.standard == code %} selected{% endif %}>{{ label }}</option>
+    {% endfor %}
   </select>
   <div class="mb-3">
     <label for="tags" class="form-label">Tags</label>

--- a/tests/test_document_standard_flow.py
+++ b/tests/test_document_standard_flow.py
@@ -14,6 +14,14 @@ os.environ.setdefault("S3_ENDPOINT", "http://s3")
 os.environ.setdefault("S3_BUCKET_MAIN", "test-bucket")
 os.environ.setdefault("S3_ACCESS_KEY", "test")
 os.environ.setdefault("S3_SECRET_KEY", "test")
+os.environ.setdefault(
+    "ISO_STANDARDS",
+    "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001",
+)
+
+ISO_MAP = dict(item.split(":", 1) for item in os.environ["ISO_STANDARDS"].split(","))
+FIRST_STANDARD = list(ISO_MAP.keys())[0]
+FIRST_LABEL = ISO_MAP[FIRST_STANDARD]
 
 repo_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(repo_root))
@@ -57,7 +65,7 @@ def test_document_standard_creation_flow(app_models, client):
         "type": "T",
         "department": "Dept",
         "tags": "tag1,tag2",
-        "standard": "ISO9001",
+        "standard": FIRST_STANDARD,
     }
     resp = client.post("/documents/new?step=1", data=step1_data)
     assert resp.status_code == 302
@@ -74,8 +82,8 @@ def test_document_standard_creation_flow(app_models, client):
     resp = client.post("/documents/new?step=3", data={})
     assert resp.status_code == 302
 
-    resp = client.get("/documents?standard=ISO9001")
+    resp = client.get(f"/documents?standard={FIRST_STANDARD}")
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert "Flow Doc" in body
-    assert "<th colspan=\"7\">ISO 9001</th>" in body
+    assert f"<th colspan=\"7\">{FIRST_LABEL}</th>" in body


### PR DESCRIPTION
## Summary
- Build ISO standard mapping from `ISO_STANDARDS` env var
- Render standard options dynamically in document templates
- Update seeds and tests for environment-driven ISO standards

## Testing
- `pytest tests/test_document_standard_api.py tests/test_document_standard_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4d6e638c0832b90d4e1785ba67cf4