### PR TITLE
Add archive retention test with moto

### DIFF
--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -18,3 +18,4 @@ PyJWT==2.8.0
 passlib
 pycryptodome
 alembic==1.13.1
+moto

--- a/tests/test_archive_retention.py
+++ b/tests/test_archive_retention.py
@@ -1,0 +1,33 @@
+import os
+import importlib
+from datetime import datetime
+
+import boto3
+import pytest
+
+moto = pytest.importorskip("moto")
+from moto import mock_s3
+
+
+def test_move_to_archive_retains_object_and_lists():
+    os.environ.pop("S3_ENDPOINT", None)
+    os.environ["S3_ACCESS_KEY"] = "test"
+    os.environ["S3_SECRET_KEY"] = "test"
+    os.environ["S3_BUCKET_MAIN"] = "qdms"
+    os.environ["S3_BUCKET_ARCHIVE"] = "qdms-archive"
+
+    with mock_s3():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket="qdms", ObjectLockEnabledForBucket=True)
+        client.create_bucket(Bucket="qdms-archive", ObjectLockEnabledForBucket=True)
+        client.put_object(Bucket="qdms", Key="sample.txt", Body=b"data")
+
+        storage = importlib.reload(importlib.import_module("storage"))
+        dest_key = storage.move_to_archive("sample.txt", retention_days=1)
+
+        head = client.head_object(Bucket="qdms-archive", Key=dest_key)
+        assert head["ObjectLockMode"] == "COMPLIANCE"
+        assert head["ObjectLockRetainUntilDate"] > datetime.utcnow()
+
+        assert dest_key in storage.list_archived()
+


### PR DESCRIPTION
## Summary
- add unit test using moto to verify `move_to_archive` applies object-lock retention and lists archived files
- add moto to dependencies

## Testing
- `pip install moto` *(fails: Could not find a version that satisfies the requirement moto)*
- `pytest tests/test_archive_retention.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aec6adede4832b9dd8d0a431d19668