### PR TITLE
docs: update token imports and static path

### DIFF
--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -17,7 +17,7 @@ Design tokens centralize style values for colors, typography, spacing, and more.
 
 ### JavaScript
 ```javascript
-import { getToken } from './tokens';
+import { getToken } from './tokens.js';
 
 const primary = getToken('color-primary');
 ```

--- a/portal/static/src/README.md
+++ b/portal/static/src/README.md
@@ -13,8 +13,8 @@ Include the assets in your template and place a container element with the
 `data-component="data-table"` attribute where the table should render.
 
 ```html
-<link rel="stylesheet" href="/static/dist/data-table-<hash>.css">
-<script type="module" src="/static/dist/data-table-<hash>.js"></script>
+<link rel="stylesheet" href="/static/data-table-<hash>.css">
+<script type="module" src="/static/data-table-<hash>.js"></script>
 <div data-component="data-table"></div>
 ```
 
@@ -22,7 +22,7 @@ When content is swapped in by HTMX, re-initialize the component on the
 `htmx:load` event:
 
 ```javascript
-import { initDataTable } from '/static/dist/data-table-<hash>.js';
+import { initDataTable } from '/static/data-table-<hash>.js';
 document.body.addEventListener('htmx:load', (evt) => {
   evt.target.querySelectorAll('[data-component="data-table"]').forEach(initDataTable);
 });


### PR DESCRIPTION
## Summary
- clarify JavaScript token import to use `./tokens.js`
- update static asset examples to serve from `/static/`

## Testing
- `python portal/static/build.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a80b7df32c832b87086cd4a24369a9