### PR TITLE
Automatically rebuild static assets on startup

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -40,6 +40,7 @@ from search import index_document, search_documents
 from signing import create_signed_pdf
 from storage import generate_presigned_url, storage_client
 from translations import t
+from static_build import build_all
 
 
 # Automatically run database migrations in non-SQLite environments.
@@ -62,6 +63,15 @@ _run_migrations()
 from search import create_index
 
 create_index()
+
+# Rebuild static assets on each application start.
+def _build_static_assets() -> None:
+    try:
+        build_all()
+    except FileNotFoundError:
+        pass
+
+_build_static_assets()
 
 # Serve static assets from the root ``static`` directory and load templates from the
 # project-level ``templates`` folder. Explicitly setting these paths ensures static

--- a/portal/static_build.py
+++ b/portal/static_build.py
@@ -45,7 +45,16 @@ def build_file(src_path, rel_path):
     with open(out_full, 'w') as f:
         f.write(minified)
 
-if __name__ == '__main__':
+
+def build_all() -> None:
+    """Rebuild all static assets into ``static-dist``.
+
+    The function mirrors the script's command line behaviour so it can be
+    reused programmatically. It skips execution if the source directory does
+    not exist, allowing environments without the optional static volume to
+    start without failing.
+    """
+
     os.makedirs(DEST_DIR, exist_ok=True)
     if not os.path.isdir(SRC_DIR):
         raise FileNotFoundError(
@@ -55,6 +64,11 @@ if __name__ == '__main__':
     for root, _, files in os.walk(SRC_DIR):
         rel_dir = os.path.relpath(root, SRC_DIR)
         for fname in files:
-            if fname.endswith(('.css', '.js')):
-                rel_path = fname if rel_dir == '.' else os.path.join(rel_dir, fname)
+            if fname.endswith((".css", ".js")):
+                rel_path = (
+                    fname if rel_dir == "." else os.path.join(rel_dir, fname)
+                )
                 build_file(os.path.join(root, fname), rel_path)
+
+if __name__ == "__main__":
+    build_all()


### PR DESCRIPTION
## Summary
- add reusable `build_all` helper to rebuild portal static assets
- invoke asset rebuild during app startup so containers regenerate bundles each restart

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_68af0303651c832ba355430ca9f55235