### PR TITLE
Enhance approvals guidance and documentation

### DIFF
--- a/docs/approvals-guide.md
+++ b/docs/approvals-guide.md
@@ -1,0 +1,14 @@
+# Approvals Guide
+
+This guide summarizes the approval workflow used in the portal. It can be expanded over time as the process evolves.
+
+## Workflow Steps
+1. Review the document's details and content.
+2. Enter a comment explaining your decision.
+3. Choose to **Approve** or **Reject** the document.
+
+## Future Enhancements
+- Include screenshots or video tutorials.
+- Add more detailed policy explanations for each step.
+- Document common questions or troubleshooting tips.
+

--- a/portal/templates/approvals/detail.html
+++ b/portal/templates/approvals/detail.html
@@ -4,6 +4,7 @@
 <a class="btn btn-secondary" href="{{ url_for('approval_queue') }}">Back</a>
 {% endblock %}
 {% block content %}
+<div class="alert alert-info mb-3">Review the document, add a comment, then choose to approve or reject.</div>
 <div id="editor-container" class="vh-100 overflow-auto">
   <iframe id="docEditor" class="w-100 h-100 border-0" title="Document preview" loading="lazy"></iframe>
 </div>

--- a/portal/templates/approvals/list.html
+++ b/portal/templates/approvals/list.html
@@ -2,6 +2,7 @@
 {% block title %}Approvals{% endblock %}
 {% block content %}
 <h1>Approvals</h1>
+<p class="text-muted">Review the pending documents below and decide whether to approve or reject them.</p>
 <div id="approval-table">
   {% include 'partials/approvals/_table.html' %}
 </div>

--- a/portal/templates/partials/approvals/_modal.html
+++ b/portal/templates/partials/approvals/_modal.html
@@ -9,6 +9,11 @@
             hx-headers='{"Content-Type":"application/json"}'
             hx-vals="js:{comment: this.querySelector('textarea[name=comment]').value}">
         <div class="modal-body">
+          <ol class="mb-3">
+            <li>Review the document.</li>
+            <li>Enter a comment.</li>
+            <li>Approve or Reject.</li>
+          </ol>
           <div class="mb-3">
             <label class="form-label">Comment</label>
             <textarea class="form-control" name="comment" rows="3"></textarea>
@@ -16,7 +21,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <button type="submit" class="btn btn-{{ 'success' if action=='approve' else 'danger' }}" data-bs-dismiss="modal">{{ action|capitalize }}</button>
+          <button type="submit" class="btn btn-{{ 'success' if action=='approve' else 'danger' }}" data-bs-dismiss="modal" data-bs-toggle="tooltip" title="{{ 'Approve the document' if action=='approve' else 'Reject the document' }}">{{ action|capitalize }}</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- Add introductory description to approvals list
- Show step-by-step instructions with tooltips in approval modal
- Provide approval process info box and new markdown guide

## Testing
- `pytest tests/test_pending_approvals.py tests/test_approvals_api.py tests/test_workflow_start_approvals.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a83954b220832b9347fc36aeebb7a0