### PR TITLE
Initialize Bootstrap tooltips

### DIFF
--- a/portal/static/src/app.js
+++ b/portal/static/src/app.js
@@ -3,6 +3,12 @@ import { getToken } from './tokens.js';
 // so there's no need for an ES module import here.
 getToken('color-primary');
 
+document.addEventListener('DOMContentLoaded', () => {
+  document
+    .querySelectorAll('[data-bs-toggle="tooltip"]')
+    .forEach((el) => new bootstrap.Tooltip(el));
+});
+
 function displayToast(message) {
   const toastEl = document.getElementById('action-toast');
   if (!toastEl) return;

--- a/portal/static/src/forms/tooltip.js
+++ b/portal/static/src/forms/tooltip.js
@@ -2,6 +2,7 @@ export function attachTooltip(element, text) {
   element.setAttribute('title', text);
   element.setAttribute('aria-label', text);
   element.setAttribute('data-bs-toggle', 'tooltip');
+  new bootstrap.Tooltip(element);
   return element;
 }
 


### PR DESCRIPTION
## Summary
- Initialize Bootstrap tooltips when attaching form tooltips
- Create global tooltip initialization on DOMContentLoaded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a82e403afc832b9aaef4aa3fcb304e