### PR TITLE
Allow jsdelivr CDN for Bootstrap assets

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -29,7 +29,7 @@ http {
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options "DENY";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src-elem 'self' https://cdn.jsdelivr.net; style-src-elem 'self' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'" always;
 
     # 443 kullanacaksanız:
     # listen 443 ssl http2;
@@ -74,7 +74,7 @@ http {
       proxy_set_header X-Forwarded-Port $server_port;
       proxy_hide_header X-Frame-Options;
       add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; frame-ancestors 'self'" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src-elem 'self' https://cdn.jsdelivr.net; style-src-elem 'self' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self' ws: wss:; frame-ancestors 'self'" always;
     }
 
     # WebSocket yolları (OnlyOffice)


### PR DESCRIPTION
## Summary
- permit cdn.jsdelivr.net in script and style CSP rules
- add script-src-elem and style-src-elem for CDN-hosted resources

## Testing
- `nginx -t -c $(pwd)/nginx/nginx.conf` *(fails: command not found)*
- `pytest -q` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68aefcaaaa08832b8f5a79a422f761f1