### PR TITLE
feat: expand audit logging

### DIFF
--- a/alembic/versions/0014_add_entity_fields_to_audit_logs.py
+++ b/alembic/versions/0014_add_entity_fields_to_audit_logs.py
@@ -1,0 +1,29 @@
+"""Add entity fields to audit logs
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2025-08-19
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.add_column("audit_logs", sa.Column("entity_type", sa.String(), nullable=True))
+    op.add_column("audit_logs", sa.Column("entity_id", sa.Integer(), nullable=True))
+    op.add_column("audit_logs", sa.Column("payload", sa.JSON(), nullable=True))
+    op.alter_column("audit_logs", "created_at", new_column_name="at")
+    op.alter_column("audit_logs", "user_id", existing_type=sa.Integer(), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("audit_logs", "user_id", existing_type=sa.Integer(), nullable=False)
+    op.alter_column("audit_logs", "at", new_column_name="created_at")
+    op.drop_column("audit_logs", "payload")
+    op.drop_column("audit_logs", "entity_id")
+    op.drop_column("audit_logs", "entity_type")

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,67 @@
+import importlib
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+
+@pytest.fixture()
+def models():
+    models_module = importlib.reload(importlib.import_module("models"))
+    models_module.Base.metadata.create_all(bind=models_module.engine)
+    return models_module
+
+
+def test_document_crud_logs(models):
+    m = models
+    session = m.SessionLocal()
+    doc = m.Document(doc_key="doc.log", title="Log Doc")
+    session.add(doc)
+    session.commit()
+    doc_id = doc.id
+
+    logs = session.query(m.AuditLog).filter_by(entity_type="Document", entity_id=doc_id, action="create").all()
+    assert len(logs) == 1
+    assert logs[0].payload["title"] == "Log Doc"
+
+    doc.title = "Updated"
+    session.commit()
+    logs = session.query(m.AuditLog).filter_by(entity_type="Document", entity_id=doc_id, action="update").all()
+    assert len(logs) == 1
+    assert logs[0].payload["changes"]["title"]["old"] == "Log Doc"
+    assert logs[0].payload["changes"]["title"]["new"] == "Updated"
+
+    session.delete(doc)
+    session.commit()
+    logs = session.query(m.AuditLog).filter_by(entity_type="Document", entity_id=doc_id, action="delete").all()
+    assert len(logs) == 1
+    session.close()
+
+
+def test_workflow_step_comment_log(models):
+    m = models
+    session = m.SessionLocal()
+    doc = m.Document(doc_key="wf.doc", title="WF Doc")
+    session.add(doc)
+    session.commit()
+    step = m.WorkflowStep(doc_id=doc.id, step_order=1, status="Pending")
+    session.add(step)
+    session.commit()
+    step_id = step.id
+
+    step.comment = "Needs changes"
+    session.commit()
+    logs = session.query(m.AuditLog).filter_by(entity_type="WorkflowStep", entity_id=step_id, action="comment").all()
+    assert len(logs) == 1
+    assert logs[0].payload["comment"] == "Needs changes"
+    session.close()


### PR DESCRIPTION
## Summary
- add entity_type, entity_id, payload fields to AuditLog and rename created_at to at
- log document and workflow step CRUD/actions via SQLAlchemy listeners
- extend log_action utility and cover new audit trails with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad6f241768832bbe40175c98e7c5e5