### PR TITLE
Handle missing standard codes in document listing

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -743,6 +743,14 @@ def _get_documents():
     # Sort documents by standard_code to ensure grouped display in templates
     docs = sorted(docs, key=lambda d: (d.standard_code or "", d.id))
 
+    # Normalize missing standard codes to empty strings so template
+    # grouping via ``groupby('standard_code')`` does not attempt to
+    # compare ``None`` values, which causes a ``TypeError`` in Jinja's
+    # sorting.
+    for d in docs:
+        if d.standard_code is None:
+            d.standard_code = ""
+
     session.close()
 
     params = request.args.to_dict()

--- a/tests/test_document_search.py
+++ b/tests/test_document_search.py
@@ -132,3 +132,14 @@ def test_get_documents_filter_by_standard():
     assert filters["standard"] == "ISO9001"
     assert params["standard"] == "ISO9001"
 
+
+def test_get_documents_normalizes_missing_standard_code():
+    """Documents with no standard_code are normalized for grouping."""
+    _populate_docs()
+    with app.test_request_context("/documents"):
+        docs, _, _, _, _, _ = _get_documents()
+
+    codes = {d.standard_code for d in docs}
+    assert None not in codes
+    assert "" in codes
+


### PR DESCRIPTION
## Summary
- Normalize documents with `standard_code=None` to use empty string for grouping
- Add regression test covering missing standard codes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e7058c60832b8e515064e0c8d708