### PR TITLE
Seed default roles and admin user

### DIFF
--- a/alembic/versions/0011_seed_default_roles_and_admin.py
+++ b/alembic/versions/0011_seed_default_roles_and_admin.py
@@ -1,0 +1,67 @@
+"""Seed default roles and admin user
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2025-02-17 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    roles = [
+        "reader",
+        "contributor",
+        "reviewer",
+        "approver",
+        "publisher",
+        "quality_admin",
+        "auditor",
+        "survey_admin",
+        "complaints_owner",
+        "risk_committee",
+    ]
+
+    roles_table = sa.table(
+        "roles",
+        sa.column("name", sa.String()),
+        sa.column("standard_scope", sa.String()),
+    )
+    op.bulk_insert(
+        roles_table,
+        [{"name": r, "standard_scope": "ALL"} for r in roles],
+    )
+
+    users_table = sa.table(
+        "users",
+        sa.column("username", sa.String()),
+        sa.column("email", sa.String()),
+    )
+    op.bulk_insert(
+        users_table,
+        [{"username": "admin", "email": "admin@example.com"}],
+    )
+
+    op.execute(
+        """
+        INSERT INTO user_roles (user_id, role_id)
+        SELECT u.id, r.id FROM users u, roles r
+        WHERE u.username='admin' AND r.name='quality_admin'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DELETE FROM user_roles WHERE user_id = (SELECT id FROM users WHERE username='admin')"
+    )
+    op.execute("DELETE FROM users WHERE username='admin'")
+    op.execute(
+        "DELETE FROM roles WHERE name IN ('reader','contributor','reviewer','approver','publisher','quality_admin','auditor','survey_admin','complaints_owner','risk_committee')"
+    )

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -27,3 +27,13 @@ alembic upgrade head
 
 Migrations replace any implicit `Base.metadata.create_all` calls. Developers
 must run the commands above to create or update the database schema.
+
+## Seeding default data
+
+After applying migrations, populate default roles and an admin user:
+
+```bash
+python scripts/seed_data.py
+```
+
+The script can be re-run safely; existing entries are left untouched.

--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -1,0 +1,35 @@
+"""Seed default roles and admin user."""
+
+from portal.models import Role, RoleEnum, User, SessionLocal
+
+
+def seed_roles(session) -> None:
+    """Ensure all default roles exist."""
+    for role in RoleEnum:
+        if not session.query(Role).filter_by(name=role.value).first():
+            session.add(Role(name=role.value))
+
+
+def seed_admin_user(session) -> None:
+    """Create default admin user with quality_admin role."""
+    admin = session.query(User).filter_by(username="admin").first()
+    if not admin:
+        admin = User(username="admin", email="admin@example.com")
+        qa_role = session.query(Role).filter_by(name=RoleEnum.QUALITY_ADMIN.value).first()
+        if qa_role:
+            admin.roles.append(qa_role)
+        session.add(admin)
+
+
+def seed() -> None:
+    session = SessionLocal()
+    try:
+        seed_roles(session)
+        seed_admin_user(session)
+        session.commit()
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    seed()


### PR DESCRIPTION
## Summary
- add migration seeding default roles and admin user
- provide reusable `scripts/seed_data.py` seeding utility
- document how to seed data after migrations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad53b64064832b9df6ec72aa53248a