### PR TITLE
Remove asset manifest check and ensure static files exist

### DIFF
--- a/scripts/run_security_tests.sh
+++ b/scripts/run_security_tests.sh
@@ -2,8 +2,12 @@
 # Run security scanners and generate reports.
 set -e
 
-# Ensure static assets are built and base.js is present in the manifest.
+# Ensure static assets are built and expected files are present.
 python portal/static/build.py
+if [ ! -f portal/static/dist/base.js ]; then
+  echo "base.js not found" >&2
+  exit 1
+fi
 
 # Bandit: Python static analysis
 if command -v bandit >/dev/null 2>&1; then

--- a/tests/test_asset_manifest.py
+++ b/tests/test_asset_manifest.py
@@ -1,0 +1,12 @@
+"""Verify that key static files are built without relying on a manifest."""
+
+import os
+
+
+def test_static_assets_present():
+    base = os.path.join('portal', 'static', 'dist')
+    expected_files = ['base.js', 'app.js', 'app.css']
+    for fname in expected_files:
+        path = os.path.join(base, fname)
+        assert os.path.exists(path), f"{fname} missing"
+        assert os.path.getsize(path) > 0, f"{fname} empty"


### PR DESCRIPTION
## Summary
- add regression test verifying built static files exist instead of relying on an asset manifest
- update security test script to build assets and assert `base.js` is present

## Testing
- `pytest tests/test_asset_manifest.py -q`
- `bash scripts/run_security_tests.sh >/tmp/security.log && tail -n 20 /tmp/security.log`


------
https://chatgpt.com/codex/tasks/task_e_68a86b3a2a28832bbd97c1ab6239e6f5