### PR TITLE
Use toolbar wrappers for navigation links

### DIFF
--- a/portal/static/toolbar/toolbar.css
+++ b/portal/static/toolbar/toolbar.css
@@ -1,1 +1,5 @@
-[data-component="toolbar"] {display: flex;gap: 0.5rem;}
+[data-component="toolbar"] {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}

--- a/portal/templates/approvals/detail.html
+++ b/portal/templates/approvals/detail.html
@@ -1,7 +1,11 @@
 {% extends "base.html" %}
 {% block title %}Approval Detail{% endblock %}
 {% block page_actions %}
-<a class="btn btn-secondary" href="{{ url_for('approval_queue') }}">Back</a>
+<link rel="stylesheet" href="{{ url_for('static', filename='toolbar/toolbar.css') }}">
+<div class="toolbar" data-component="toolbar">
+  <a class="btn btn-secondary" href="{{ url_for('approval_queue') }}">Back</a>
+</div>
+<script type="module" src="{{ url_for('static', filename='toolbar/toolbar.js') }}"></script>
 {% endblock %}
 {% block content %}
 <div class="alert alert-info mb-3">Review the document, add a comment, then choose to approve or reject.</div>

--- a/portal/templates/dif/detail.html
+++ b/portal/templates/dif/detail.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 {% block title %}DIF {{ dif.id }}{% endblock %}
+{% block page_actions %}
+<link rel="stylesheet" href="{{ url_for('static', filename='toolbar/toolbar.css') }}">
+<script type="module" src="{{ url_for('static', filename='toolbar/toolbar.js') }}"></script>
+{% endblock %}
 {% block content %}
 <h3>{{ dif.subject }}</h3>
 {% include "partials/dif/_status.html" %}
@@ -20,7 +24,9 @@
 <p><strong>Description:</strong> {{ dif.description }}</p>
 <p><strong>Impact:</strong> {{ dif.impact }}</p>
 {% if attachment_url %}
-<p><a href="{{ attachment_url }}">Download Attachment</a></p>
+<div class="toolbar" data-component="toolbar">
+  <a class="btn btn-secondary" href="{{ attachment_url }}">Download Attachment</a>
+</div>
 {% endif %}
 {% include "partials/_audit_log.html" %}
 {% endblock %}

--- a/portal/templates/document_compare.html
+++ b/portal/templates/document_compare.html
@@ -1,9 +1,15 @@
 {% extends "base.html" %}
 {% block title %}Compare Versions{% endblock %}
+{% block page_actions %}
+<link rel="stylesheet" href="{{ url_for('static', filename='toolbar/toolbar.css') }}">
+<script type="module" src="{{ url_for('static', filename='toolbar/toolbar.js') }}"></script>
+{% endblock %}
 {% block content %}
 <h1>Version Comparison</h1>
 <div class="mb-3">
   {{ diff|safe }}
 </div>
-<a class="btn btn-secondary" href="{{ url_for('document_detail', doc_id=doc_id) }}">Back</a>
+<div class="toolbar" data-component="toolbar">
+  <a class="btn btn-secondary" href="{{ url_for('document_detail', doc_id=doc_id) }}">Back</a>
+</div>
 {% endblock %}

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -10,10 +10,16 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <button type="submit" class="btn btn-primary">Publish</button>
   </form>
+  {% else %}
+  <button type="button" class="btn btn-primary" disabled>Publish</button>
   {% endif %}
   {% if doc.status == 'Published' %}
   <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#assignModal">
     Assign Mandatory Reading <span class="badge bg-secondary" id="assignment-count">{{ ack_count }}</span>
+  </button>
+  {% else %}
+  <button type="button" class="btn btn-outline-primary" disabled>
+    Assign Mandatory Reading <span class="badge bg-secondary" id="assignment-count">{{ ack_count | default(0) }}</span>
   </button>
   {% endif %}
 </div>
@@ -48,12 +54,12 @@
 
 {% include "partials/_audit_log.html" %}
 
-<p>
-  <a href="{{ url_for('list_documents') }}">Back to documents</a>
+<div class="toolbar" data-component="toolbar">
+  <a class="btn btn-secondary" href="{{ url_for('list_documents') }}">Back to documents</a>
   {% if download_url %}
-  | <a href="{{ download_url }}">Download</a>
+  <a class="btn btn-secondary" href="{{ download_url }}">Download</a>
   {% endif %}
-</p>
+</div>
 
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">

--- a/portal/templates/documents/edit.html
+++ b/portal/templates/documents/edit.html
@@ -1,9 +1,13 @@
 {% extends "base.html" %}
 {% block title %}Edit Document{% endblock %}
 {% block page_actions %}
-<a class="btn btn-secondary" href="{{ url_for('document_detail', doc_id=doc_id) }}">Back</a>
-<a class="btn btn-secondary" href="{{ url_for('document_detail', doc_id=doc_id) }}#versions">Versions</a>
-<a class="btn btn-secondary" href="{{ url_for('compare_document_versions', doc_id=doc_id) }}">Compare</a>
+<link rel="stylesheet" href="{{ url_for('static', filename='toolbar/toolbar.css') }}">
+<div class="toolbar" data-component="toolbar">
+  <a class="btn btn-secondary" href="{{ url_for('document_detail', doc_id=doc_id) }}">Back</a>
+  <a class="btn btn-secondary" href="{{ url_for('document_detail', doc_id=doc_id) }}#versions">Versions</a>
+  <a class="btn btn-secondary" href="{{ url_for('compare_document_versions', doc_id=doc_id) }}">Compare</a>
+</div>
+<script type="module" src="{{ url_for('static', filename='toolbar/toolbar.js') }}"></script>
 {% endblock %}
 {% block content %}
 <div id="editor-container" class="vh-100 overflow-auto">


### PR DESCRIPTION
## Summary
- Wrap back and download links across templates in a shared `toolbar` container
- Add disabled placeholders for Publish and Assign Mandatory Reading buttons on document detail view
- Align toolbar items via minimal CSS for consistent spacing

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*
- `pip install 'moto<5'` *(fails: Could not find a version that satisfies the requirement moto<5)*

------
https://chatgpt.com/codex/tasks/task_e_68aeed95544c832ba0d1c23e6e6387dc