### PR TITLE
Add DIF workflow step model with audit logging

### DIFF
--- a/alembic/versions/0016_add_dif_workflow_steps.py
+++ b/alembic/versions/0016_add_dif_workflow_steps.py
@@ -1,0 +1,33 @@
+"""Add dif workflow steps table
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2025-09-07
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0016"
+down_revision = "0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dif_workflow_steps",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("dif_id", sa.Integer(), sa.ForeignKey("dif_requests.id"), nullable=False),
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("step_order", sa.Integer(), nullable=False),
+        sa.Column("sla_hours", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False, server_default="Pending"),
+        sa.Column("acted_at", sa.DateTime(), nullable=True),
+        sa.Column("comment", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("dif_workflow_steps")


### PR DESCRIPTION
## Summary
- add DifWorkflowStep model for DIF request workflows and link to DifRequest
- track DifWorkflowStep create/update/delete in AuditLog
- cover DIF workflow step audit trail with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ada23e48c8832bb235a516e47f6ce1