### PR TITLE
Require standard when creating documents

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1496,7 +1496,9 @@ def create_document_api():
         if not value:
             errors[field] = f"{field} is required."
     standard = data.get("standard")
-    if standard and standard not in ALLOWED_STANDARDS:
+    if not standard:
+        errors["standard"] = "Standard is required."
+    elif standard not in ALLOWED_STANDARDS:
         errors["standard"] = "Invalid standard."
     if errors:
         return jsonify({"errors": errors}), 400

--- a/portal/templates/documents/new_step1.html
+++ b/portal/templates/documents/new_step1.html
@@ -24,11 +24,15 @@
     <input type="text" class="form-control{% if errors.department %} is-invalid{% endif %}" id="department" name="department" value="{{ form.department or '' }}">
     {% if errors.department %}<div class="invalid-feedback">{{ errors.department }}</div>{% endif %}
   </div>
-  <select name="standard" class="form-select mb-3">
-    {% for code, label in standard_map.items() %}
-      <option value="{{ code }}"{% if form.standard == code %} selected{% endif %}>{{ label }}</option>
-    {% endfor %}
-  </select>
+  <div class="mb-3">
+    <label for="standard" class="form-label">Standard</label>
+    <select id="standard" name="standard" class="form-select{% if errors.standard %} is-invalid{% endif %}" required>
+      {% for code, label in standard_map.items() %}
+        <option value="{{ code }}"{% if form.standard == code %} selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+    {% if errors.standard %}<div class="invalid-feedback">{{ errors.standard }}</div>{% endif %}
+  </div>
   <div class="mb-3">
     <label for="tags" class="form-label">Tags</label>
     <input type="text" class="form-control{% if errors.tags %} is-invalid{% endif %}" id="tags" name="tags" value="{{ form.tags or '' }}" placeholder="tag1, tag2">

--- a/tests/test_document_standard_api.py
+++ b/tests/test_document_standard_api.py
@@ -97,6 +97,26 @@ def test_create_document_invalid_standard(app_models, client):
     assert "standard" in data["errors"]
 
 
+def test_create_document_missing_standard(app_models, client):
+    app_module, _ = app_models
+    _mock_env(app_module)
+
+    payload = {
+        "code": "DOC1",
+        "title": "My Doc",
+        "type": "T",
+        "department": "Dept",
+        "tags": "tag1,tag2",
+        "uploaded_file_key": "abc123",
+        "uploaded_file_name": "file.txt",
+    }
+
+    resp = client.post("/api/documents", json=payload)
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["errors"]["standard"] == "Standard is required."
+
+
 def test_update_document_standard(app_models, client):
     app_module, models = app_models
     _mock_env(app_module)


### PR DESCRIPTION
## Summary
- require standard in document creation API
- make standard field mandatory on new document form
- test that missing standard fails

## Testing
- `pytest tests/test_document_standard_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68a71f05c91c832b8831df8ecf523447