### PR TITLE
Prefix approval modal IDs with step context

### DIFF
--- a/portal/templates/approval_queue.html
+++ b/portal/templates/approval_queue.html
@@ -38,8 +38,8 @@
       <td class="status">{{ step.status }}</td>
       <td>
         {% if step.status == 'Pending' %}
-        <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#approveModal-{{ step.id }}">Approve</button>
-        <button class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#rejectModal-{{ step.id }}">Reject</button>
+        <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#step-{{ step.id }}-approve-modal">Approve</button>
+        <button class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#step-{{ step.id }}-reject-modal">Reject</button>
         {% with action='approve' %}{% include 'partials/approvals/_modal.html' %}{% endwith %}
         {% with action='reject' %}{% include 'partials/approvals/_modal.html' %}{% endwith %}
         {% else %}

--- a/portal/templates/partials/approvals/_modal.html
+++ b/portal/templates/partials/approvals/_modal.html
@@ -1,4 +1,4 @@
-<div class="modal fade" id="{{ action }}Modal-{{ step.id }}" tabindex="-1" aria-hidden="true">
+<div class="modal fade" id="step-{{ step.id }}-{{ action }}-modal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/portal/templates/partials/approvals/_queue_body.html
+++ b/portal/templates/partials/approvals/_queue_body.html
@@ -7,8 +7,8 @@
   <td class="status">{{ step.status }}</td>
   <td>
     {% if step.status == 'Pending' %}
-    <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#approveModal-{{ step.id }}">Approve</button>
-    <button class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#rejectModal-{{ step.id }}">Reject</button>
+    <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#step-{{ step.id }}-approve-modal">Approve</button>
+    <button class="btn btn-danger btn-sm" data-bs-toggle="modal" data-bs-target="#step-{{ step.id }}-reject-modal">Reject</button>
     {% with action='approve' %}{% include 'partials/approvals/_modal.html' %}{% endwith %}
     {% with action='reject' %}{% include 'partials/approvals/_modal.html' %}{% endwith %}
     {% else %}

--- a/portal/templates/partials/approvals/_reassign_modal.html
+++ b/portal/templates/partials/approvals/_reassign_modal.html
@@ -1,4 +1,4 @@
-<div class="modal fade" id="reassignModal-{{ step.id }}" tabindex="-1" aria-hidden="true">
+<div class="modal fade" id="step-{{ step.id }}-reassign-modal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/portal/templates/partials/approvals/_row.html
+++ b/portal/templates/partials/approvals/_row.html
@@ -10,7 +10,7 @@
     {% if step.status == 'Pending' %}
     <button id="approve-{{ step.id }}" class="btn btn-success btn-sm" hx-post="/api/approvals/{{ step.id }}/approve" hx-target="#step-{{ step.id }}" hx-swap="outerHTML" title="Approve this step">Approve</button>
     <button id="reject-{{ step.id }}" class="btn btn-danger btn-sm" hx-post="/api/approvals/{{ step.id }}/reject" hx-target="#step-{{ step.id }}" hx-swap="outerHTML" title="Reject this step">Reject</button>
-    <button id="reassign-{{ step.id }}" class="btn btn-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#reassignModal-{{ step.id }}" title="Reassign this step">Reassign</button>
+    <button id="reassign-{{ step.id }}" class="btn btn-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#step-{{ step.id }}-reassign-modal" title="Reassign this step">Reassign</button>
     <script type="module">
       import { attachTooltip } from '{{ url_for('static', filename='forms/index.js') }}';
       attachTooltip(document.getElementById('approve-{{ step.id }}'), 'Approve this step');

--- a/tests/test_modal_ids.py
+++ b/tests/test_modal_ids.py
@@ -1,0 +1,65 @@
+import os
+import importlib
+from pathlib import Path
+import sys
+import re
+import pytest
+
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+
+@pytest.fixture()
+def app_models():
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    models_module.Base.metadata.create_all(bind=models_module.engine)
+    return app_module.app, models_module
+
+
+@pytest.fixture()
+def client(app_models):
+    app, _ = app_models
+    return app.test_client()
+
+
+def test_modal_ids_unique(client, app_models):
+    _, m = app_models
+    session = m.SessionLocal()
+    user = m.User(username="approver")
+    doc1 = m.Document(doc_key="doc1.docx", title="Doc1", status="Review")
+    doc2 = m.Document(doc_key="doc2.docx", title="Doc2", status="Review")
+    session.add_all([user, doc1, doc2])
+    session.commit()
+    step1 = m.WorkflowStep(doc_id=doc1.id, step_order=1, user_id=user.id, status="Pending", step_type="approval")
+    step2 = m.WorkflowStep(doc_id=doc2.id, step_order=1, user_id=user.id, status="Pending", step_type="approval")
+    session.add_all([step1, step2])
+    session.commit()
+    user_id = user.id
+    step1_id = step1.id
+    step2_id = step2.id
+    session.close()
+
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": user_id}
+        sess["roles"] = ["approver"]
+
+    resp = client.get("/approvals")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    for sid in (step1_id, step2_id):
+        assert html.count(f'id="step-{sid}-approve-modal"') == 1
+        assert html.count(f'id="step-{sid}-reject-modal"') == 1
+        assert html.count(f'id="step-{sid}-reassign-modal"') == 1
+        assert html.count(f'data-bs-target="#step-{sid}-reassign-modal"') == 1
+
+    modal_ids = re.findall(r'id="(step-\d+-(?:approve|reject|reassign)-modal)"', html)
+    assert len(modal_ids) == len(set(modal_ids))


### PR DESCRIPTION
## Summary
- scope approval modal IDs by step and action
- update buttons to target new scoped modal IDs
- cover approval page with test ensuring modal IDs are unique per step

## Testing
- `pytest tests/test_modal_ids.py -q`
- `pytest tests/test_approvals_api.py::test_api_approve_step -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef7069ca8832bb8c1db2dd3429775