### PR TITLE
Serve static assets locally

### DIFF
--- a/docs/modal-drawer-toast.md
+++ b/docs/modal-drawer-toast.md
@@ -1,6 +1,6 @@
 # Modal, Drawer & Toast Components
 
-Reusable UI elements available under `portal/static/src/components`.
+Reusable UI elements available under `portal/static/dist/components`.
 
 ## Confirmation Modal
 

--- a/docs/state-components.md
+++ b/docs/state-components.md
@@ -4,7 +4,7 @@ Reusable UI helpers for displaying loading, empty and error states.
 
 ## Installation
 
-Import the helpers directly from `state-components.js` located in `portal/static/src`.
+Import the helpers directly from `state-components.js` located in `portal/static/dist`.
 
 ```
 import { createSkeleton, createNoData, createErrorCard } from './state-components';

--- a/portal/static/src/README.md
+++ b/portal/static/src/README.md
@@ -13,8 +13,8 @@ Include the script in your template and place a container element with the
 `data-component="data-table"` attribute where the table should render.
 
 ```html
-<link rel="stylesheet" href="/static/app.css">
-<script type="module" src="/static/data-table-<hash>.js"></script>
+<link rel="stylesheet" href="/static/dist/app.css">
+<script type="module" src="/static/dist/data-table-<hash>.js"></script>
 <div data-component="data-table"></div>
 ```
 
@@ -22,7 +22,7 @@ When content is swapped in by HTMX, re-initialize the component on the
 `htmx:load` event:
 
 ```javascript
-import { initDataTable } from '/static/data-table-<hash>.js';
+import { initDataTable } from '/static/dist/data-table-<hash>.js';
 document.body.addEventListener('htmx:load', (evt) => {
   evt.target.querySelectorAll('[data-component="data-table"]').forEach(initDataTable);
 });

