### PR TITLE
Handle existing dif_request_status enum in migration

### DIFF
--- a/alembic/versions/0015_add_dif_requests.py
+++ b/alembic/versions/0015_add_dif_requests.py
@@ -23,6 +23,7 @@ def upgrade() -> None:
         "rejected",
         "implemented",
         name="dif_request_status",
+        create_type=False,
     )
     status.create(op.get_bind(), checkfirst=True)
     op.create_table(
@@ -49,5 +50,6 @@ def downgrade() -> None:
         "rejected",
         "implemented",
         name="dif_request_status",
+        create_type=False,
     )
     status.drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
## Summary
- prevent `dif_request_status` enum from being recreated during migration
- include matching drop logic on downgrade

## Testing
- `pytest tests/test_ack_assign_api.py::test_assign_acknowledgements_role_targets`

------
https://chatgpt.com/codex/tasks/task_e_68adb0e4d36c832bb93e7887e943196d