### PR TITLE
Ensure documents create and maintain standard links

### DIFF
--- a/tests/test_document_standard_api.py
+++ b/tests/test_document_standard_api.py
@@ -76,6 +76,8 @@ def test_create_document_with_standard(app_models, client):
     session_db = models.SessionLocal()
     doc = session_db.get(models.Document, data["id"])
     assert doc.standard_code == first
+    standards = [s.standard_code for s in doc.standards]
+    assert standards == [first]
     session_db.close()
 
 
@@ -149,6 +151,8 @@ def test_update_document_standard(app_models, client):
     session_db = models.SessionLocal()
     doc = session_db.get(models.Document, doc_id)
     assert doc.standard_code == second
+    standards = [s.standard_code for s in doc.standards]
+    assert standards == [second]
     session_db.close()
 
 

--- a/tests/test_z_dashboard_api.py
+++ b/tests/test_z_dashboard_api.py
@@ -208,6 +208,15 @@ def test_api_standard_summary(client, models):
     assert any(d["standard"] == "STD2" and d["count"] == 1 for d in data)
 
 
+def test_document_standard_relationship(models):
+    SessionLocal = models.SessionLocal
+    Document = models.Document
+    session_db = SessionLocal()
+    doc = session_db.query(Document).filter_by(doc_key="assigned1.docx").one()
+    assert [s.standard_code for s in doc.standards] == ["STD1"]
+    session_db.close()
+
+
 def test_reports_standard_summary(client, models, app_module):
     with client.session_transaction() as sess:
         sess["user"] = {"id": 1, "name": "Tester"}


### PR DESCRIPTION
## Summary
- Record associated standard for each document via `DocumentStandard` when creating a document
- Update or recreate `DocumentStandard` entries when modifying document standard
- Extend tests to assert documents maintain correct standard associations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a813bfd8bc832b8c926d4cc757584e