### PR TITLE
Handle Uncategorized document standard

### DIFF
--- a/alembic/versions/0008_backfill_uncategorized_standard_code.py
+++ b/alembic/versions/0008_backfill_uncategorized_standard_code.py
@@ -1,0 +1,24 @@
+"""Backfill Uncategorized standard code
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2025-02-15 00:00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE documents SET standard_code='Uncategorized' WHERE standard_code IS NULL")
+
+
+def downgrade() -> None:
+    op.execute("UPDATE documents SET standard_code=NULL WHERE standard_code='Uncategorized'")

--- a/portal/app.py
+++ b/portal/app.py
@@ -252,6 +252,7 @@ STANDARD_MAP = _parse_standard_map(
         "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001",
     )
 )
+STANDARD_MAP.setdefault("Uncategorized", "Uncategorized")
 ALLOWED_STANDARDS = set(STANDARD_MAP.keys())
 
 


### PR DESCRIPTION
## Summary
- add placeholder 'Uncategorized' to allowed standards
- backfill existing documents with missing standard codes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a71d960fd8832b9e2e5508d645f2b6