### PR TITLE
Remove SSE-based notification handling

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -49,8 +49,6 @@ from notifications import (
     notify_mandatory_read,
     notify_approval_queue,
     notify_user,
-    subscribe,
-    unsubscribe,
 )
 from reports import (
     build_report,


### PR DESCRIPTION
## Summary
- drop subscribe/unsubscribe and in-memory channels
- simplify notify_user to persist and deliver via email/webhook only
- clean up references to SSE imports in app

## Testing
- `pytest`
- `rg -n "notifications/stream" --no-ignore`
- `rg -n "EventSource" --no-ignore`
- `rg -n "subscribe\(" --no-ignore`
- `rg -n "unsubscribe\(" --no-ignore`


------
https://chatgpt.com/codex/tasks/task_e_68ac6026af78832bbe9ab56e40a9f7a8