### PR TITLE
Build portal static assets at image build time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,9 @@ services:
       - elasticsearch
     networks: [qdms]
     volumes:
-      # Shared volume for built static assets
+      # Shared volume for static assets built at image creation. The contents
+      # are copied from the image into this volume on first run so nginx can
+      # serve them.
       - portal_static:/app/portal/static-dist
 
   scheduler:
@@ -135,7 +137,7 @@ services:
       - onlyoffice
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      # Serve static assets from the build output directory
+      # Serve static assets built at image creation
       - portal_static:/app/portal/static-dist:ro
       - nginx_cache:/var/cache/nginx
       # SSL sertifikası kullanacaksanız aşağıyı açın ve dosyaları koyun

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -17,9 +17,8 @@ COPY alembic ./alembic
 
 RUN pip install libsass rcssmin jsmin
 
-# Build static assets after the volume is mounted so nginx can serve them
-# from the shared ``portal_static`` volume. The build step previously ran at
-# image build time, but the runtime volume mount would hide the generated
-# files. Running the build here ensures the output is written into the
-# mounted directory.
-CMD ["sh", "-c", "python portal/static_build.py && alembic upgrade head && python portal/app.py"]
+# Build static assets during the image build so they can be copied into the
+# shared ``portal_static`` volume when the container starts.
+RUN python portal/static_build.py
+
+CMD ["sh", "-c", "alembic upgrade head && python portal/app.py"]


### PR DESCRIPTION
## Summary
- Build portal static assets during the Docker image build and start the app without rebuilding
- Clarify shared `portal_static` volume usage for portal and nginx services

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aea0450b2c832b919a2d58c46d46bc