### PR TITLE
Log document view events

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1029,6 +1029,10 @@ def document_detail(doc_id: int | None = None, id: int | None = None):
     if not doc:
         return "Document not found", 404
 
+    user = session.get("user")
+    if user and user.get("id"):
+        log_action(user["id"], doc.id, "view")
+
     revisions = sorted(
         doc.revisions,
         key=lambda r: (r.major_version, r.minor_version),

--- a/portal/models.py
+++ b/portal/models.py
@@ -312,6 +312,7 @@ class AuditLog(Base):
     action = Column(String, nullable=False)
     endpoint = Column(String)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    timestamp = synonym("created_at")
 
     user = relationship("User")
     document = relationship("Document")


### PR DESCRIPTION
## Summary
- log document views in audit log when a user accesses `/documents/<id>`
- expose `timestamp` attribute on `AuditLog`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac759f1184832bb939006f8a7e3d20