### PR TITLE
Move static build script out of mounted volume

### DIFF
--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -22,4 +22,4 @@ RUN pip install libsass rcssmin jsmin
 # image build time, but the runtime volume mount would hide the generated
 # files. Running the build here ensures the output is written into the
 # mounted directory.
-CMD ["sh", "-c", "python portal/static/build.py && alembic upgrade head && python portal/app.py"]
+CMD ["sh", "-c", "python portal/static_build.py && alembic upgrade head && python portal/app.py"]

--- a/portal/static_build.py
+++ b/portal/static_build.py
@@ -1,6 +1,6 @@
 import os, re
 
-BASE_DIR = os.path.dirname(__file__)
+BASE_DIR = os.path.join(os.path.dirname(__file__), 'static')
 SRC_DIR = os.path.join(BASE_DIR, 'src')
 # Previously assets were written to ``static/dist``. The build step now
 # outputs directly into ``static`` so the runtime container and nginx can

--- a/scripts/run_security_tests.sh
+++ b/scripts/run_security_tests.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Ensure static assets are built and expected files are present.
-python portal/static/build.py
+python portal/static_build.py
 if [ ! -f portal/static/base.js ]; then
   echo "base.js not found" >&2
   exit 1

--- a/tests/test_minify.py
+++ b/tests/test_minify.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from portal.static.build import minify
+from portal.static_build import minify
 
 
 def test_minify_removes_single_line_comments():


### PR DESCRIPTION
## Summary
- relocate static build script to avoid being hidden by runtime volume mount
- update Docker CMD and security test script to call new build location
- adjust unit tests for relocated minify helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8826615c0832bb39a4fb334653a8c