### PR TITLE
Add JS extensions to component exports and rebuild assets

### DIFF
--- a/portal/static/components/index.js
+++ b/portal/static/components/index.js
@@ -1,1 +1,1 @@
-export { confirmationModal, xlModal } from './modal';export { openDrawer } from './drawer';export { showToast } from './toast';
+export { confirmationModal, xlModal } from './modal.js';export { openDrawer } from './drawer.js';export { showToast } from './toast.js';

--- a/portal/static/src/components/index.js
+++ b/portal/static/src/components/index.js
@@ -1,3 +1,3 @@
-export { confirmationModal, xlModal } from './modal';
-export { openDrawer } from './drawer';
-export { showToast } from './toast';
+export { confirmationModal, xlModal } from './modal.js';
+export { openDrawer } from './drawer.js';
+export { showToast } from './toast.js';


### PR DESCRIPTION
## Summary
- include `.js` extensions in component re-exports
- rebuild portal static components to match new exports

## Testing
- `python portal/static_build.py`
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_68af0087e9a0832bb5d6dba38e25c411