### PR TITLE
Validate new document wizard inputs and show errors

### DIFF
--- a/portal/templates/documents/new_step1.html
+++ b/portal/templates/documents/new_step1.html
@@ -2,6 +2,9 @@
 {% block title %}New Document - Step 1{% endblock %}
 {% block content %}
 <h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">New Document - Step 1</h1>
+{% if errors %}
+<div class="alert alert-danger">Please correct the errors below.</div>
+{% endif %}
 <form method="post" action="{{ url_for('new_document', step=1) }}">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">

--- a/portal/templates/documents/new_step2.html
+++ b/portal/templates/documents/new_step2.html
@@ -7,6 +7,9 @@
 {% elif form.preview_url %}
 <div class="alert alert-success">Preview ready. <a href="{{ form.preview_url }}" target="_blank">View preview</a></div>
 {% endif %}
+{% if errors %}
+<div class="alert alert-danger">Please correct the errors below.</div>
+{% endif %}
 <form method="post" action="{{ url_for('new_document', step=2) }}" enctype="multipart/form-data">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
@@ -22,7 +25,7 @@
 
   <div class="mb-3">
     <label for="template" class="form-label">Template</label>
-    <select class="form-select" id="template" name="template" title="Select a template">
+    <select class="form-select{% if errors.template %} is-invalid{% endif %}" id="template" name="template" title="Select a template">
       <option value="">-- Select Template --</option>
       {% for group, files in template_options.items() %}
         <optgroup label="{{ group|capitalize }}">
@@ -32,11 +35,13 @@
         </optgroup>
       {% endfor %}
     </select>
+    {% if errors.template %}<div class="invalid-feedback">{{ errors.template }}</div>{% endif %}
   </div>
 
   <div class="mb-3">
     <label for="upload_file" class="form-label">Upload File</label>
-    <input type="file" class="form-control" id="upload_file" name="upload_file" title="Upload document file">
+    <input type="file" class="form-control{% if errors.upload_file %} is-invalid{% endif %}" id="upload_file" name="upload_file" title="Upload document file">
+    {% if errors.upload_file %}<div class="invalid-feedback">{{ errors.upload_file }}</div>{% endif %}
   </div>
 
   <div class="mb-3 form-check">

--- a/portal/templates/documents/new_step3.html
+++ b/portal/templates/documents/new_step3.html
@@ -12,6 +12,15 @@
 {% elif form.uploaded_file_key %}
 <div class="alert alert-success">File uploaded successfully.</div>
 {% endif %}
+{% if errors %}
+<div class="alert alert-danger">
+  <ul class="mb-0">
+    {% for msg in errors.values() %}
+    <li>{{ msg }}</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
 <form method="post" action="{{ url_for('new_document', step=3) }}">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <p><strong>Code:</strong> {{ form.code }}</p>

--- a/tests/test_new_document_session.py
+++ b/tests/test_new_document_session.py
@@ -26,6 +26,7 @@ def test_upload_does_not_bloat_cookie():
         "title": "My Doc",
         "type": "T",
         "department": "Dept",
+        "standard": "ISO9001",
         "tags": "",
     }
     resp = client.post("/documents/new?step=1", data=step1_data)


### PR DESCRIPTION
## Summary
- validate required fields before advancing in the new document wizard
- display field and general submission errors in step templates
- surface missing upload and API errors on final step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aecda9f014832b996f42508b6e44e6