### PR TITLE
Add strict CSP headers for OnlyOffice and portal

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -29,6 +29,7 @@ http {
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options "DENY";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'" always;
 
     # 443 kullanacaksanız:
     # listen 443 ssl http2;
@@ -73,6 +74,7 @@ http {
       proxy_set_header X-Forwarded-Port $server_port;
       proxy_hide_header X-Frame-Options;
       add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; frame-ancestors 'self'" always;
     }
 
     # WebSocket yolları (OnlyOffice)


### PR DESCRIPTION
## Summary
- enforce global Content-Security-Policy and X-Frame-Options DENY
- allow OnlyOffice iframe with relaxed CSP and SAMEORIGIN frame option

## Testing
- `pytest`
- `nginx -t -c $(pwd)/nginx/nginx.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb2a34ab8832ba43ad23757d22169