### PR TITLE
Add DIF request routes and templates

### DIFF
--- a/portal/templates/dif/detail.html
+++ b/portal/templates/dif/detail.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}DIF {{ dif.id }}{% endblock %}
+{% block content %}
+<h3>{{ dif.subject }}</h3>
+<p><strong>Status:</strong> {{ dif.status }}</p>
+<p><strong>Requester:</strong> {{ dif.requester.username if dif.requester else '' }}</p>
+<p><strong>Description:</strong> {{ dif.description }}</p>
+<p><strong>Impact:</strong> {{ dif.impact }}</p>
+{% if attachment_url %}
+<p><a href="{{ attachment_url }}">Download Attachment</a></p>
+{% endif %}
+{% endblock %}

--- a/portal/templates/dif/list.html
+++ b/portal/templates/dif/list.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% block title %}DIF Requests{% endblock %}
+{% block content %}
+<h3>DIF Requests</h3>
+<form class="row g-2 mb-3" method="get">
+  <div class="col">
+    <input class="form-control" type="text" name="status" placeholder="Status" value="{{ filters.status }}">
+  </div>
+  <div class="col">
+    <input class="form-control" type="text" name="requester" placeholder="Requester" value="{{ filters.requester }}">
+  </div>
+  <div class="col">
+    <input class="form-control" type="date" name="start" value="{{ filters.start }}">
+  </div>
+  <div class="col">
+    <input class="form-control" type="date" name="end" value="{{ filters.end }}">
+  </div>
+  <div class="col-auto">
+    <button class="btn btn-secondary" type="submit">Filter</button>
+  </div>
+</form>
+<table class="table">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Subject</th>
+      <th>Status</th>
+      <th>Requester</th>
+      <th>Created</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for dif in difs %}
+    <tr>
+      <td><a href="{{ url_for('dif_detail', id=dif.id) }}">{{ dif.id }}</a></td>
+      <td>{{ dif.subject }}</td>
+      <td>{{ dif.status }}</td>
+      <td>{{ dif.requester.username if dif.requester else '' }}</td>
+      <td>{{ dif.created_at.strftime('%Y-%m-%d') }}</td>
+    </tr>
+    {% else %}
+    <tr><td colspan="5">No requests</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+<a class="btn btn-primary" href="{{ url_for('dif_new') }}">New DIF Request</a>
+{% endblock %}

--- a/portal/templates/dif/new.html
+++ b/portal/templates/dif/new.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block title %}New DIF Request{% endblock %}
+{% block content %}
+<h3>New DIF Request</h3>
+<form method="post" enctype="multipart/form-data">
+  <div class="mb-3">
+    <label class="form-label">Subject</label>
+    <input class="form-control{% if errors.subject %} is-invalid{% endif %}" type="text" name="subject" value="{{ form.subject }}">
+    {% if errors.subject %}<div class="invalid-feedback">{{ errors.subject }}</div>{% endif %}
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea class="form-control{% if errors.description %} is-invalid{% endif %}" name="description">{{ form.description }}</textarea>
+    {% if errors.description %}<div class="invalid-feedback">{{ errors.description }}</div>{% endif %}
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Impact</label>
+    <textarea class="form-control{% if errors.impact %} is-invalid{% endif %}" name="impact">{{ form.impact }}</textarea>
+    {% if errors.impact %}<div class="invalid-feedback">{{ errors.impact }}</div>{% endif %}
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Priority</label>
+    <input class="form-control" type="text" name="priority" value="{{ form.priority }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Related Document ID</label>
+    <input class="form-control" type="text" name="related_doc_id" value="{{ form.related_doc_id }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Attachment</label>
+    <input class="form-control" type="file" name="attachment">
+  </div>
+  <button class="btn btn-primary" type="submit">Submit</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add routes for creating, viewing and listing DIF requests with validation and storage
- create templates for DIF request form, details and list views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ada47fdc68832b859f46d4856de508