### PR TITLE
Expose portal bind port in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       FLASK_ENV: production
       SECRET_KEY: ${PORTAL_SECRET_KEY}
       DEBUG: ${PORTAL_DEBUG}
+      PORTAL_BIND: ${PORTAL_BIND}
       BIND: ${PORTAL_BIND}
       DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       REDIS_URL: redis://redis:6379/0


### PR DESCRIPTION
## Summary
- expose `PORTAL_BIND` environment variable for the portal service in docker-compose

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac4ec29e4c832ba9641a3906d6f0e6