### PR TITLE
Add admin UI for document standard mapping

### DIFF
--- a/portal/templates/admin/document_standards.html
+++ b/portal/templates/admin/document_standards.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Document Standards</h1>
+<table class="table">
+  <thead><tr><th>ID</th><th>Code</th><th>Title</th><th>Standard</th></tr></thead>
+  <tbody>
+  {% for doc in documents %}
+  <tr>
+    <td>{{ doc.id }}</td>
+    <td>{{ doc.code }}</td>
+    <td>{{ doc.title }}</td>
+    <td>
+      <form method="post" action="{{ url_for('update_document_standard', doc_id=doc.id) }}">
+        <select name="standard" class="form-select form-select-sm d-inline w-auto">
+          {% for code in standards %}
+          <option value="{{ code }}" {% if code == doc.standard_code %}selected{% endif %}>{{ standard_map[code] }}</option>
+          {% endfor %}
+        </select>
+        <button type="submit" class="btn btn-sm btn-primary">Save</button>
+      </form>
+    </td>
+  </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/tests/test_document_standard_admin.py
+++ b/tests/test_document_standard_admin.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+
+import pytest
+
+# Required environment variables for app initialization
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+os.environ.setdefault("S3_BUCKET_MAIN", "test-bucket")
+os.environ.setdefault("S3_ACCESS_KEY", "test")
+os.environ.setdefault("S3_SECRET_KEY", "test")
+
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+
+@pytest.fixture(autouse=True)
+def iso_standards_env(monkeypatch):
+    monkeypatch.setenv(
+        "ISO_STANDARDS",
+        "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001",
+    )
+
+
+@pytest.fixture()
+def app_models():
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    return app_module, models_module
+
+
+@pytest.fixture()
+def admin_client(app_models):
+    app_module, _ = app_models
+    client = app_module.app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1}
+        sess["roles"] = ["quality_admin"]
+    return client
+
+
+def test_document_standards_page_lists_docs(app_models, admin_client):
+    app_module, models = app_models
+    models.seed_documents()
+    resp = admin_client.get("/admin/document-standards")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Seeded Document 1" in body
+
+
+def test_admin_updates_document_standard(app_models, admin_client):
+    app_module, models = app_models
+    models.seed_documents()
+    session_db = models.SessionLocal()
+    doc = session_db.query(models.Document).filter_by(code="SD1").first()
+    session_db.close()
+
+    codes = list(app_module.STANDARD_MAP.keys())
+    new_standard = codes[1] if len(codes) > 1 else codes[0]
+
+    resp = admin_client.post(
+        f"/admin/document-standards/{doc.id}", json={"standard": new_standard}
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+    session_db = models.SessionLocal()
+    updated = session_db.get(models.Document, doc.id)
+    assert updated.standard_code == new_standard
+    assert [s.standard_code for s in updated.standards] == [new_standard]
+    session_db.close()

--- a/tests/test_document_standard_api.py
+++ b/tests/test_document_standard_api.py
@@ -13,20 +13,23 @@ os.environ.setdefault("S3_ENDPOINT", "http://s3")
 os.environ.setdefault("S3_BUCKET_MAIN", "test-bucket")
 os.environ.setdefault("S3_ACCESS_KEY", "test")
 os.environ.setdefault("S3_SECRET_KEY", "test")
-os.environ.setdefault(
-    "ISO_STANDARDS",
-    "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001",
-)
-
 repo_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(repo_root))
 sys.path.insert(0, str(repo_root / "portal"))
 
 
+@pytest.fixture(autouse=True)
+def iso_standards_env(monkeypatch):
+    monkeypatch.setenv(
+        "ISO_STANDARDS",
+        "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001",
+    )
+
+
 @pytest.fixture()
 def app_models():
-    app_module = importlib.import_module("app")
-    models_module = importlib.import_module("models")
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
     app_module.app.config["WTF_CSRF_ENABLED"] = False
     return app_module, models_module
 

--- a/tests/test_document_standard_flow.py
+++ b/tests/test_document_standard_flow.py
@@ -2,6 +2,8 @@ import io
 import os
 import sys
 import importlib
+import os
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -14,20 +16,24 @@ os.environ.setdefault("S3_ENDPOINT", "http://s3")
 os.environ.setdefault("S3_BUCKET_MAIN", "test-bucket")
 os.environ.setdefault("S3_ACCESS_KEY", "test")
 os.environ.setdefault("S3_SECRET_KEY", "test")
-os.environ.setdefault(
-    "ISO_STANDARDS",
-    "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001",
-)
 
 repo_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(repo_root))
 sys.path.insert(0, str(repo_root / "portal"))
 
 
+@pytest.fixture(autouse=True)
+def iso_standards_env(monkeypatch):
+    monkeypatch.setenv(
+        "ISO_STANDARDS",
+        "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001",
+    )
+
+
 @pytest.fixture()
 def app_models():
-    app_module = importlib.import_module("app")
-    models_module = importlib.import_module("models")
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
     app_module.app.config["WTF_CSRF_ENABLED"] = False
     return app_module, models_module
 

--- a/tests/test_role_standard_scope.py
+++ b/tests/test_role_standard_scope.py
@@ -1,4 +1,5 @@
 import os
+import os
 import sys
 import importlib
 from pathlib import Path
@@ -9,10 +10,6 @@ repo_root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(repo_root))
 sys.path.insert(0, str(repo_root / "portal"))
 
-os.environ.setdefault(
-    "ISO_STANDARDS",
-    "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001",
-)
 os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
 os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
 os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
@@ -22,10 +19,18 @@ os.environ.setdefault("S3_ACCESS_KEY", "test")
 os.environ.setdefault("S3_SECRET_KEY", "test")
 
 
+@pytest.fixture(autouse=True)
+def iso_standards_env(monkeypatch):
+    monkeypatch.setenv(
+        "ISO_STANDARDS",
+        "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001",
+    )
+
+
 @pytest.fixture()
 def client(monkeypatch):
-    app_module = importlib.import_module("app")
-    models_module = importlib.import_module("models")
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
     app_module.app.config["WTF_CSRF_ENABLED"] = False
     client = app_module.app.test_client()
     with client.session_transaction() as sess:

--- a/tests/test_standard_scope_access.py
+++ b/tests/test_standard_scope_access.py
@@ -10,7 +10,6 @@ sys.path.insert(0, str(repo_root))
 sys.path.insert(0, str(repo_root / "portal"))
 
 # Set required environment variables
-os.environ.setdefault("ISO_STANDARDS", "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001")
 os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
 os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
 os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
@@ -20,10 +19,18 @@ os.environ.setdefault("S3_ACCESS_KEY", "test")
 os.environ.setdefault("S3_SECRET_KEY", "test")
 
 
+@pytest.fixture(autouse=True)
+def iso_standards_env(monkeypatch):
+    monkeypatch.setenv(
+        "ISO_STANDARDS",
+        "ISO9001:ISO 9001,ISO27001:ISO 27001,ISO14001:ISO 14001",
+    )
+
+
 @pytest.fixture()
 def client():
-    app_module = importlib.import_module("app")
-    models_module = importlib.import_module("models")
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
     app_module.app.config["WTF_CSRF_ENABLED"] = False
     return app_module.app.test_client(), models_module
 


### PR DESCRIPTION
## Summary
- allow ISO standards to be optional when not configured
- add `/admin/document-standards` page for managing document standard codes
- support updating a document's `standard_code` and associated `DocumentStandard` entries
- add integration tests for the mapping workflow and clean up ISO_STANDARDS usage in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7203d755c832bb4a458b82b549a80