### PR TITLE
Ensure search indices created at startup

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -57,6 +57,11 @@ def _run_migrations() -> None:
 
 _run_migrations()
 
+# Ensure search indices exist after migrations have been applied.
+from search import create_index
+
+create_index()
+
 # Serve static assets from the root ``static`` directory and load templates from the
 # project-level ``templates`` folder. Explicitly setting these paths ensures static
 # URLs such as ``/static/app.css`` resolve correctly in both the development server and

--- a/portal/search.py
+++ b/portal/search.py
@@ -148,6 +148,3 @@ def search_documents(keyword: str, filters: dict, page: int = 1, per_page: int =
     total = resp.get("hits", {}).get("total", {}).get("value", 0)
 
     return results, aggs, total
-
-
-create_index()


### PR DESCRIPTION
## Summary
- Create search indices during app startup after running migrations
- Remove search module side effects by eliminating module-level index creation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aea1199c6c832ba7e6983029195bf3