### PR TITLE
fix bootstrap module resolution

### DIFF
--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -10,6 +10,14 @@
     integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
     crossorigin="anonymous"
   >
+  <script type="importmap">
+    {
+      "imports": {
+        "bootstrap": "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.esm.min.js",
+        "bootstrap/dist/css/bootstrap.css": "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      }
+    }
+  </script>
   <style>
     body{color:#1a1a1a;background-color:#fff;}
     .skip-link{position:absolute;top:-40px;left:0;background:#fff;color:#005ea2;padding:8px;z-index:100;}


### PR DESCRIPTION
## Summary
- add import map for bootstrap assets so module specifiers resolve to CDN versions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a855c5da48832b8097aa74f5c7b059