### PR TITLE
Add terminology glossary and link in UI

### DIFF
--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,0 +1,26 @@
+# Terminoloji
+
+Sık kullanılan terimler ve kısa açıklamaları.
+
+## Belge (Document)
+Kurumsal dokümanların genel adı.
+
+## Revizyon (Revision)
+Bir belgedeki değişiklikle oluşturulan yeni sürüm.
+
+## Onay (Approval)
+Belgenin yetkili kişilerce incelenip kabul edilmesi süreci.
+
+## Zorunlu Okuma (Mandatory Reading)
+Belirli kullanıcıların okumakla yükümlü olduğu belgeler.
+
+## CAPA
+"Corrective and Preventive Action" ifadesinin kısaltmasıdır. Uygunsuzlukları düzeltmek ve tekrarını önlemek için yapılan işlemleri kapsar.
+
+## Workflow
+Bir belgenin oluşturulması, gözden geçirilmesi ve onaylanması için izlenen adımlar dizisi.
+
+---
+
+*İleride bu sözlük, uygulama içinde açılan bir modal veya tooltip dizisi olarak sunulabilir.*
+

--- a/portal/app.py
+++ b/portal/app.py
@@ -581,6 +581,17 @@ def help_page():
     return render_template("help.html", help_content=Markup(help_content))
 
 
+@app.route("/terminology")
+def terminology_page():
+    docs_path = Path(__file__).resolve().parent.parent / "docs" / "terminology.md"
+    glossary_content = ""
+    if docs_path.exists():
+        glossary_content = docs_path.read_text(encoding="utf-8")
+    return render_template(
+        "terminology.html", terminology_content=Markup(glossary_content)
+    )
+
+
 @app.get("/api/dashboard/cards/recent-docs")
 @login_required
 def dashboard_recent_docs_card():

--- a/portal/templates/ack/list.html
+++ b/portal/templates/ack/list.html
@@ -4,10 +4,10 @@
 <h1>Acknowledgements (<span id="ack-count">{{ remaining }}</span>)</h1>
 <form hx-get="{{ url_for('ack.list') }}" hx-target="#ack-table" hx-push-url="true" class="row g-2 mb-3">
   <div class="col-md-3">
-    <input class="form-control" name="status" placeholder="Status" value="{{ filters.status or '' }}">
+    <input class="form-control" name="status" placeholder="Status" value="{{ filters.status or '' }}" title="Filter by acknowledgement status">
   </div>
   <div class="col-md-3">
-    <input class="form-control" type="date" name="due" value="{{ filters.due or '' }}">
+    <input class="form-control" type="date" name="due" value="{{ filters.due or '' }}" title="Filter by due date">
   </div>
   <div class="col-md-2">
     <button class="btn btn-primary w-100" type="submit">Filter</button>

--- a/portal/templates/document_workflow.html
+++ b/portal/templates/document_workflow.html
@@ -6,10 +6,10 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th>Order</th>
-      <th>User</th>
-      <th>Type</th>
-      <th>Status</th>
+      <th title="Workflow step order">Order</th>
+      <th title="Assigned user or role">User</th>
+      <th title="Review or approval type">Type</th>
+      <th title="Current step status">Status</th>
     </tr>
   </thead>
   <tbody>

--- a/portal/templates/partials/_header.html
+++ b/portal/templates/partials/_header.html
@@ -18,6 +18,7 @@
     </button>
 
     <ul class="navbar-nav align-items-center">
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('terminology_page') }}">Terminoloji</a></li>
       {% if current_user %}
       <li class="nav-item">
         <a class="nav-link position-relative" role="button"

--- a/portal/templates/terminology.html
+++ b/portal/templates/terminology.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Terminoloji{% endblock %}
+{% block content %}
+<h1>Terminoloji</h1>
+{{ terminology_content | safe }}
+{% endblock %}


### PR DESCRIPTION
## Summary
- document common terms in new `docs/terminology.md`
- expose glossary at `/terminology` and link from header
- show helpful `title` tooltips on workflow table and acknowledgement filters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a83f868bc0832bb9c1184e98ff1cf5