### PR TITLE
Notify DIF requester via email

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -3712,6 +3712,11 @@ def dif_new():
                 )
                 db.add(dif)
                 db.commit()
+                notify_user(
+                    dif.requester_id,
+                    "DİF Submitted",
+                    f"Request #{dif.id} created",
+                )
                 return redirect(url_for("dif_detail", id=dif.id))
             finally:
                 db.close()

--- a/tests/test_dif_notifications.py
+++ b/tests/test_dif_notifications.py
@@ -1,0 +1,40 @@
+import os
+import importlib
+from sqlalchemy.orm import sessionmaker
+
+
+def test_dif_creation_enqueues_email(monkeypatch):
+    # Set required environment variables before importing the app
+    os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+    os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+    os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+    os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+    rq = importlib.import_module("rq")
+    notifications = importlib.reload(importlib.import_module("notifications"))
+    q = rq.Queue("notifications")
+    monkeypatch.setattr(notifications, "queue", q)
+
+    app_module = importlib.reload(importlib.import_module("app"))
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    client = app_module.app.test_client()
+
+    models = importlib.import_module("models")
+    Session = sessionmaker(bind=models.engine)
+    sess = Session()
+    sess.add(models.User(id=1, username="u1", email="user@example.com"))
+    sess.commit()
+    sess.close()
+
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1}
+        sess["roles"] = [app_module.RoleEnum.CONTRIBUTOR.value]
+
+    payload = {
+        "subject": "My request",
+        "description": "desc",
+        "impact": "high",
+    }
+    resp = client.post("/dif/new", data=payload)
+    assert resp.status_code == 302
+    assert len(q.jobs) == 1


### PR DESCRIPTION
## Summary
- send a notification when a DIF request is created
- test that submitting a DIF enqueues a notification email

## Testing
- `pytest tests/test_dif_notifications.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ada78962a4832b9c18ce17a13dc0a4