### PR TITLE
Fix nginx service indentation in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,11 +129,11 @@ services:
     depends_on:
       - portal
       - onlyoffice
-      volumes:
-        - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-        # Serve static assets from the build output directory
-        - portal_static:/app/portal/static-dist:ro
-        - nginx_cache:/var/cache/nginx
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      # Serve static assets from the build output directory
+      - portal_static:/app/portal/static-dist:ro
+      - nginx_cache:/var/cache/nginx
       # SSL sertifikası kullanacaksanız aşağıyı açın ve dosyaları koyun
       # - ./nginx/certs:/etc/nginx/certs:ro
     ports:


### PR DESCRIPTION
## Summary
- fix indentation in docker-compose nginx section to valid YAML

## Testing
- `pytest -q`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac46c9cab4832b9ee5aee31d724089