### PR TITLE
Add HTMX-based acknowledgement assignment modal

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1231,6 +1231,11 @@ def document_detail(doc_id: int | None = None, id: int | None = None):
         .order_by(AuditLog.at.desc())
         .all()
     )
+
+    roles = db.query(Role).order_by(Role.name).all()
+    users = db.query(User).order_by(User.username).all()
+    ack_count = db.query(Acknowledgement).filter_by(doc_id=doc.id).count()
+
     db.close()
 
     user = session.get("user")
@@ -1298,6 +1303,9 @@ def document_detail(doc_id: int | None = None, id: int | None = None):
         preview=preview,
         logs=logs,
         download_url=download_url,
+        roles=roles,
+        users=users,
+        ack_count=ack_count,
     )
 
 

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -13,7 +13,7 @@
   {% endif %}
   {% if doc.status == 'Published' %}
   <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#assignModal">
-    Assign Mandatory Reading
+    Assign Mandatory Reading <span class="badge bg-secondary" id="assignment-count">{{ ack_count }}</span>
   </button>
   {% endif %}
 </div>
@@ -58,7 +58,7 @@
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
-      <form id="assign-form">
+      <form id="assign-form" hx-post="/api/ack/assign" hx-swap="none">
         <div class="modal-header">
           <h5 class="modal-title">Assign Mandatory Reading</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -66,8 +66,24 @@
         <div class="modal-body">
           <input type="hidden" name="doc_id" value="{{ doc.id }}">
           <div class="mb-3">
-            <label class="form-label" for="assign-targets">Targets (roles or user IDs, comma separated)</label>
-            <input type="text" class="form-control" id="assign-targets" name="targets">
+            <label class="form-label">Roles</label>
+            {% for role in roles %}
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="role-{{ role.id }}" name="targets" value="{{ role.name }}">
+              <label class="form-check-label" for="role-{{ role.id }}">{{ role.name }}</label>
+            </div>
+            {% endfor %}
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Users</label>
+            <div class="overflow-auto" style="max-height: 200px;">
+              {% for user in users %}
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="user-{{ user.id }}" name="targets" value="{{ user.id }}">
+                <label class="form-check-label" for="user-{{ user.id }}">{{ user.username }}</label>
+              </div>
+              {% endfor %}
+            </div>
           </div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
## Summary
- Display roles and users as checkboxes in a new assignment modal with badge for existing count
- Use HTMX to submit acknowledgement assignments and show toast feedback
- Include roles/users/count in document detail view context

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*
- `pytest tests/test_ack_assign_api.py::test_assign_acknowledgements_role_targets -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee0bcfd6c832ba19a5437870ccf83