### PR TITLE
Use presigned URLs for document downloads

### DIFF
--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -32,8 +32,9 @@
 
 <p>
   <a href="{{ url_for('list_documents') }}">Back to documents</a>
-  |
-  <a href="{{ url_for('download_document', doc_id=doc.id) }}">Download</a>
+  {% if download_url %}
+  | <a href="{{ download_url }}">Download</a>
+  {% endif %}
 </p>
 {% endblock %}
 

--- a/portal/templates/partials/documents/_versions.html
+++ b/portal/templates/partials/documents/_versions.html
@@ -25,7 +25,9 @@
           <button type="button" id="compare-to-button" class="btn btn-outline-primary mt-2"
             data-url="{{ url_for('compare_document_versions', doc_id=doc.id) }}"
             data-rev-id="{{ revision.id }}">Compare to…</button>
-          <a class="btn btn-outline-secondary mt-2" href="{{ url_for('download_document', doc_id=doc.id) }}">Download</a>
+          {% if download_url %}
+          <a class="btn btn-outline-secondary mt-2" href="{{ download_url }}">Download</a>
+          {% endif %}
         </div>
         {% else %}
         <div id="revision-note">

--- a/tests/test_files_route.py
+++ b/tests/test_files_route.py
@@ -24,6 +24,10 @@ def app_modules():
     app_module = importlib.reload(importlib.import_module("app"))
     models_module = importlib.reload(importlib.import_module("models"))
     app_module.app.config["WTF_CSRF_ENABLED"] = False
+    @app_module.app.route("/signed")
+    def signed():
+        return "signed-url"
+
     return app_module, models_module
 
 
@@ -57,16 +61,17 @@ def _setup_document(models, allow_download=True):
 def test_files_route_redirects_when_authorized(app_modules, client):
     app_module, models = app_modules
     _setup_document(models, allow_download=True)
-    app_module.storage_client.generate_presigned_url = MagicMock(return_value="https://signed")
-    resp = client.get("/files/foo/bar.txt")
-    assert resp.status_code == 302
-    assert resp.headers["Location"] == "https://signed"
+    app_module.storage_client.generate_presigned_url = MagicMock(return_value="/signed")
+    resp = client.get("/files/foo/bar.txt", follow_redirects=True)
+    assert resp.status_code == 200
+    assert resp.request.path == "/signed"
+    assert "signed-url" in resp.get_data(as_text=True)
 
 
 def test_files_route_returns_403_without_permission(app_modules, client):
     app_module, models = app_modules
     _setup_document(models, allow_download=False)
-    app_module.storage_client.generate_presigned_url = MagicMock(return_value="https://signed")
+    app_module.storage_client.generate_presigned_url = MagicMock(return_value="/signed")
     resp = client.get("/files/foo/bar.txt")
     assert resp.status_code == 403
 
@@ -74,7 +79,7 @@ def test_files_route_returns_403_without_permission(app_modules, client):
 def test_files_route_sets_cache_control_header(app_modules, client):
     app_module, models = app_modules
     _setup_document(models, allow_download=True)
-    app_module.storage_client.generate_presigned_url = MagicMock(return_value="https://signed")
+    app_module.storage_client.generate_presigned_url = MagicMock(return_value="/signed")
     resp = client.get("/files/foo/bar.txt")
     assert resp.status_code == 302
     assert resp.headers["Cache-Control"] == "public, max-age=86400"
@@ -89,7 +94,7 @@ def test_files_route_respects_size_limit(app_modules, client):
         backend, type(backend)
     )
     backend.client.head_object = MagicMock(return_value={"ContentLength": 51 * 1024 * 1024})
-    backend.client.generate_presigned_url = MagicMock(return_value="https://signed")
+    backend.client.generate_presigned_url = MagicMock(return_value="/signed")
     resp = client.get("/files/foo/bar.txt")
     assert resp.status_code == 404
     backend.client.generate_presigned_url.assert_not_called()


### PR DESCRIPTION
## Summary
- Generate presigned URLs in `document_detail` and pass as `download_url`
- Update templates to use provided `download_url`
- Remove obsolete `download_document` route and adapt tests to follow presigned links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aec0f8f1f0832bbaaf2f60d63d2bb5