### PR TITLE
Preserve department/type across document creation steps

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -999,12 +999,6 @@ def new_document():
 
         if step == "2":
             data.update(request.form.to_dict())
-            data["department"] = data.get("department", "").strip()
-            if not data["department"]:
-                errors["department"] = "Department is required"
-            data["type"] = data.get("type", "").strip()
-            if not data["type"]:
-                errors["type"] = "Type is required"
             data["template"] = request.form.get("template", "").strip()
             data["generate_docxf"] = bool(request.form.get("generate_docxf"))
             uploaded = request.files.get("upload_file")

--- a/portal/templates/documents/new_step2.html
+++ b/portal/templates/documents/new_step2.html
@@ -12,16 +12,6 @@
 {% endif %}
 <form method="post" action="{{ url_for('new_document', step=2) }}" enctype="multipart/form-data">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-  <div class="mb-3">
-    <label for="department" class="form-label">Department</label>
-    <input type="text" class="form-control{% if errors.department %} is-invalid{% endif %}" id="department" name="department" value="{{ form.department or '' }}" title="Responsible department">
-    {% if errors.department %}<div class="invalid-feedback">{{ errors.department }}</div>{% endif %}
-  </div>
-  <div class="mb-3">
-    <label for="type" class="form-label">Type</label>
-    <input type="text" class="form-control{% if errors.type %} is-invalid{% endif %}" id="type" name="type" value="{{ form.type or '' }}" title="Document type">
-    {% if errors.type %}<div class="invalid-feedback">{{ errors.type }}</div>{% endif %}
-  </div>
 
   <div class="mb-3">
     <label for="template" class="form-label">Template</label>
@@ -53,14 +43,6 @@
 
 <script type="module">
   import { attachHelpText, attachTooltip } from '{{ url_for('static', filename='forms/index.js') }}';
-
-  const departmentInput = document.getElementById('department');
-  attachHelpText(departmentInput, 'Department responsible for the document.');
-  attachTooltip(departmentInput, 'Responsible department');
-
-  const typeInput = document.getElementById('type');
-  attachHelpText(typeInput, 'Type of document.');
-  attachTooltip(typeInput, 'Document type');
 
   const templateSelect = document.getElementById('template');
   attachHelpText(templateSelect, 'Select a template to start from.');

--- a/tests/test_new_document_session.py
+++ b/tests/test_new_document_session.py
@@ -41,3 +41,45 @@ def test_upload_does_not_bloat_cookie():
 
     cookie = resp.headers.get("Set-Cookie", "")
     assert len(cookie) < 4093
+
+
+def test_final_payload_includes_department_and_type():
+    app_module = importlib.reload(importlib.import_module("app"))
+    app_module.app.config.update(WTF_CSRF_ENABLED=False)
+    client = app_module.app.test_client()
+
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1, "username": "tester"}
+        sess["roles"] = [app_module.RoleEnum.CONTRIBUTOR.value]
+
+    step1_data = {
+        "code": "DOC-2",
+        "title": "Other Doc",
+        "type": "Process",
+        "department": "QA",
+        "standard": "ISO9001",
+        "tags": "",
+    }
+    resp = client.post("/documents/new?step=1", data=step1_data)
+    assert resp.status_code == 302
+
+    file = (io.BytesIO(b"content"), "file.txt")
+    resp = client.post(
+        "/documents/new?step=2",
+        data={"upload_file": file},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 302
+
+    captured = {}
+
+    def fake_create_document_api():
+        captured.update(app_module.request.get_json() or {})
+        return app_module.jsonify({"id": 1}), 201
+
+    app_module.create_document_api = fake_create_document_api
+
+    resp = client.post("/documents/new?step=3")
+    assert resp.status_code == 302
+    assert captured["department"] == step1_data["department"]
+    assert captured["type"] == step1_data["type"]


### PR DESCRIPTION
## Summary
- remove department/type fields from step 2 form and logic
- maintain department/type from step 1 and include when creating documents
- add regression test for preserving department/type across steps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedbc009d0832ba960c0a7d552f67c