### PR TITLE
Enhance standard reports and search indexing

### DIFF
--- a/portal/search.py
+++ b/portal/search.py
@@ -63,6 +63,16 @@ def index_document(doc, content: str = "") -> None:
     if es is None:
         return
 
+    # ``doc.standards`` is a relationship yielding ``DocumentStandard``
+    # instances. Collect all associated codes so that a document can be indexed
+    # under multiple standards. If no relationship entries exist we fall back to
+    # the legacy single ``standard_code`` attribute for backward compatibility.
+    standards = [s.standard_code for s in getattr(doc, "standards", [])]
+    if not standards:
+        legacy = getattr(doc, "standard_code", None)
+        if legacy:
+            standards = [legacy]
+
     body = {
         "title": doc.title,
         "code": doc.code,
@@ -70,7 +80,7 @@ def index_document(doc, content: str = "") -> None:
         "department": doc.department,
         "status": getattr(doc, "status", ""),
         "type": getattr(doc, "type", ""),
-        "standard": getattr(doc, "standard_code", ""),
+        "standard": standards,
         "content": content,
     }
     try:

--- a/tests/test_z_dashboard_api.py
+++ b/tests/test_z_dashboard_api.py
@@ -232,7 +232,7 @@ def test_reports_standard_summary(client, models, app_module):
     assert resp.status_code == 200
     assert resp.mimetype == "text/csv"
     text = resp.data.decode()
-    assert "standard,count" in text
+    assert "standard,description,count" in text
     assert "STD1" in text and "STD2" in text
 
     resp = client.get("/reports/export?kind=standard-summary&type=pdf")


### PR DESCRIPTION
## Summary
- Include full standard descriptions in standard summary report
- Index all associated standards for documents so search supports multiple codes
- Update tests for new report CSV structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a81962afc0832bb0f582b1eb530306