### PR TITLE
feat: localize document upload messages

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -39,6 +39,7 @@ from reports import (build_report, pending_approvals_report, revision_report,
 from search import index_document, search_documents
 from signing import create_signed_pdf
 from storage import generate_presigned_url, storage_client
+from translations import t
 
 
 # Automatically run database migrations in non-SQLite environments.
@@ -129,7 +130,12 @@ def inject_user():
     user = session.get("user")
     def has_role(role):
         return role in roles
-    return {"current_user": user, "user_roles": roles, "has_role": has_role}
+    return {
+        "current_user": user,
+        "user_roles": roles,
+        "has_role": has_role,
+        "t": t,
+    }
 
 # -- Preview configuration -------------------------------------------------
 #

--- a/portal/templates/documents/new_step3.html
+++ b/portal/templates/documents/new_step3.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
-{% block title %}New Document - Step 3{% endblock %}
+{% block title %}{{ t('new_document_step3_title') }}{% endblock %}
 {% block content %}
-<h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">New Document - Step 3</h1>
+<h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">{{ t('new_document_step3_title') }}</h1>
 {% if form.docxf_error %}
-<div class="alert alert-danger">Generation failed: {{ form.docxf_error }}</div>
+<div class="alert alert-danger">{{ t('generation_failed', error=form.docxf_error) }}</div>
 {% elif form.preview_url %}
-<div class="alert alert-success">Document generated successfully.</div>
+<div class="alert alert-success">{{ t('document_generated_success') }}</div>
 <div class="mb-3"><iframe src="{{ form.preview_url }}" class="w-100" style="height:600px;"></iframe></div>
 {% elif form.upload_error %}
-<div class="alert alert-danger">Upload failed: {{ form.upload_error }}</div>
+<div class="alert alert-danger">{{ t('upload_failed', error=form.upload_error) }}</div>
 {% elif form.uploaded_file_key %}
-<div class="alert alert-success">File uploaded successfully.</div>
+<div class="alert alert-success">{{ t('file_uploaded_success') }}</div>
 {% endif %}
 {% if errors %}
 <div class="alert alert-danger">
@@ -28,18 +28,24 @@ Object.values(errors).flat().forEach(msg => showToast(msg, { timeout: 6000 }));
 {% endif %}
 <form method="post" action="{{ url_for('new_document', step=3) }}">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-  <p><strong>Code:</strong> {{ form.code }}</p>
-  <p><strong>Title:</strong> {{ form.title }}</p>
-  <p><strong>Department:</strong> {{ form.department }}</p>
-  <p><strong>Type:</strong> {{ form.type }}</p>
-  <p><strong>Standard:</strong> {{ standard_map.get(form.standard, form.standard) }}</p>
-  <button type="submit" class="btn btn-primary">{% if form.generate_docxf %}View Document{% else %}Create{% endif %}</button>
-  {% if not form.generate_docxf %}<button type="button" id="save-draft" class="btn btn-secondary ms-2">Taslak olarak kaydet</button>{% endif %}
-  <button type="submit" name="cancel" value="1" class="btn btn-secondary ms-2">Cancel</button>
+  <p><strong>{{ t('code_label') }}:</strong> {{ form.code }}</p>
+  <p><strong>{{ t('title_label') }}:</strong> {{ form.title }}</p>
+  <p><strong>{{ t('department_label') }}:</strong> {{ form.department }}</p>
+  <p><strong>{{ t('type_label') }}:</strong> {{ form.type }}</p>
+  <p><strong>{{ t('standard_label') }}:</strong> {{ standard_map.get(form.standard, form.standard) }}</p>
+  <button type="submit" class="btn btn-primary">{% if form.generate_docxf %}{{ t('view_document') }}{% else %}{{ t('create') }}{% endif %}</button>
+  {% if not form.generate_docxf %}<button type="button" id="save-draft" class="btn btn-secondary ms-2">{{ t('save_draft') }}</button>{% endif %}
+  <button type="submit" name="cancel" value="1" class="btn btn-secondary ms-2">{{ t('cancel') }}</button>
 </form>
 {% if not form.generate_docxf %}
 <script type="module">
 import { showToast } from '{{ url_for('static', filename='components/index.js') }}';
+const messages = {
+  fileNotUploaded: {{ t('file_not_uploaded') | tojson }},
+  sessionEnded: {{ t('session_ended') | tojson }},
+  documentUploaded: {{ t('document_uploaded_for_approval') | tojson }},
+  documentCreateError: {{ t('document_create_error') | tojson }},
+};
 
 document.getElementById('save-draft').addEventListener('click', async () => {
   const data = {
@@ -55,7 +61,7 @@ document.getElementById('save-draft').addEventListener('click', async () => {
     generate_docxf: {{ 'true' if form.generate_docxf else 'false' }}
   };
   if (!data.uploaded_file_key) {
-    showToast('Dosya yüklenemedi', { timeout: 6000 });
+    showToast(messages.fileNotUploaded, { timeout: 6000 });
     return;
   }
   const csrf = document.querySelector('input[name=csrf_token]').value;
@@ -68,17 +74,17 @@ document.getElementById('save-draft').addEventListener('click', async () => {
     body: JSON.stringify(data)
   });
   if (response.status === 403) {
-    showToast('Oturumunuz sonlandı. Lütfen sayfayı yenileyin.', { timeout: 6000 });
+    showToast(messages.sessionEnded, { timeout: 6000 });
     return;
   }
   const result = await response.json();
   if (result.id) {
-    showToast('Doküman başarıyla yüklendi ve onaya gönderildi');
+    showToast(messages.documentUploaded);
     window.location = `/documents/${result.id}?created=1`;
   } else if (result.errors) {
     Object.values(result.errors).forEach(msg => showToast(msg, { timeout: 6000 }));
   } else {
-    showToast('Doküman oluşturulurken bir hata oluştu', { timeout: 6000 });
+    showToast(messages.documentCreateError, { timeout: 6000 });
   }
 });
 </script>

--- a/portal/translations.py
+++ b/portal/translations.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from flask import has_request_context, request
+
+TRANSLATIONS = {
+    "en": {
+        "new_document_step3_title": "New Document - Step 3",
+        "generation_failed": "Generation failed: {error}",
+        "document_generated_success": "Document generated successfully.",
+        "upload_failed": "Upload failed: {error}",
+        "file_uploaded_success": "File uploaded successfully.",
+        "view_document": "View Document",
+        "create": "Create",
+        "save_draft": "Save as Draft",
+        "cancel": "Cancel",
+        "file_not_uploaded": "File could not be uploaded",
+        "session_ended": "Your session has ended. Please refresh the page.",
+        "document_uploaded_for_approval": (
+            "Document uploaded successfully and sent for approval"
+        ),
+        "document_create_error": (
+            "An error occurred while creating the document"
+        ),
+        "code_label": "Code",
+        "title_label": "Title",
+        "department_label": "Department",
+        "type_label": "Type",
+        "standard_label": "Standard",
+    },
+    "tr": {
+        "new_document_step3_title": "Yeni Doküman - Adım 3",
+        "generation_failed": "Oluşturma başarısız: {error}",
+        "document_generated_success": "Doküman başarıyla oluşturuldu.",
+        "upload_failed": "Yükleme başarısız: {error}",
+        "file_uploaded_success": "Dosya başarıyla yüklendi.",
+        "view_document": "Dokümanı Görüntüle",
+        "create": "Oluştur",
+        "save_draft": "Taslak olarak kaydet",
+        "cancel": "İptal",
+        "file_not_uploaded": "Dosya yüklenemedi",
+        "session_ended": "Oturumunuz sonlandı. Lütfen sayfayı yenileyin.",
+        "document_uploaded_for_approval": (
+            "Doküman başarıyla yüklendi ve onaya gönderildi"
+        ),
+        "document_create_error": (
+            "Doküman oluşturulurken bir hata oluştu"
+        ),
+        "code_label": "Kod",
+        "title_label": "Başlık",
+        "department_label": "Departman",
+        "type_label": "Tür",
+        "standard_label": "Standart",
+    },
+}
+
+
+def get_locale() -> str:
+    if has_request_context():
+        return request.cookies.get("pref-language", "en")
+    return "en"
+
+
+def t(key: str, **kwargs: str) -> str:
+    locale = get_locale()
+    text = TRANSLATIONS.get(locale, TRANSLATIONS["en"]).get(key, key)
+    try:
+        return text.format(**kwargs)
+    except Exception:
+        return text


### PR DESCRIPTION
## Summary
- add translations module with English and Turkish messages
- expose translation helper to templates
- replace inline strings in document creation step 3 with localized variables

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_68aef89578f8832b9b471e05eae8e1a9