### PR TITLE
Add tooltips and help text for document forms

### DIFF
--- a/portal/templates/documents/new_step1.html
+++ b/portal/templates/documents/new_step1.html
@@ -6,27 +6,27 @@
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="code" class="form-label">Code</label>
-    <input type="text" class="form-control{% if errors.code %} is-invalid{% endif %}" id="code" name="code" value="{{ form.code or '' }}">
+    <input type="text" class="form-control{% if errors.code %} is-invalid{% endif %}" id="code" name="code" value="{{ form.code or '' }}" title="Unique document code">
     {% if errors.code %}<div class="invalid-feedback">{{ errors.code }}</div>{% endif %}
   </div>
   <div class="mb-3">
     <label for="title" class="form-label">Title</label>
-    <input type="text" class="form-control{% if errors.title %} is-invalid{% endif %}" id="title" name="title" value="{{ form.title or '' }}">
+    <input type="text" class="form-control{% if errors.title %} is-invalid{% endif %}" id="title" name="title" value="{{ form.title or '' }}" title="Document title">
     {% if errors.title %}<div class="invalid-feedback">{{ errors.title }}</div>{% endif %}
   </div>
   <div class="mb-3">
     <label for="type" class="form-label">Type</label>
-    <input type="text" class="form-control{% if errors.type %} is-invalid{% endif %}" id="type" name="type" value="{{ form.type or '' }}">
+    <input type="text" class="form-control{% if errors.type %} is-invalid{% endif %}" id="type" name="type" value="{{ form.type or '' }}" title="Document type">
     {% if errors.type %}<div class="invalid-feedback">{{ errors.type }}</div>{% endif %}
   </div>
   <div class="mb-3">
     <label for="department" class="form-label">Department</label>
-    <input type="text" class="form-control{% if errors.department %} is-invalid{% endif %}" id="department" name="department" value="{{ form.department or '' }}">
+    <input type="text" class="form-control{% if errors.department %} is-invalid{% endif %}" id="department" name="department" value="{{ form.department or '' }}" title="Responsible department">
     {% if errors.department %}<div class="invalid-feedback">{{ errors.department }}</div>{% endif %}
   </div>
   <div class="mb-3">
     <label for="standard" class="form-label">Standard</label>
-    <select id="standard" name="standard" class="form-select{% if errors.standard %} is-invalid{% endif %}" required>
+    <select id="standard" name="standard" class="form-select{% if errors.standard %} is-invalid{% endif %}" required title="Applicable standard">
       {% for code, label in standard_map.items() %}
         <option value="{{ code }}"{% if form.standard == code %} selected{% endif %}>{{ label }}</option>
       {% endfor %}
@@ -35,9 +35,40 @@
   </div>
   <div class="mb-3">
     <label for="tags" class="form-label">Tags</label>
-    <input type="text" class="form-control{% if errors.tags %} is-invalid{% endif %}" id="tags" name="tags" value="{{ form.tags or '' }}" placeholder="tag1, tag2">
+    <input type="text" class="form-control{% if errors.tags %} is-invalid{% endif %}" id="tags" name="tags" value="{{ form.tags or '' }}" placeholder="tag1, tag2" title="Comma-separated tags">
     {% if errors.tags %}<div class="invalid-feedback">{{ errors.tags }}</div>{% endif %}
   </div>
-  <button type="submit" class="btn btn-primary">Next</button>
-</form>
-{% endblock %}
+    <button type="submit" class="btn btn-primary" id="next-step1" title="Proceed to next step">Next</button>
+  </form>
+
+<script type="module">
+  import { attachHelpText, attachTooltip } from '/static/src/forms/index.js';
+
+  const code = document.getElementById('code');
+  attachHelpText(code, 'Unique identifier for the document.');
+  attachTooltip(code, 'Unique document code');
+
+  const titleInput = document.getElementById('title');
+  attachHelpText(titleInput, 'Title of the document.');
+  attachTooltip(titleInput, 'Document title');
+
+  const typeInput = document.getElementById('type');
+  attachHelpText(typeInput, 'Type of document.');
+  attachTooltip(typeInput, 'Document type');
+
+  const departmentInput = document.getElementById('department');
+  attachHelpText(departmentInput, 'Department responsible for the document.');
+  attachTooltip(departmentInput, 'Responsible department');
+
+  const standardSelect = document.getElementById('standard');
+  attachHelpText(standardSelect, 'Choose the standard that applies.');
+  attachTooltip(standardSelect, 'Applicable standard');
+
+  const tagsInput = document.getElementById('tags');
+  attachHelpText(tagsInput, 'Add comma-separated tags.');
+  attachTooltip(tagsInput, 'Comma-separated tags');
+
+  const nextBtn = document.getElementById('next-step1');
+  attachTooltip(nextBtn, 'Proceed to next step');
+</script>
+  {% endblock %}

