### PR TITLE
Fix pending approvals report join

### DIFF
--- a/portal/reports.py
+++ b/portal/reports.py
@@ -129,7 +129,8 @@ def pending_approvals_report(
                 User.username,
                 Document.created_at,
             )
-            .join(Document)
+            .select_from(WorkflowStep)
+            .join(Document, WorkflowStep.doc_id == Document.id)
             .outerjoin(User, WorkflowStep.user_id == User.id)
             .filter(WorkflowStep.status == "Pending")
             .order_by(None)

--- a/tests/test_pending_approvals_report_export.py
+++ b/tests/test_pending_approvals_report_export.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def setup_data():
+    repo_root = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(repo_root))
+    sys.path.insert(0, str(repo_root / "portal"))
+    models = importlib.import_module("models")
+    session = models.SessionLocal()
+    user = models.User(username="approver1")
+    session.add(user)
+    session.commit()
+    doc = models.Document(doc_key="doc.docx", title="Doc", status="Review")
+    session.add(doc)
+    session.commit()
+    step = models.WorkflowStep(
+        doc_id=doc.id,
+        step_order=1,
+        user_id=user.id,
+        status="Pending",
+        step_type="approval",
+    )
+    session.add(step)
+    session.commit()
+    session.close()
+    yield
+
+
+def test_pending_approvals_report(setup_data):
+    reports = importlib.import_module("reports")
+    rows = reports.pending_approvals_report()
+    assert len(rows) == 1
+    assert rows[0]["document"] == "Doc"
+    assert rows[0]["approver"] == "approver1"


### PR DESCRIPTION
## Summary
- Correct pending approvals report query by selecting from `WorkflowStep` and explicitly joining `Document` and `User`
- Add regression test ensuring pending approvals report exports pending steps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad946c1220832bb7016b9d9ffc9f85