### PR TITLE
Use dynamic CSRF token and handle 403

### DIFF
--- a/portal/templates/documents/new_step3.html
+++ b/portal/templates/documents/new_step3.html
@@ -58,14 +58,19 @@ document.getElementById('save-draft').addEventListener('click', async () => {
     showToast('Dosya yüklenemedi', { timeout: 6000 });
     return;
   }
+  const csrf = document.querySelector('input[name=csrf_token]').value;
   const response = await fetch('/api/documents', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'X-CSRFToken': '{{ csrf_token() }}'
+      'X-CSRFToken': csrf
     },
     body: JSON.stringify(data)
   });
+  if (response.status === 403) {
+    showToast('Oturumunuz sonlandı. Lütfen sayfayı yenileyin.', { timeout: 6000 });
+    return;
+  }
   const result = await response.json();
   if (result.id) {
     showToast('Doküman başarıyla yüklendi ve onaya gönderildi');


### PR DESCRIPTION
## Summary
- load CSRF token from hidden input when saving draft
- show toast prompting user to refresh on 403 responses

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68aef6415b14832b9faa2ee69faab72e