### PR TITLE
Handle missing documentation pages gracefully

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -597,6 +597,8 @@ def help_page():
     help_content = ""
     if docs_path.exists():
         help_content = docs_path.read_text(encoding="utf-8")
+    else:
+        return render_template("help.html", error="İçerik bulunamadı")
     return render_template("help.html", help_content=Markup(help_content))
 
 
@@ -606,6 +608,8 @@ def terminology_page():
     glossary_content = ""
     if docs_path.exists():
         glossary_content = docs_path.read_text(encoding="utf-8")
+    else:
+        return render_template("terminology.html", error="İçerik bulunamadı")
     return render_template(
         "terminology.html", terminology_content=Markup(glossary_content)
     )

--- a/portal/templates/help.html
+++ b/portal/templates/help.html
@@ -2,5 +2,9 @@
 {% block title %}Help{% endblock %}
 {% block content %}
 <h1>Help</h1>
+{% if error %}
+<p>{{ error }}</p>
+{% else %}
 {{ help_content | safe }}
+{% endif %}
 {% endblock %}

--- a/portal/templates/terminology.html
+++ b/portal/templates/terminology.html
@@ -2,5 +2,9 @@
 {% block title %}Terminoloji{% endblock %}
 {% block content %}
 <h1>Terminoloji</h1>
+{% if error %}
+<p>{{ error }}</p>
+{% else %}
 {{ terminology_content | safe }}
+{% endif %}
 {% endblock %}

--- a/tests/test_help_terminology_pages.py
+++ b/tests/test_help_terminology_pages.py
@@ -1,0 +1,73 @@
+import importlib
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _client():
+    app_module = importlib.import_module("app")
+    return app_module.app.test_client()
+
+
+def test_help_route_missing_file_returns_error():
+    client = _client()
+    original_exists = Path.exists
+
+    def fake_exists(self):
+        if self.name == "help.md":
+            return False
+        return original_exists(self)
+
+    with patch("app.Path.exists", fake_exists):
+        resp = client.get("/help")
+
+    assert resp.status_code == 200
+    assert "İçerik bulunamadı" in resp.get_data(as_text=True)
+
+
+def test_terminology_route_missing_file_returns_error():
+    client = _client()
+    original_exists = Path.exists
+
+    def fake_exists(self):
+        if self.name == "terminology.md":
+            return False
+        return original_exists(self)
+
+    with patch("app.Path.exists", fake_exists):
+        resp = client.get("/terminology")
+
+    assert resp.status_code == 200
+    assert "İçerik bulunamadı" in resp.get_data(as_text=True)
+
+
+def test_help_route_renders_content_when_present():
+    client = _client()
+    original_read = Path.read_text
+
+    def fake_read(self, encoding="utf-8"):
+        if self.name == "help.md":
+            return "yardim icerigi"
+        return original_read(self, encoding=encoding)
+
+    with patch("app.Path.read_text", fake_read):
+        resp = client.get("/help")
+
+    assert resp.status_code == 200
+    assert "yardim icerigi" in resp.get_data(as_text=True)
+
+
+def test_terminology_route_renders_content_when_present():
+    client = _client()
+    original_read = Path.read_text
+
+    def fake_read(self, encoding="utf-8"):
+        if self.name == "terminology.md":
+            return "terminoloji icerigi"
+        return original_read(self, encoding=encoding)
+
+    with patch("app.Path.read_text", fake_read):
+        resp = client.get("/terminology")
+
+    assert resp.status_code == 200
+    assert "terminoloji icerigi" in resp.get_data(as_text=True)
+


### PR DESCRIPTION
## Summary
- show informative error when help or terminology docs are missing
- display error placeholder in templates
- test routes for missing and present documentation

## Testing
- `pytest tests/test_help_terminology_pages.py tests/test_quick_search_panel.py -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68adbec7fc9c832b8914314401f54163