### PR TITLE
Add standard scope to roles

### DIFF
--- a/alembic/versions/0007_add_standard_scope_to_roles.py
+++ b/alembic/versions/0007_add_standard_scope_to_roles.py
@@ -1,0 +1,32 @@
+"""Add standard_scope to roles
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2025-02-14 00:00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "roles",
+        sa.Column(
+            "standard_scope",
+            sa.String(),
+            nullable=False,
+            server_default="ALL",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("roles", "standard_scope")

--- a/portal/models.py
+++ b/portal/models.py
@@ -131,6 +131,7 @@ class Role(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, unique=True, nullable=False)
     ldap_group = Column(String, unique=True)
+    standard_scope = Column(String, nullable=False, default="ALL")
     users = relationship(
         "User", secondary=user_roles, back_populates="roles"
     )
@@ -334,7 +335,7 @@ def seed_roles_and_users():
     try:
         for role in RoleEnum:
             if not session.query(Role).filter_by(name=role.value).first():
-                session.add(Role(name=role.value))
+                session.add(Role(name=role.value, standard_scope="ALL"))
         session.commit()
         for role in RoleEnum:
             username = f"test_{role.value}"


### PR DESCRIPTION
## Summary
- add `standard_scope` column to roles and corresponding migration
- default seeded roles to "ALL" standard scope

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e2edab18832b9ed6beff09b2164f