### PR TITLE
Simplify static asset serving configuration

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,13 +45,9 @@ http {
     }
 
     location /static/ {
-      # Serve pre-built assets from ``dist`` if present; fall back to ``src``
-      # when the build step has not populated the ``dist`` directory.  This
-      # allows development setups without the build artefacts to still load
-      # JavaScript and CSS files while keeping production fast when the
-      # hashed files exist.
+      # Serve pre-built assets directly from the ``dist`` directory.
       rewrite ^/static/(.*)$ /$1 break;
-      try_files /app/portal/static/dist$uri /app/portal/static/src$uri =404;
+      try_files /app/portal/static/dist$uri =404;
       expires 7d;
       add_header Cache-Control "public";
     }


### PR DESCRIPTION
## Summary
- Serve static files directly from `portal/static/dist`
- Remove hashed/static src fallback and simplify `try_files`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a86908b364832baf25845d464e8438