### PR TITLE
Use dedicated static-dist volume for portal assets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,8 @@ services:
       - elasticsearch
     networks: [qdms]
     volumes:
-      - portal_static:/app/portal/static
+      # Shared volume for built static assets
+      - portal_static:/app/portal/static-dist
 
   scheduler:
     image: python:3.12-slim
@@ -128,10 +129,11 @@ services:
     depends_on:
       - portal
       - onlyoffice
-    volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - portal_static:/app/portal/static:ro
-      - nginx_cache:/var/cache/nginx
+      volumes:
+        - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+        # Serve static assets from the build output directory
+        - portal_static:/app/portal/static-dist:ro
+        - nginx_cache:/var/cache/nginx
       # SSL sertifikası kullanacaksanız aşağıyı açın ve dosyaları koyun
       # - ./nginx/certs:/etc/nginx/certs:ro
     ports:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -56,7 +56,7 @@ http {
       # Serve pre-built assets directly from the shared volume instead of
       # proxying through the Flask application. This avoids 404 errors when
       # requesting files like `/static/app.js`.
-      alias /app/portal/static/;
+      alias /app/portal/static-dist/;
       expires 30d;
       add_header Cache-Control "public";
     }

--- a/portal/static_build.py
+++ b/portal/static_build.py
@@ -2,10 +2,10 @@ import os, re
 
 BASE_DIR = os.path.join(os.path.dirname(__file__), 'static')
 SRC_DIR = os.path.join(BASE_DIR, 'src')
-# Previously assets were written to ``static/dist``. The build step now
-# outputs directly into ``static`` so the runtime container and nginx can
-# serve them from a single location.
-DEST_DIR = BASE_DIR
+# Write minified assets into a dedicated ``static-dist`` directory. This
+# directory is mounted as a shared volume between the portal and nginx
+# containers so both can access the generated files.
+DEST_DIR = os.path.join(os.path.dirname(__file__), 'static-dist')
 
 def minify(content):
     """Basic minifier for JS/CSS files.


### PR DESCRIPTION
## Summary
- serve built assets from `/app/portal/static-dist` for portal and nginx
- update build script to write into `static-dist` and ensure directory exists

## Testing
- `python portal/static_build.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac448d9af8832b80ba8540c2bff786