### PR TITLE
Add help page and navigation link

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -1,0 +1,15 @@
+<h2>Sıkça Sorulan Sorular (SSS)</h2>
+<dl>
+  <dt>Portal nedir?</dt>
+  <dd>Portal, kurum içi dokümanların yönetimi ve paylaşımı için kullanılan web tabanlı bir uygulamadır.</dd>
+  <dt>Nasıl giriş yaparım?</dt>
+  <dd>Kullanıcı adınız ve şifreniz ile <code>Login</code> sayfasından giriş yapabilirsiniz.</dd>
+  <dt>Belgeyi nasıl ararım?</dt>
+  <dd>Üst menüdeki arama kutusunu kullanarak belge adı veya numarası ile arama yapabilirsiniz.</dd>
+</dl>
+<h2>Genel Kullanım Talimatları</h2>
+<ol>
+  <li>Sol kenar çubuğundaki menüden ihtiyacınız olan modülü seçin.</li>
+  <li>Yeni belge eklemek veya mevcut bir belgeyi güncellemek için ilgili sayfalardaki talimatları izleyin.</li>
+  <li>Herhangi bir sorunla karşılaşırsanız bu yardım sayfasına geri dönerek sık sorulan soruları gözden geçirin.</li>
+</ol>

--- a/portal/app.py
+++ b/portal/app.py
@@ -11,6 +11,7 @@ from flask import (
     session,
     make_response,
 )
+from markupsafe import Markup
 from flask_wtf.csrf import CSRFProtect
 from auth import auth_bp, init_app as auth_init, login_required, roles_required
 from models import (
@@ -569,6 +570,15 @@ def profile_view():
         "profile/index.html",
         breadcrumbs=[{"title": "Profile"}]
     )
+
+
+@app.route("/help")
+def help_page():
+    docs_path = Path(__file__).resolve().parent.parent / "docs" / "help.md"
+    help_content = ""
+    if docs_path.exists():
+        help_content = docs_path.read_text(encoding="utf-8")
+    return render_template("help.html", help_content=Markup(help_content))
 
 
 @app.get("/api/dashboard/cards/recent-docs")

--- a/portal/templates/help.html
+++ b/portal/templates/help.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Help{% endblock %}
+{% block content %}
+<h1>Help</h1>
+{{ help_content | safe }}
+{% endblock %}

--- a/portal/templates/partials/_sidebar.html
+++ b/portal/templates/partials/_sidebar.html
@@ -37,4 +37,9 @@
     <li class="nav-item"><a class="nav-link {% if p.startswith('/settings') %}active{% endif %}" href="/settings" {% if p.startswith('/settings') %}aria-current="page"{% endif %}>Settings</a></li>
   </ul>
   {% endif %}
+
+  <h6 class="nav-heading">Help</h6>
+  <ul class="nav flex-column subnav mb-3">
+    <li class="nav-item"><a class="nav-link {% if p.startswith('/help') %}active{% endif %}" href="/help" {% if p.startswith('/help') %}aria-current="page"{% endif %}>Help</a></li>
+  </ul>
 </nav>


### PR DESCRIPTION
## Summary
- Add `/help` route rendering new help template
- Provide help content with FAQ and usage tips sourced from `docs/help.md`
- Link to the help page from the sidebar navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a83721fd1c832bbfb80b6095b53e57