### PR TITLE
Serve Bootstrap from CDN

### DIFF
--- a/portal/static/dist/bootstrap/dist/css/bootstrap.css
+++ b/portal/static/dist/bootstrap/dist/css/bootstrap.css
@@ -1,1 +1,0 @@
-/* Placeholder Bootstrap CSS - actual content not bundled in this environment */

--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -4,7 +4,12 @@
   <meta charset="utf-8">
   <title>{% block title %}Portal{% endblock %}</title>
   <meta name="csrf-token" content="{{ csrf_token() }}">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+    integrity="sha384-QWTKZyjpPEjISi6V+N9H59BILowKIiMzFxLpy0X58F3RJTJ63HgFUsERKccqK7MF"
+    crossorigin="anonymous"
+  >
   <style>
     body{color:#1a1a1a;background-color:#fff;}
     .skip-link{position:absolute;top:-40px;left:0;background:#fff;color:#005ea2;padding:8px;z-index:100;}
@@ -59,7 +64,11 @@
 </div>
 {% include 'partials/_toasts.html' %}
 {% include 'partials/_skeleton.html' %}
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script
+  src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-YVPn0Bbm8Fd7g6WZ+eukerY7SmWHeP/1RgZNpmjQe7YQDdyCjTiMQuuXyZJRi5Ob"
+  crossorigin="anonymous"
+></script>
 <script type="module" src="{{ asset_url('app.js') }}"></script>
 <script type="module" src="{{ asset_url('quick_search.js') }}"></script>
 <script src="{{ asset_url('base.js') }}" defer></script>


### PR DESCRIPTION
## Summary
- Load Bootstrap 5.3.3 CSS and bundle from jsDelivr CDN with integrity checks
- Remove unused local Bootstrap assets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a84734fecc832b8fc4cad4470fae9f