### PR TITLE
Proxy static assets through portal service

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -44,11 +44,18 @@ http {
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # location /static/ {
+    #   # Serve pre-built assets directly from ``portal/static``.
+    #   rewrite ^/static/(.*)$ /$1 break;
+    #   try_files /app/portal/static$uri =404;
+    #   expires 7d;
+    #   add_header Cache-Control "public";
+    # }
+
     location /static/ {
-      # Serve pre-built assets directly from ``portal/static``.
-      rewrite ^/static/(.*)$ /$1 break;
-      try_files /app/portal/static$uri =404;
-      expires 7d;
+      proxy_pass http://portal_up/static/;  # servis adı 'portal' ise
+      proxy_set_header Host $host;
+      expires 30d;
       add_header Cache-Control "public";
     }
 


### PR DESCRIPTION
## Summary
- comment old static asset handling
- proxy `/static/` requests to portal service with cache headers

## Testing
- `pytest`
- `docker compose restart nginx` *(fails: command not found)*
- `curl -i http://localhost:8090/static/app.css` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68a879c95114832b8965a1de47fe05db