### PR TITLE
Add overdue DIF workflow notification job

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,7 @@ services:
     command: >
       sh -c "pip install -r requirements.txt &&
              ( while :; do python archive_job.py; sleep 86400; done ) &
+             ( while :; do python dif_overdue_job.py; sleep 3600; done ) &
              ( while :; do python periodic_review.py; sleep 31536000; done ) &
              wait"
     depends_on: [ portal ]

--- a/portal/dif_overdue_job.py
+++ b/portal/dif_overdue_job.py
@@ -1,0 +1,36 @@
+"""Cron job to notify overdue DIF workflow steps."""
+from datetime import datetime, timedelta
+from models import get_session, DifWorkflowStep, User, Role
+from notifications import notify_dif_step_overdue
+
+
+def run() -> None:
+    """Scan for workflow steps exceeding their SLA and notify responsible users."""
+    session = get_session()
+    now = datetime.utcnow()
+    steps = (
+        session.query(DifWorkflowStep)
+        .filter(DifWorkflowStep.status == "Pending")
+        .filter(DifWorkflowStep.sla_hours != None)
+        .all()
+    )
+    for step in steps:
+        base = step.created_at or getattr(step.dif_request, "created_at", None)
+        if not base:
+            continue
+        if now - base > timedelta(hours=step.sla_hours or 0):
+            users = (
+                session.query(User.id)
+                .join(User.roles)
+                .filter(Role.name == step.role)
+                .all()
+            )
+            user_ids = [u.id for u in users]
+            notify_dif_step_overdue(step, user_ids)
+            step.status = "Overdue"
+    session.commit()
+    session.close()
+
+
+if __name__ == "__main__":
+    run()

--- a/portal/models.py
+++ b/portal/models.py
@@ -350,6 +350,7 @@ class DifWorkflowStep(Base):
     status = Column(String, default="Pending", nullable=False)
     acted_at = Column(DateTime)
     comment = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
 
     dif_request = relationship("DifRequest", back_populates="workflow_steps")
 

--- a/portal/notifications.py
+++ b/portal/notifications.py
@@ -220,6 +220,10 @@ _TEMPLATES = {
         "Document {title} requires your acknowledgement",
         "Please read and acknowledge document {title}.",
     ),
+    "dif_step_overdue": (
+        "DIF workflow step overdue",
+        "A workflow step for DIF request {dif_id} assigned to {role} is overdue.",
+    ),
 }
 
 
@@ -245,6 +249,14 @@ def notify_revision_time(doc, user_ids):
 
 def notify_mandatory_read(doc, user_ids):
     subject, body = _render("mandatory_read", title=doc.title)
+    for uid in user_ids:
+        notify_user(uid, subject, body)
+
+
+def notify_dif_step_overdue(step, user_ids):
+    subject, body = _render(
+        "dif_step_overdue", dif_id=step.dif_id, role=step.role
+    )
     for uid in user_ids:
         notify_user(uid, subject, body)
 

--- a/tests/test_dif_overdue_job.py
+++ b/tests/test_dif_overdue_job.py
@@ -1,0 +1,39 @@
+import importlib
+from datetime import datetime, timedelta
+from sqlalchemy.orm import sessionmaker
+
+def test_dif_overdue_job_notifies_and_marks(monkeypatch):
+    rq = importlib.import_module("rq")
+    notifications = importlib.reload(importlib.import_module("notifications"))
+    q = rq.Queue("notifications")
+    monkeypatch.setattr(notifications, "queue", q)
+    job_module = importlib.reload(importlib.import_module("dif_overdue_job"))
+    models = importlib.import_module("models")
+    Session = sessionmaker(bind=models.engine)
+    session = Session()
+    role = models.Role(name="reviewer")
+    user = models.User(username="rev", email="rev@example.com", roles=[role])
+    requester = models.User(username="req")
+    session.add_all([role, user, requester])
+    session.commit()
+    dif = models.DifRequest(subject="S", requester_id=requester.id)
+    session.add(dif)
+    session.commit()
+    step = models.DifWorkflowStep(
+        dif_id=dif.id,
+        role="reviewer",
+        step_order=1,
+        sla_hours=1,
+        status="Pending",
+        created_at=datetime.utcnow() - timedelta(hours=2),
+    )
+    session.add(step)
+    session.commit()
+    step_id = step.id
+    session.close()
+    job_module.run()
+    session = Session()
+    step_db = session.get(models.DifWorkflowStep, step_id)
+    assert step_db.status == "Overdue"
+    session.close()
+    assert len(q.jobs) == 1


### PR DESCRIPTION
## Summary
- track creation time for DIF workflow steps
- notify responsible roles when DIF steps exceed SLA and mark overdue
- schedule periodic DIF SLA job in docker compose

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adac985ad0832ba54adeb744fe2f59