### PR TITLE
Add multi-role access check and corresponding tests

### DIFF
--- a/portal/auth.py
+++ b/portal/auth.py
@@ -62,6 +62,25 @@ def roles_required(*required_roles):
     return decorator
 
 
+def require_roles(*required_roles):
+    """Ensure the user has *all* of the given roles."""
+
+    def decorator(view):
+        @wraps(view)
+        def wrapped(*args, **kwargs):
+            if not session.get('user'):
+                return redirect(url_for('auth.login'))
+            user_roles = session.get('roles', [])
+            role_names = [r.value if hasattr(r, 'value') else r for r in required_roles]
+            if any(r not in user_roles for r in role_names):
+                abort(403)
+            return view(*args, **kwargs)
+
+        return wrapped
+
+    return decorator
+
+
 def ldap_auth(username: str, password: str) -> bool:
     uri = current_app.config.get("LDAP_URL")
     domain = current_app.config.get("LDAP_DOMAIN")

--- a/portal/models.py
+++ b/portal/models.py
@@ -63,6 +63,9 @@ class RoleEnum(PyEnum):
     PUBLISHER = "publisher"
     QUALITY_ADMIN = "quality_admin"
     AUDITOR = "auditor"
+    SURVEY_ADMIN = "survey_admin"
+    COMPLAINTS_OWNER = "complaints_owner"
+    RISK_COMMITTEE = "risk_committee"
 
 
 class Document(Base):

--- a/tests/test_require_roles.py
+++ b/tests/test_require_roles.py
@@ -1,0 +1,59 @@
+import os
+import importlib
+import pytest
+
+# Set minimal environment variables before importing the application
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+
+@pytest.fixture()
+def client_and_models():
+    app_module = importlib.reload(importlib.import_module("app"))
+    models = importlib.reload(importlib.import_module("models"))
+    from auth import require_roles
+
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+
+    @app_module.app.route("/qa")
+    @require_roles(models.RoleEnum.QUALITY_ADMIN.value)
+    def qa_route():
+        return "ok"
+
+    @app_module.app.route("/qa-approve")
+    @require_roles(models.RoleEnum.QUALITY_ADMIN.value, models.RoleEnum.APPROVER.value)
+    def qa_approve_route():
+        return "ok"
+
+    client = app_module.app.test_client()
+    return client, models
+
+
+def test_require_roles_single_role(client_and_models):
+    client, models = client_and_models
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1, "name": "Tester"}
+        sess["roles"] = []
+    assert client.get("/qa").status_code == 403
+
+    with client.session_transaction() as sess:
+        sess["roles"] = [models.RoleEnum.QUALITY_ADMIN.value]
+    assert client.get("/qa").status_code == 200
+
+
+def test_require_roles_multiple_roles(client_and_models):
+    client, models = client_and_models
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1, "name": "Tester"}
+        sess["roles"] = [models.RoleEnum.QUALITY_ADMIN.value]
+    assert client.get("/qa-approve").status_code == 403
+
+    with client.session_transaction() as sess:
+        sess["roles"] = [
+            models.RoleEnum.QUALITY_ADMIN.value,
+            models.RoleEnum.APPROVER.value,
+        ]
+    assert client.get("/qa-approve").status_code == 200
+


### PR DESCRIPTION
## Summary
- add `require_roles` decorator that demands all listed roles
- expand `RoleEnum` with survey, complaints, and risk roles so seeding covers them
- test role-protected routes return 403 without roles and 200 with all required roles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad524d6b30832babf2d517e1d666bd