### PR TITLE
Add reassign modal for approvals

### DIFF
--- a/portal/templates/partials/approvals/_reassign_modal.html
+++ b/portal/templates/partials/approvals/_reassign_modal.html
@@ -1,0 +1,34 @@
+<div class="modal fade" id="reassignModal-{{ step.id }}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Reassign "{{ step.document.title }}"?</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form hx-post="/api/approvals/{{ step.id }}/reassign" hx-target="#step-{{ step.id }}" hx-swap="outerHTML"
+            hx-headers='{"Content-Type":"application/json"}'
+            hx-vals="js:{user_id: this.querySelector('input[name=user_id]').value,
+                          role: this.querySelector('input[name=role]').value,
+                          comment: this.querySelector('textarea[name=comment]').value}">
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">User ID</label>
+            <input type="number" class="form-control" name="user_id" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Role</label>
+            <input type="text" class="form-control" name="role" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Comment (optional)</label>
+            <textarea class="form-control" name="comment" rows="3"></textarea>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-secondary" data-bs-dismiss="modal" data-bs-toggle="tooltip" title="Reassign this step">Reassign</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/portal/templates/partials/approvals/_row.html
+++ b/portal/templates/partials/approvals/_row.html
@@ -10,11 +10,7 @@
     {% if step.status == 'Pending' %}
     <button id="approve-{{ step.id }}" class="btn btn-success btn-sm" hx-post="/api/approvals/{{ step.id }}/approve" hx-target="#step-{{ step.id }}" hx-swap="outerHTML" title="Approve this step">Approve</button>
     <button id="reject-{{ step.id }}" class="btn btn-danger btn-sm" hx-post="/api/approvals/{{ step.id }}/reject" hx-target="#step-{{ step.id }}" hx-swap="outerHTML" title="Reject this step">Reject</button>
-    <form id="reassign-form-{{ step.id }}" class="d-inline" hx-post="/api/approvals/{{ step.id }}/reassign" hx-target="#step-{{ step.id }}" hx-swap="outerHTML">
-      <input type="number" name="user_id" class="form-control form-control-sm d-inline" placeholder="User ID">
-      <input type="text" name="role" class="form-control form-control-sm d-inline" placeholder="Role">
-      <button id="reassign-{{ step.id }}" type="submit" class="btn btn-secondary btn-sm" title="Reassign this step">Reassign</button>
-    </form>
+    <button id="reassign-{{ step.id }}" class="btn btn-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#reassignModal-{{ step.id }}" title="Reassign this step">Reassign</button>
     <script type="module">
       import { attachTooltip } from '{{ url_for('static', filename='forms/index.js') }}';
       attachTooltip(document.getElementById('approve-{{ step.id }}'), 'Approve this step');

--- a/portal/templates/partials/approvals/_table.html
+++ b/portal/templates/partials/approvals/_table.html
@@ -24,4 +24,5 @@
   {% include 'partials/approvals/_modal.html' %}
   {% set action = 'reject' %}
   {% include 'partials/approvals/_modal.html' %}
+  {% include 'partials/approvals/_reassign_modal.html' %}
 {% endfor %}


### PR DESCRIPTION
## Summary
- add a modal for reassigning approval steps with user/role and optional comment
- replace inline reassign form with button that launches the modal
- include reassign modal in approvals table rendering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aedf067df4832bb49afbb1b45cd38b