### PR TITLE
Prevent duplicate dif_request_status enum creation

### DIFF
--- a/alembic/versions/0015_add_dif_requests.py
+++ b/alembic/versions/0015_add_dif_requests.py
@@ -8,6 +8,7 @@ Create Date: 2025-09-07
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 revision = "0015"
 down_revision = "0014"
@@ -34,7 +35,7 @@ def upgrade() -> None:
         END$$;
         """
     )
-    status = sa.Enum(
+    status = postgresql.ENUM(
         "new",
         "in_review",
         "approved",


### PR DESCRIPTION
## Summary
- avoid recreating `dif_request_status` enum by using dialect-specific ENUM in migration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb7edd7ec832bb651736c5e4bf56b