### PR TITLE
Clean up uploads on document creation cancel

### DIFF
--- a/portal/templates/documents/new_step3.html
+++ b/portal/templates/documents/new_step3.html
@@ -35,6 +35,7 @@ Object.values(errors).flat().forEach(msg => showToast(msg, { timeout: 6000 }));
   <p><strong>Standard:</strong> {{ standard_map.get(form.standard, form.standard) }}</p>
   <button type="submit" class="btn btn-primary">{% if form.generate_docxf %}View Document{% else %}Create{% endif %}</button>
   {% if not form.generate_docxf %}<button type="button" id="save-draft" class="btn btn-secondary ms-2">Taslak olarak kaydet</button>{% endif %}
+  <button type="submit" name="cancel" value="1" class="btn btn-secondary ms-2">Cancel</button>
 </form>
 {% if not form.generate_docxf %}
 <script type="module">


### PR DESCRIPTION
## Summary
- track uploaded file key in session and delete it from storage on cancel or restart
- add Cancel button to step 3 of new document flow
- test cancel behaviour and ensure session cleanup

## Testing
- `pytest tests/test_new_document_session.py tests/test_document_upload_key_extension.py`
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68aef0339a18832ba9e5a9172f051f07