### PR TITLE
Trigger ackUpdated event after assignments

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -3244,7 +3244,11 @@ def assign_acknowledgements_endpoint():
         if doc and user_ids:
             notify_mandatory_read(doc, list(user_ids))
         broadcast_counts()
-        return jsonify(ok=True)
+        resp = jsonify(ok=True)
+        resp.headers["HX-Trigger"] = json.dumps(
+            {"ackUpdated": True, "showToast": "Assignments added"}
+        )
+        return resp
     finally:
         db.close()
 

--- a/portal/static/document_detail.js
+++ b/portal/static/document_detail.js
@@ -120,7 +120,6 @@ function initAssignForm() {
   });
   form.addEventListener('htmx:afterRequest', (evt) => {
     if (evt.detail.successful) {
-      showToast('Assignments saved');
       const modalEl = document.getElementById('assignModal');
       const modal =
         bootstrap.Modal.getInstance(modalEl) ||

--- a/portal/static/src/document_detail.js
+++ b/portal/static/src/document_detail.js
@@ -120,7 +120,6 @@ function initAssignForm() {
   });
   form.addEventListener('htmx:afterRequest', (evt) => {
     if (evt.detail.successful) {
-      showToast('Assignments saved');
       const modalEl = document.getElementById('assignModal');
       const modal =
         bootstrap.Modal.getInstance(modalEl) ||

--- a/portal/templates/mandatory_reading.html
+++ b/portal/templates/mandatory_reading.html
@@ -23,7 +23,13 @@
       <th scope="col">Confirm</th>
     </tr>
   </thead>
-  <tbody>
+  <tbody
+    hx-get="{{ url_for('mandatory_reading', filter=filter) }}"
+    hx-trigger="ackUpdated from:body"
+    hx-target="this"
+    hx-swap="outerHTML"
+    hx-select="#reading-table tbody"
+  >
     {% include 'partials/_mandatory_body.html' %}
   </tbody>
 </table>

--- a/tests/test_ack_assign_api.py
+++ b/tests/test_ack_assign_api.py
@@ -3,6 +3,7 @@ import importlib
 from pathlib import Path
 import sys
 import uuid
+import json
 
 import pytest
 from unittest.mock import patch
@@ -74,8 +75,10 @@ def test_assign_acknowledgements_role_targets(client, app_models):
             json={"doc_id": doc_id, "targets": [f"ack_reader_{uid}"]},
         )
         broadcast_mock.assert_called_once()
-
     assert resp.status_code == 200
+    trigger = json.loads(resp.headers.get("HX-Trigger"))
+    assert trigger.get("ackUpdated") is True
+    assert trigger.get("showToast") == "Assignments added"
     session = m.SessionLocal()
     acks = session.query(m.Acknowledgement).filter_by(doc_id=doc_id).all()
     ack_user_ids = {a.user_id for a in acks}


### PR DESCRIPTION
## Summary
- fire `ackUpdated` and `showToast` events when assigning mandatory readings
- auto-refresh mandatory reading table on `ackUpdated`
- rely on server-sent events for assignment toast

## Testing
- `pytest tests/test_ack_assign_api.py::test_assign_acknowledgements_role_targets`
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68aef9a14f2c832b8dcebe9a1c9696f6