### PR TITLE
Fix misreferenced Alembic revision

### DIFF
--- a/alembic/versions/0010_add_document_fields.py
+++ b/alembic/versions/0010_add_document_fields.py
@@ -1,7 +1,7 @@
 """Add file and ownership fields to documents
 
 Revision ID: 0010
-Revises: 0009_create_standards_table
+Revises: 0009
 Create Date: 2024-05-18 00:00:00
 """
 
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "0010"
-down_revision = "0009_create_standards_table"
+down_revision = "0009"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- correct down_revision in document fields migration to point to revision 0009

## Testing
- `pytest -q`
- `alembic upgrade head` *(fails: sqlite3.OperationalError: duplicate column name: step_type)*

------
https://chatgpt.com/codex/tasks/task_e_68ad714632f0832b8b543fb077baa0aa