### PR TITLE
Add SSE proxy endpoints to nginx config

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -44,6 +44,20 @@ http {
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location /events {
+      proxy_pass http://portal_up;
+      proxy_read_timeout 1h;
+      proxy_send_timeout 1h;
+      proxy_buffering off;
+    }
+
+    location /notifications/stream {
+      proxy_pass http://portal_up;
+      proxy_read_timeout 1h;
+      proxy_send_timeout 1h;
+      proxy_buffering off;
+    }
+
     # location /static/ {
     #   # Serve pre-built assets directly from ``portal/static``.
     #   rewrite ^/static/(.*)$ /$1 break;


### PR DESCRIPTION
## Summary
- add dedicated `/events` and `/notifications/stream` locations for SSE endpoints with extended timeouts and disabled buffering

## Testing
- `pytest`
- `nginx -t` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ac5352321c832ba25917e921b797b6