### PR TITLE
Add DifRequest model and migration

### DIFF
--- a/alembic/versions/0015_add_dif_requests.py
+++ b/alembic/versions/0015_add_dif_requests.py
@@ -1,0 +1,53 @@
+"""Add dif requests table
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2025-09-07
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0015"
+down_revision = "0014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    status = sa.Enum(
+        "new",
+        "in_review",
+        "approved",
+        "rejected",
+        "implemented",
+        name="dif_request_status",
+    )
+    status.create(op.get_bind(), checkfirst=True)
+    op.create_table(
+        "dif_requests",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("subject", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("requester_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("impact", sa.String(), nullable=True),
+        sa.Column("priority", sa.String(), nullable=True),
+        sa.Column("status", status, nullable=False, server_default="new"),
+        sa.Column("related_doc_id", sa.Integer(), sa.ForeignKey("documents.id"), nullable=True),
+        sa.Column("attachment_key", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("dif_requests")
+    status = sa.Enum(
+        "new",
+        "in_review",
+        "approved",
+        "rejected",
+        "implemented",
+        name="dif_request_status",
+    )
+    status.drop(op.get_bind(), checkfirst=True)

--- a/portal/models.py
+++ b/portal/models.py
@@ -312,6 +312,34 @@ class CAPAAction(Base):
     document = relationship("Document")
 
 
+class DifRequest(Base):
+    __tablename__ = "dif_requests"
+    id = Column(Integer, primary_key=True)
+    subject = Column(String, nullable=False)
+    description = Column(Text)
+    requester_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    impact = Column(String)
+    priority = Column(String)
+    status = Column(
+        Enum(
+            "new",
+            "in_review",
+            "approved",
+            "rejected",
+            "implemented",
+            name="dif_request_status",
+        ),
+        default="new",
+        nullable=False,
+    )
+    related_doc_id = Column(Integer, ForeignKey("documents.id"))
+    attachment_key = Column(String)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    requester = relationship("User", back_populates="dif_requests")
+    related_doc = relationship("Document", back_populates="dif_requests")
+
+
 class UserSetting(Base):
     __tablename__ = "user_settings"
     id = Column(Integer, primary_key=True)
@@ -380,6 +408,12 @@ Document.revisions = relationship(
 )
 Document.standards = relationship(
     DocumentStandard, back_populates="document", cascade="all, delete-orphan"
+)
+Document.dif_requests = relationship(
+    DifRequest, back_populates="related_doc", cascade="all, delete-orphan"
+)
+User.dif_requests = relationship(
+    DifRequest, back_populates="requester", cascade="all, delete-orphan"
 )
 
 


### PR DESCRIPTION
## Summary
- add `DifRequest` model for tracking DIF requests with relationships to users and documents
- create Alembic migration to create `dif_requests` table and status enum

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ada05f0938832b9dd2ba758a59e2a6