### PR TITLE
Return JSON publish errors and display alert

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -2948,9 +2948,9 @@ def publish_document(id: int):
     try:
         doc = db.get(Document, id)
         if not doc:
-            return "Not found", 404
+            return jsonify({"error": "Not found"}), 404
         if doc.status != "Approved":
-            return "Document not approved", 400
+            return jsonify({"error": "Document not approved"}), 400
         pending = (
             db.query(WorkflowStep)
             .filter(
@@ -2960,7 +2960,7 @@ def publish_document(id: int):
             .count()
         )
         if pending > 0:
-            return "Document not approved", 400
+            return jsonify({"error": "Document has pending steps"}), 400
         doc.status = "Published"
         user_ids = set()
         for uid in request.form.getlist("users"):

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -80,5 +80,21 @@
 </div>
 
 <script type="module" src="{{ url_for('static', filename='document_detail.js') }}"></script>
+<script>
+document.addEventListener('htmx:responseError', function (evt) {
+  if (evt.target.id === 'publish-form') {
+    let message = 'Failed to publish document';
+    try {
+      const data = JSON.parse(evt.detail.xhr.responseText);
+      if (data && data.error) {
+        message = data.error;
+      }
+    } catch (e) {
+      // ignore JSON parse errors
+    }
+    alert(message);
+  }
+});
+</script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Return JSON-formatted errors in `publish_document` when document is missing, unapproved, or has pending steps
- Add client-side handler on document detail page to surface publish errors as alerts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aedfb20600832b87046ae4f20473f6