### PR TITLE
Configure Flask static and template directories

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -81,12 +81,16 @@ def _run_migrations() -> None:
 
 _run_migrations()
 
-# Serve compiled assets from ``/static`` so the application's static URLs
-# match the web server configuration. Previously the Flask app exposed
-# assets under ``/dist`` which did not align with Nginx's ``/static/``
-# alias, causing requests like ``/dist/app.css`` to miss the static-file
-# mapping and return 404s.
-app = Flask(__name__, static_folder="static/dist", static_url_path="/static")
+# Serve static assets from the root ``static`` directory and load templates from the
+# project-level ``templates`` folder. Explicitly setting these paths ensures static
+# URLs such as ``/static/app.css`` resolve correctly in both the development server and
+# when deployed behind a web server.
+app = Flask(
+    __name__,
+    static_url_path="/static",
+    static_folder="static",
+    template_folder="../templates",
+)
 app.secret_key = os.environ.get("SECRET_KEY", "dev")
 app.config.update(
     SESSION_COOKIE_HTTPONLY=True,


### PR DESCRIPTION
## Summary
- Serve static assets from root `static` directory and set template folder to project-level `templates`

## Testing
- `pytest` *(fails: 13 failed, 45 passed)*
- `curl -I http://127.0.0.1:5000/static/app.css`


------
https://chatgpt.com/codex/tasks/task_e_68a8760ebe24832b9fa3d212a391e545