### PR TITLE
Fix duplicate enum creation in doc workflows migration

### DIFF
--- a/alembic/versions/0012_add_doc_workflows.py
+++ b/alembic/versions/0012_add_doc_workflows.py
@@ -24,6 +24,7 @@ def upgrade() -> None:
         "published",
         "obsolete",
         name="doc_workflow_state",
+        create_type=False,
     )
     state_enum.create(op.get_bind(), checkfirst=True)
     op.create_table(
@@ -48,5 +49,6 @@ def downgrade() -> None:
         "published",
         "obsolete",
         name="doc_workflow_state",
+        create_type=False,
     )
     state_enum.drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
## Summary
- avoid recreating `doc_workflow_state` enum by disabling auto-type creation and checking first

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad88b76fd0832bbe61c2c8755787bb