### PR TITLE
fix: correct bootstrap integrity hashes

### DIFF
--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -7,7 +7,7 @@
   <link
     href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
     rel="stylesheet"
-    integrity="sha384-QWTKZyjpPEjISi6V+N9H59BILowKIiMzFxLpy0X58F3RJTJ63HgFUsERKccqK7MF"
+    integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
     crossorigin="anonymous"
   >
   <style>
@@ -66,7 +66,7 @@
 {% include 'partials/_skeleton.html' %}
 <script
   src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-  integrity="sha384-YVPn0Bbm8Fd7g6WZ+eukerY7SmWHeP/1RgZNpmjQe7YQDdyCjTiMQuuXyZJRi5Ob"
+  integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
   crossorigin="anonymous"
 ></script>
 <script type="module" src="{{ asset_url('app.js') }}"></script>


### PR DESCRIPTION
## Summary
- update Bootstrap CDN integrity hashes so CSS/JS load correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a84cf3d5d4832ba5ea7a56a7294b51