### PR TITLE
Add autocomplete attributes to login fields

### DIFF
--- a/portal/templates/login.html
+++ b/portal/templates/login.html
@@ -6,11 +6,11 @@
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
     <label for="username" class="form-label">Username</label>
-    <input type="text" class="form-control" id="username" name="username" required>
+    <input type="text" class="form-control" id="username" name="username" autocomplete="username" required>
   </div>
   <div class="mb-3">
     <label for="password" class="form-label">Password</label>
-    <input type="password" class="form-control" id="password" name="password" required>
+    <input type="password" class="form-control" id="password" name="password" autocomplete="current-password" required>
   </div>
   <button type="submit" class="btn btn-primary">Login</button>
 </form>


### PR DESCRIPTION
## Summary
- Improve login form UX by adding `autocomplete` hints for username and password fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a840c6f170832b8cfe08b53f4225a8