--- a/portal/templates/documents/new_step2.html
+++ b/portal/templates/documents/new_step2.html
@@ -6,18 +6,18 @@
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="department" class="form-label">Department</label>
-    <input type="text" class="form-control{% if errors.department %} is-invalid{% endif %}" id="department" name="department" value="{{ form.department or '' }}">
+    <input type="text" class="form-control{% if errors.department %} is-invalid{% endif %}" id="department" name="department" value="{{ form.department or '' }}" title="Responsible department">
     {% if errors.department %}<div class="invalid-feedback">{{ errors.department }}</div>{% endif %}
   </div>
   <div class="mb-3">
     <label for="type" class="form-label">Type</label>
-    <input type="text" class="form-control{% if errors.type %} is-invalid{% endif %}" id="type" name="type" value="{{ form.type or '' }}">
+    <input type="text" class="form-control{% if errors.type %} is-invalid{% endif %}" id="type" name="type" value="{{ form.type or '' }}" title="Document type">
     {% if errors.type %}<div class="invalid-feedback">{{ errors.type }}</div>{% endif %}
   </div>
 
   <div class="mb-3">
     <label for="template" class="form-label">Template</label>
-    <select class="form-select" id="template" name="template">
+    <select class="form-select" id="template" name="template" title="Select a template">
       <option value="">-- Select Template --</option>
       {% for group, files in template_options.items() %}
         <optgroup label="{{ group|capitalize }}">
@@ -31,13 +31,40 @@
 
   <div class="mb-3">
     <label for="upload_file" class="form-label">Upload File</label>
-    <input type="file" class="form-control" id="upload_file" name="upload_file">
+    <input type="file" class="form-control" id="upload_file" name="upload_file" title="Upload document file">
   </div>
 
   <div class="mb-3 form-check">
-    <input type="checkbox" class="form-check-input" id="generate_docxf" name="generate_docxf" value="1"{% if form.generate_docxf %} checked{% endif %}>
+    <input type="checkbox" class="form-check-input" id="generate_docxf" name="generate_docxf" value="1"{% if form.generate_docxf %} checked{% endif %} title="Generate document from DOCXF">
     <label class="form-check-label" for="generate_docxf">Generate from DOCXF</label>
   </div>
-  <button type="submit" class="btn btn-primary">Next</button>
+  <button type="submit" class="btn btn-primary" id="next-step2" title="Proceed to next step">Next</button>
 </form>
+
+<script type="module">
+  import { attachHelpText, attachTooltip } from '/static/src/forms/index.js';
+
+  const departmentInput = document.getElementById('department');
+  attachHelpText(departmentInput, 'Department responsible for the document.');
+  attachTooltip(departmentInput, 'Responsible department');
+
+  const typeInput = document.getElementById('type');
+  attachHelpText(typeInput, 'Type of document.');
+  attachTooltip(typeInput, 'Document type');
+
+  const templateSelect = document.getElementById('template');
+  attachHelpText(templateSelect, 'Select a template to start from.');
+  attachTooltip(templateSelect, 'Select a template');
+
+  const uploadInput = document.getElementById('upload_file');
+  attachHelpText(uploadInput, 'Upload the document file.');
+  attachTooltip(uploadInput, 'Upload document file');
+
+  const generateDocxf = document.getElementById('generate_docxf');
+  attachHelpText(generateDocxf, 'Generate document from a DOCXF file.');
+  attachTooltip(generateDocxf, 'Generate from DOCXF');
+
+  const nextBtn = document.getElementById('next-step2');
+  attachTooltip(nextBtn, 'Proceed to next step');
+</script>
 {% endblock %}

--- a/portal/templates/partials/approvals/_row.html
+++ b/portal/templates/partials/approvals/_row.html
@@ -6,8 +6,13 @@
   <td>{{ step.comment or '' }}</td>
   <td>
     {% if step.status == 'Pending' %}
-    <button class="btn btn-success btn-sm" hx-post="/api/approvals/{{ step.id }}/approve" hx-target="#step-{{ step.id }}" hx-swap="outerHTML">Approve</button>
-    <button class="btn btn-danger btn-sm" hx-post="/api/approvals/{{ step.id }}/reject" hx-target="#step-{{ step.id }}" hx-swap="outerHTML">Reject</button>
+    <button id="approve-{{ step.id }}" class="btn btn-success btn-sm" hx-post="/api/approvals/{{ step.id }}/approve" hx-target="#step-{{ step.id }}" hx-swap="outerHTML" title="Approve this step">Approve</button>
+    <button id="reject-{{ step.id }}" class="btn btn-danger btn-sm" hx-post="/api/approvals/{{ step.id }}/reject" hx-target="#step-{{ step.id }}" hx-swap="outerHTML" title="Reject this step">Reject</button>
+    <script type="module">
+      import { attachTooltip } from '/static/src/forms/index.js';
+      attachTooltip(document.getElementById('approve-{{ step.id }}'), 'Approve this step');
+      attachTooltip(document.getElementById('reject-{{ step.id }}'), 'Reject this step');
+    </script>
     {% else %}
     {{ step.status }}
     {% endif %}


### PR DESCRIPTION
## Summary
- add title attributes and help tooltips to document creation steps
- expose attachHelpText and attachTooltip to document forms
- provide tooltips on approval action buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a82f483828832ba4c394931c975f09