--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -28,7 +28,7 @@
     .quick-search-box{max-width:600px;margin:10vh auto;background:#fff;padding:1rem;border-radius:.5rem;}
     .quick-search-overlay .list-group-item{cursor:pointer;}
   </style>
-  <link rel="stylesheet" href="https://cdn.example.com/app.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='dist/app.css') }}">
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -77,6 +77,6 @@
   integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
   crossorigin="anonymous"
 ></script>
-<script type="module" src="https://cdn.example.com/app.js"></script>
+<script type="module" src="{{ url_for('static', filename='dist/app.js') }}"></script>
 </body>
 </html>

--- a/portal/templates/dashboard.html
+++ b/portal/templates/dashboard.html
@@ -106,5 +106,5 @@
     </div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
-  <script type="module" src="/static/dashboard.js"></script>
+  <script type="module" src="{{ url_for('static', filename='dist/dashboard.js') }}"></script>
   {% endblock %}

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Document Detail{% endblock %}
 {% block page_actions %}
-<link rel="stylesheet" href="/static/toolbar/toolbar.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='dist/toolbar/toolbar.css') }}">
 <div class="toolbar" data-component="toolbar">
   {% if has_role('CONTRIBUTOR') %}
   <a class="btn btn-primary" href="{{ url_for('edit_document', doc_id=doc.id) }}">Edit</a>
@@ -17,7 +17,7 @@
   <a class="btn btn-outline-secondary" href="{{ url_for('compare_document_versions', doc_id=doc.id) }}">Karşılaştır</a>
   <a class="btn btn-outline-primary" href="{{ url_for('download_document', doc_id=doc.id) }}">Download</a>
 </div>
-<script type="module" src="/static/toolbar/toolbar.js"></script>
+<script type="module" src="{{ url_for('static', filename='dist/toolbar/toolbar.js') }}"></script>
 {% endblock %}
 {% block content %}
 {% set status_classes = {
@@ -160,9 +160,9 @@
     </div>
   </div>
 
-  <script type="module" src="/static/document_detail.js"></script>
+  <script type="module" src="{{ url_for('static', filename='dist/document_detail.js') }}"></script>
   <script type="module">
-    import { showToast } from '/static/src/components/index.js';
+    import { showToast } from '{{ url_for('static', filename='dist/components/index.js') }}';
 
     document.getElementById('revise-form').addEventListener('submit', async function (e) {
       if (!confirm('Revizyonu başlatmak istediğinize emin misiniz?')) {

--- a/portal/templates/document_edit.html
+++ b/portal/templates/document_edit.html
@@ -10,5 +10,5 @@
   window.editorTokenHeader = {{ token_header | tojson }};
 </script>
 <script src="{{ editor_js }}"></script>
-<script type="module" src="/static/document_edit.js"></script>
+<script type="module" src="{{ url_for('static', filename='dist/document_edit.js') }}"></script>
 {% endblock %}

--- a/portal/templates/documents/list.html
+++ b/portal/templates/documents/list.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 {% block title %}Documents{% endblock %}
 {% block page_actions %}
-<link rel="stylesheet" href="/static/toolbar/toolbar.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='dist/toolbar/toolbar.css') }}">
 <div class="toolbar" data-component="toolbar" data-variant="icon-text">
   <a href="/documents/new" class="btn btn-primary" data-action="new"><svg class="icon"><use xlink:href="#icon-plus"></use></svg><span>New</span></a>
   <a href="#" class="btn btn-outline-primary" data-action="import"><svg class="icon"><use xlink:href="#icon-upload"></use></svg><span>Import</span></a>
   <a href="#" class="btn btn-outline-primary" data-action="export"><svg class="icon"><use xlink:href="#icon-download"></use></svg><span>Export</span></a>
   <button type="button" class="btn btn-outline-secondary" data-action="filter"><svg class="icon"><use xlink:href="#icon-filter"></use></svg><span>Filter</span></button>
 </div>
-<script type="module" src="/static/toolbar/toolbar.js"></script>
+<script type="module" src="{{ url_for('static', filename='dist/toolbar/toolbar.js') }}"></script>
 {% endblock %}
 {% block content %}
   <h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">Documents</h1>
@@ -68,5 +68,5 @@
 <div id="document-table">
   {% include 'documents/_table.html' %}
 </div>
-<script type="module" src="/static/document_list.js"></script>
+<script type="module" src="{{ url_for('static', filename='dist/document_list.js') }}"></script>
 {% endblock %}

--- a/portal/templates/documents/new_step1.html
+++ b/portal/templates/documents/new_step1.html
@@ -42,7 +42,7 @@
   </form>
 
 <script type="module">
-  import { attachHelpText, attachTooltip } from '/static/src/forms/index.js';
+  import { attachHelpText, attachTooltip } from '{{ url_for('static', filename='dist/forms/index.js') }}';
 
   const code = document.getElementById('code');
   attachHelpText(code, 'Unique identifier for the document.');

--- a/portal/templates/documents/new_step2.html
+++ b/portal/templates/documents/new_step2.html
@@ -42,7 +42,7 @@
 </form>
 
 <script type="module">
-  import { attachHelpText, attachTooltip } from '/static/src/forms/index.js';
+  import { attachHelpText, attachTooltip } from '{{ url_for('static', filename='dist/forms/index.js') }}';
 
   const departmentInput = document.getElementById('department');
   attachHelpText(departmentInput, 'Department responsible for the document.');

--- a/portal/templates/documents/new_step3.html
+++ b/portal/templates/documents/new_step3.html
@@ -18,7 +18,7 @@
   <button type="button" id="save-draft" class="btn btn-secondary ms-2">Taslak olarak kaydet</button>
 </form>
 <script type="module">
-import { showToast } from '/static/src/components/index.js';
+import { showToast } from '{{ url_for('static', filename='dist/components/index.js') }}';
 
 document.getElementById('save-draft').addEventListener('click', async () => {
   const data = {

--- a/portal/templates/forms/sample.html
+++ b/portal/templates/forms/sample.html
@@ -7,8 +7,8 @@
   <button type="submit" class="btn btn-primary">Submit</button>
 </form>
 <script type="module">
-  import { createInput, attachHelpText, attachValidation, attachTooltip } from '/static/src/forms/index.js';
-  import { showToast } from '/static/src/components/index.js';
+  import { createInput, attachHelpText, attachValidation, attachTooltip } from '{{ url_for('static', filename='dist/forms/index.js') }}';
+  import { showToast } from '{{ url_for('static', filename='dist/components/index.js') }}';
   const container = document.getElementById('form-container');
   const emailField = createInput({ id: 'email', name: 'email', label: 'Email', type: 'email', required: true, copyable: true });
   container.appendChild(emailField.wrapper);

--- a/portal/templates/partials/approvals/_row.html
+++ b/portal/templates/partials/approvals/_row.html
@@ -9,7 +9,7 @@
     <button id="approve-{{ step.id }}" class="btn btn-success btn-sm" hx-post="/api/approvals/{{ step.id }}/approve" hx-target="#step-{{ step.id }}" hx-swap="outerHTML" title="Approve this step">Approve</button>
     <button id="reject-{{ step.id }}" class="btn btn-danger btn-sm" hx-post="/api/approvals/{{ step.id }}/reject" hx-target="#step-{{ step.id }}" hx-swap="outerHTML" title="Reject this step">Reject</button>
     <script type="module">
-      import { attachTooltip } from '/static/src/forms/index.js';
+      import { attachTooltip } from '{{ url_for('static', filename='dist/forms/index.js') }}';
       attachTooltip(document.getElementById('approve-{{ step.id }}'), 'Approve this step');
       attachTooltip(document.getElementById('reject-{{ step.id }}'), 'Reject this step');
     </script>

--- a/portal/templates/profile/index.html
+++ b/portal/templates/profile/index.html
@@ -29,5 +29,5 @@
     </select>
   </div>
 </form>
-<script src="/static/profile_index.js" defer></script>
+<script src="{{ url_for('static', filename='dist/profile_index.js') }}" defer></script>
 {% endblock %}

--- a/portal/templates/reports/index.html
+++ b/portal/templates/reports/index.html
@@ -38,5 +38,5 @@
   </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
-<script type="module" src="/static/reports.js"></script>
+<script type="module" src="{{ url_for('static', filename='dist/reports.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Use Flask `url_for` to load compiled app.css and app.js from `dist`
- Correct dashboard and other templates to point to built static assets
- Update documentation to reference `portal/static/dist`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a86dd9f224832b8328ad0ba409a2cf