### PR TITLE
fix nginx static asset paths

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,7 +45,13 @@ http {
     }
 
     location /static/ {
-      alias /app/portal/static/dist/;
+      # Serve pre-built assets from ``dist`` if present; fall back to ``src``
+      # when the build step has not populated the ``dist`` directory.  This
+      # allows development setups without the build artefacts to still load
+      # JavaScript and CSS files while keeping production fast when the
+      # hashed files exist.
+      rewrite ^/static/(.*)$ /$1 break;
+      try_files /app/portal/static/dist$uri /app/portal/static/src$uri =404;
       expires 7d;
       add_header Cache-Control "public";
     }


### PR DESCRIPTION
## Summary
- fallback to source assets when pre-built static files are missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a85321cdc0832bb0ce499cb72512cf