### PR TITLE
Fix Alembic seed migration execute call

### DIFF
--- a/alembic/versions/0011_seed_default_roles_and_admin.py
+++ b/alembic/versions/0011_seed_default_roles_and_admin.py
@@ -28,8 +28,10 @@ def upgrade() -> None:
         "risk_committee",
     ]
 
+    conn = op.get_bind()
+
     for role in roles:
-        op.execute(
+        conn.execute(
             sa.text(
                 "INSERT INTO roles (name, standard_scope) VALUES (:name, 'ALL') "
                 "ON CONFLICT (name) DO NOTHING"
@@ -37,7 +39,7 @@ def upgrade() -> None:
             {"name": role},
         )
 
-    op.execute(
+    conn.execute(
         sa.text(
             "INSERT INTO users (username, email) VALUES (:username, :email) "
             "ON CONFLICT (username) DO NOTHING"


### PR DESCRIPTION
## Summary
- fix op.execute usage in seed migration by executing through bound connection

## Testing
- `alembic upgrade head` *(fails: duplicate column name: step_type)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad7dcca0e4832ba20d5d812655b5a9