### PR TITLE
Serve static files directly from Nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -53,8 +53,10 @@ http {
     # }
 
     location /static/ {
-      proxy_pass http://portal_up/static/;  # servis adı 'portal' ise
-      proxy_set_header Host $host;
+      # Serve pre-built assets directly from the shared volume instead of
+      # proxying through the Flask application. This avoids 404 errors when
+      # requesting files like `/static/app.js`.
+      alias /app/portal/static/;
       expires 30d;
       add_header Cache-Control "public";
     }


### PR DESCRIPTION
## Summary
- Serve static assets via Nginx `alias` instead of proxying to Flask to avoid 404s

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a87da242f0832b98eda3a88009d06a