### PR TITLE
Add workflow comments and progress visualization

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1139,11 +1139,17 @@ def document_workflow(doc_id: int):
         .order_by(WorkflowStep.step_order)
         .all()
     )
+    total_steps = len(steps)
+    completed_steps = sum(1 for s in steps if s.status != "Pending")
+    progress_percent = int(completed_steps / total_steps * 100) if total_steps else 0
     html = render_template(
         "document_workflow.html",
         doc=doc,
         workflow=doc.workflow,
         steps=steps,
+        total_steps=total_steps,
+        completed_steps=completed_steps,
+        progress_percent=progress_percent,
         breadcrumbs=[
             {"title": "Home", "url": url_for("dashboard")},
             {"title": "Documents", "url": url_for("list_documents")},

--- a/portal/templates/document_workflow.html
+++ b/portal/templates/document_workflow.html
@@ -6,6 +6,11 @@
 <p>Current step: {{ workflow.current_step }}</p>
 {% endif %}
 {% if steps %}
+<div class="progress mb-3">
+  <div class="progress-bar" role="progressbar" style="width: {{ progress_percent }}%;" aria-valuenow="{{ completed_steps }}" aria-valuemin="0" aria-valuemax="{{ total_steps }}">
+    {{ completed_steps }}/{{ total_steps }}
+  </div>
+</div>
 <table class="table table-striped">
   <thead>
     <tr>
@@ -15,17 +20,25 @@
       <th title="Review or approval type">Type</th>
       <th title="Due date for step">Due</th>
       <th title="Current step status">Status</th>
+      <th title="Step comment">Comment</th>
     </tr>
   </thead>
   <tbody>
     {% for step in steps %}
-    <tr{% if workflow and step.step_order == workflow.current_step %} class="table-primary"{% endif %}>
+    {% set row_class = "" %}
+    {% if workflow and step.step_order == workflow.current_step %}
+      {% set row_class = "table-primary" %}
+    {% elif step.status != "Pending" %}
+      {% set row_class = "table-success" %}
+    {% endif %}
+    <tr class="{{ row_class }}">
       <td>{{ step.step_order }}</td>
       <td>{{ step.user.username if step.user else '' }}</td>
       <td>{{ step.required_role or '' }}</td>
       <td>{{ step.step_type }}</td>
       <td>{{ step.due_at.strftime('%Y-%m-%d') if step.due_at else '' }}</td>
       <td>{{ step.status }}</td>
+      <td>{{ step.comment or '' }}</td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- show per-step comments and progress bar on document workflow page
- expose workflow progress metrics from `document_workflow` route
- verify comments and progress indicators in tests

## Testing
- `pytest tests/test_document_workflow_page.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc3153384832ba94a56ca29c417ca