### PR TITLE
Replace alert with toast in document detail

### DIFF
--- a/portal/static/src/document_detail.js
+++ b/portal/static/src/document_detail.js
@@ -67,7 +67,7 @@ function initVersionSelection() {
         (cb) => cb.checked && cb.value !== currentRevId
       );
       if (other.length !== 1) {
-        alert('Select another version to compare.');
+        showToast('Karşılaştırılacak başka bir sürüm seçin');
         return;
       }
       const url = new URL(compareUrl, window.location.origin);


### PR DESCRIPTION
## Summary
- replace alert with showToast when version selection is invalid
- ensure document detail imports showToast

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a82765af60832ba24f5ae489b05574