### PR TITLE
Ensure quick search panel starts hidden and improve shortcut detection

### DIFF
--- a/portal/static/quick_search.js
+++ b/portal/static/quick_search.js
@@ -1,1 +1,106 @@
-const mockDocs = [{ title: 'Quality Manual v1', url: '/documents/1' },{ title: 'Safety Procedure v2', url: '/documents/2' },{ title: 'HR Policy v3', url: '/documents/3' },{ title: 'Document Control 1.0', url: '/documents/4' }];function filterDocs(query) {if (!query) return [];query = query.toLowerCase();return mockDocs.filter(d => d.title.toLowerCase().includes(query));}function highlight(text, query) {if (!query) return text;const re = new RegExp(`(${query})`, 'ig');return text.replace(re, '<mark>$1</mark>');}const panel = document.getElementById('quick-search-panel');const input = document.getElementById('quick-search-input');const resultsEl = document.getElementById('quick-search-results');let activeIndex = -1;let currentResults = [];function openPanel() {panel.classList.remove('d-none');input.value = '';resultsEl.innerHTML = '';activeIndex = -1;currentResults = [];input.focus();}function closePanel() {panel.classList.add('d-none');}document.addEventListener('keydown', (e) => {if (e.ctrlKey && e.key === '/') {e.preventDefault();openPanel();} else if (e.key === 'Escape' && !panel.classList.contains('d-none')) {closePanel();}});input.addEventListener('input', (e) => {const q = e.target.value.trim();const start = performance.now();currentResults = filterDocs(q);activeIndex = -1;renderResults(q);const elapsed = performance.now() - start;if (elapsed > 150) {console.warn('Search took longer than expected:', elapsed);}});function renderResults(query) {resultsEl.innerHTML = currentResults.map((doc, idx) => `<li class="list-group-item ${idx === activeIndex ? 'active' : ''}" data-index="${idx}" data-url="${doc.url}">${highlight(doc.title, query)}</li>`).join('');}input.addEventListener('keydown', (e) => {if (e.key === 'ArrowDown') {e.preventDefault();if (activeIndex < currentResults.length - 1) {activeIndex++;renderResults(input.value.trim());}} else if (e.key === 'ArrowUp') {e.preventDefault();if (activeIndex > 0) {activeIndex--;renderResults(input.value.trim());}} else if (e.key === 'Enter') {const selected = currentResults[activeIndex];if (selected) {window.location.href = selected.url;}}});resultsEl.addEventListener('click', (e) => {const li = e.target.closest('li[data-index]');if (li) {window.location.href = li.dataset.url;}});panel.addEventListener('click', (e) => {if (e.target === panel) {closePanel();}});
+const mockDocs = [
+  { title: 'Quality Manual v1', url: '/documents/1' },
+  { title: 'Safety Procedure v2', url: '/documents/2' },
+  { title: 'HR Policy v3', url: '/documents/3' },
+  { title: 'Document Control 1.0', url: '/documents/4' },
+];
+
+function filterDocs(query) {
+  if (!query) return [];
+  query = query.toLowerCase();
+  return mockDocs.filter((d) => d.title.toLowerCase().includes(query));
+}
+
+function highlight(text, query) {
+  if (!query) return text;
+  const re = new RegExp(`(${query})`, 'ig');
+  return text.replace(re, '<mark>$1</mark>');
+}
+
+const panel = document.getElementById('quick-search-panel');
+const input = document.getElementById('quick-search-input');
+const resultsEl = document.getElementById('quick-search-results');
+let activeIndex = -1;
+let currentResults = [];
+
+document.addEventListener('DOMContentLoaded', () => {
+  panel.classList.add('d-none');
+});
+
+function openPanel() {
+  panel.classList.remove('d-none');
+  input.value = '';
+  resultsEl.innerHTML = '';
+  activeIndex = -1;
+  currentResults = [];
+  input.focus();
+}
+
+function closePanel() {
+  panel.classList.add('d-none');
+}
+
+document.addEventListener('keydown', (e) => {
+  if (e.ctrlKey && e.key === '/' && !e.shiftKey) {
+    e.preventDefault();
+    openPanel();
+  } else if (e.key === 'Escape' && !panel.classList.contains('d-none')) {
+    closePanel();
+  }
+});
+
+input.addEventListener('input', (e) => {
+  const q = e.target.value.trim();
+  const start = performance.now();
+  currentResults = filterDocs(q);
+  activeIndex = -1;
+  renderResults(q);
+  const elapsed = performance.now() - start;
+  if (elapsed > 150) {
+    console.warn('Search took longer than expected:', elapsed);
+  }
+});
+
+function renderResults(query) {
+  resultsEl.innerHTML = currentResults
+    .map(
+      (doc, idx) =>
+        `<li class="list-group-item ${idx === activeIndex ? 'active' : ''}" data-index="${idx}" data-url="${doc.url}">${highlight(doc.title, query)}</li>`
+    )
+    .join('');
+}
+
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    if (activeIndex < currentResults.length - 1) {
+      activeIndex++;
+      renderResults(input.value.trim());
+    }
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    if (activeIndex > 0) {
+      activeIndex--;
+      renderResults(input.value.trim());
+    }
+  } else if (e.key === 'Enter') {
+    const selected = currentResults[activeIndex];
+    if (selected) {
+      window.location.href = selected.url;
+    }
+  }
+});
+
+resultsEl.addEventListener('click', (e) => {
+  const li = e.target.closest('li[data-index]');
+  if (li) {
+    window.location.href = li.dataset.url;
+  }
+});
+
+panel.addEventListener('click', (e) => {
+  if (e.target === panel) {
+    closePanel();
+  }
+});
+

--- a/tests/test_quick_search_panel.py
+++ b/tests/test_quick_search_panel.py
@@ -1,0 +1,27 @@
+import importlib
+import re
+
+
+def _client():
+    app_module = importlib.import_module("app")
+    return app_module.app.test_client()
+
+
+def _assert_panel_hidden(html: str):
+    pattern = r'id="quick-search-panel"[^>]*class="[^"]*\bd-none\b'
+    assert re.search(pattern, html)
+
+
+def test_terminology_page_panel_hidden():
+    client = _client()
+    resp = client.get("/terminology")
+    assert resp.status_code == 200
+    _assert_panel_hidden(resp.get_data(as_text=True))
+
+
+def test_help_page_panel_hidden():
+    client = _client()
+    resp = client.get("/help")
+    assert resp.status_code == 200
+    _assert_panel_hidden(resp.get_data(as_text=True))
+


### PR DESCRIPTION
## Summary
- Hide quick search panel on DOMContentLoaded
- Require explicit Ctrl + / to open quick search
- Test quick search panel stays hidden on terminology and help pages

## Testing
- `pytest tests/test_quick_search_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_68adbcfd4dbc832ba817a74af3845cb8