### PR TITLE
Add standard scope to role management

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -2018,14 +2018,17 @@ def create_role():
     """Create a new role."""
     data = request.get_json(silent=True) or {}
     role_name = data.get("role")
+    standard_scope = (data.get("standard_scope") or "ALL").upper()
     if not role_name:
         return jsonify(error="role required"), 400
+    if standard_scope != "ALL" and standard_scope not in ALLOWED_STANDARDS:
+        return jsonify(error="invalid standard_scope"), 400
     session = get_session()
     try:
         existing = session.query(Role).filter_by(name=role_name).first()
         if existing:
             return jsonify(error="role exists"), 400
-        role = Role(name=role_name)
+        role = Role(name=role_name, standard_scope=standard_scope)
         session.add(role)
         session.commit()
         log_action(None, None, f"create_role:{role_name}")
@@ -2090,6 +2093,7 @@ def admin_roles_page():
             "admin/roles.html",
             users=users,
             roles=roles,
+            standards=sorted(ALLOWED_STANDARDS),
             breadcrumbs=[
                 {"title": "Home", "url": url_for("dashboard")},
                 {"title": "Admin"},

--- a/portal/templates/admin/roles.html
+++ b/portal/templates/admin/roles.html
@@ -25,19 +25,26 @@
   <button class="btn btn-primary" type="submit">Assign</button>
 </form>
 
-<h2 class="mt-4">Add Role</h2>
-<form id="newRoleForm" class="d-flex mb-4">
-  <input class="form-control me-2" name="role" placeholder="Role name">
-  <button class="btn btn-success" type="submit">Add</button>
-</form>
+  <h2 class="mt-4">Add Role</h2>
+  <form id="newRoleForm" class="d-flex mb-4">
+    <input class="form-control me-2" name="role" placeholder="Role name">
+    <select class="form-select me-2" name="standard_scope">
+      <option value="ALL">ALL</option>
+      {% for s in standards %}
+      <option value="{{ s }}">{{ s }}</option>
+      {% endfor %}
+    </select>
+    <button class="btn btn-success" type="submit">Add</button>
+  </form>
 
 <h2>Existing Roles</h2>
 <table class="table">
-  <thead><tr><th>Name</th><th>Users</th><th>Actions</th></tr></thead>
+  <thead><tr><th>Name</th><th>Standard Scope</th><th>Users</th><th>Actions</th></tr></thead>
   <tbody>
   {% for r in roles %}
     <tr>
       <td>{{ r.name }}</td>
+      <td>{{ r.standard_scope }}</td>
       <td>
         <button type="button" class="btn btn-sm btn-secondary" data-bs-toggle="collapse" data-bs-target="#role-users-{{ r.id }}" aria-expanded="false">View Users</button>
         <div class="collapse mt-2" id="role-users-{{ r.id }}">
@@ -73,11 +80,12 @@ const newRoleForm = document.getElementById('newRoleForm');
 newRoleForm.addEventListener('submit', async (e) => {
   e.preventDefault();
   const role = newRoleForm.role.value.trim();
+  const standard_scope = newRoleForm.standard_scope.value;
   if (!role) return;
   await fetch('/roles', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({role})
+    body: JSON.stringify({role, standard_scope})
   });
   location.reload();
 });

--- a/tests/test_role_standard_scope.py
+++ b/tests/test_role_standard_scope.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+import pytest
+
+# Ensure application modules are importable
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+os.environ.setdefault(
+    "ISO_STANDARDS",
+    "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001",
+)
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+os.environ.setdefault("S3_BUCKET_MAIN", "test-bucket")
+os.environ.setdefault("S3_ACCESS_KEY", "test")
+os.environ.setdefault("S3_SECRET_KEY", "test")
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    app_module = importlib.import_module("app")
+    models_module = importlib.import_module("models")
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    client = app_module.app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1}
+        sess["roles"] = ["quality_admin"]
+    monkeypatch.setattr(app_module, "log_action", lambda *a, **kw: None)
+    yield client, models_module
+    models_module.SessionLocal.remove()
+
+
+def test_create_role_standard_scope(client):
+    client_app, models = client
+    resp = client_app.post(
+        "/roles", json={"role": "auditor", "standard_scope": "ISO9001"}
+    )
+    assert resp.status_code == 200
+    db = models.SessionLocal()
+    try:
+        role = db.query(models.Role).filter_by(name="auditor").one()
+        assert role.standard_scope == "ISO9001"
+    finally:
+        db.close()
+
+
+def test_create_role_invalid_standard_scope(client):
+    client_app, _ = client
+    resp = client_app.post(
+        "/roles", json={"role": "bad", "standard_scope": "INVALID"}
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- allow specifying a standard scope when creating roles
- surface standard scope in admin UI and creation API
- test role creation with standard scope handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e4618770832ba667bc8d6ad765bf