### PR TITLE
Add recent documents dashboard card

### DIFF
--- a/portal/templates/dashboard.html
+++ b/portal/templates/dashboard.html
@@ -70,6 +70,19 @@
     </div>
   </div>
 
+  <div class="col">
+    <div class="card h-100">
+      <div class="card-header">Recent Documents</div>
+      <div class="card-body"
+           hx-get="/api/dashboard/cards/recent-docs"
+           hx-trigger="load, every 10s"
+           hx-swap="innerHTML">
+        {% set card = 'recent_docs' %}
+        {% include 'partials/dashboard/_cards.html' %}
+      </div>
+    </div>
+  </div>
+
     <div class="col">
       <div class="card h-100">
         <div class="card-header">Search Shortcuts</div>

--- a/portal/templates/partials/dashboard/_cards.html
+++ b/portal/templates/partials/dashboard/_cards.html
@@ -28,6 +28,8 @@
   {{ render_items(mandatory_reading, 'No mandatory reading.') }}
 {% elif card == 'recent' %}
   {{ render_items(recent_revisions, 'No recent changes.') }}
+{% elif card == 'recent_docs' %}
+  {{ render_items(recent_documents, 'No recent documents.') }}
 {% elif card == 'shortcuts' %}
   {{ render_items(search_shortcuts, 'No search shortcuts.') }}
 {% endif %}

--- a/tests/test_dashboard_cards.py
+++ b/tests/test_dashboard_cards.py
@@ -109,6 +109,17 @@ def test_dashboard_card_endpoints(app_models, client):
     assert "Recent Doc" in html
     assert recent_url in html
 
+    # Recent documents
+    resp = client.get(
+        "/api/dashboard/cards/recent-docs", headers={"HX-Request": "true"}
+    )
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    with app.test_request_context():
+        recent_doc_url = url_for("document_detail", doc_id=recent_doc_id)
+    assert "Recent Doc" in html
+    assert recent_doc_url in html
+
     # Dashboard main page loads successfully
     resp = client.get("/")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Show a new "Recent Documents" card on the dashboard with periodic refresh.
- Serve recent published documents via `/api/dashboard/cards/recent-docs` endpoint.
- Cover new card with test to verify rendered links.

## Testing
- `pytest tests/test_dashboard_cards.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8201987b8832b9873ced7cc4268cb