### PR TITLE
refactor: import toast directly

### DIFF
--- a/portal/static/components/index.js
+++ b/portal/static/components/index.js
@@ -1,1 +1,1 @@
-export { confirmationModal, xlModal } from './modal.js';export { openDrawer } from './drawer.js';export { showToast } from './toast.js';
+export { confirmationModal, xlModal } from './modal.js';export { openDrawer } from './drawer.js';

--- a/portal/static/document_detail.js
+++ b/portal/static/document_detail.js
@@ -1,5 +1,5 @@
 import { getToken } from './tokens.js';
-import { showToast } from './components/index.js';
+import { showToast } from './components/toast.js';
 getToken('color-primary');
 
 function initTabs() {

--- a/portal/static/src/components/index.js
+++ b/portal/static/src/components/index.js
@@ -1,3 +1,2 @@
 export { confirmationModal, xlModal } from './modal.js';
 export { openDrawer } from './drawer.js';
-export { showToast } from './toast.js';

--- a/portal/static/src/document_detail.js
+++ b/portal/static/src/document_detail.js
@@ -1,5 +1,5 @@
 import { getToken } from './tokens.js';
-import { showToast } from './components/index.js';
+import { showToast } from './components/toast.js';
 getToken('color-primary');
 
 function initTabs() {

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -120,7 +120,7 @@ document.addEventListener('htmx:responseError', function (evt) {
 </script>
 {% if request.args.get('created') %}
 <script type="module">
-import { showToast } from '{{ url_for('static', filename='components/index.js') }}';
+import { showToast } from '{{ url_for('static', filename='components/toast.js') }}';
 showToast('Doküman başarıyla yüklendi ve onaya gönderildi');
 </script>
 {% endif %}

--- a/portal/templates/documents/new_step3.html
+++ b/portal/templates/documents/new_step3.html
@@ -21,7 +21,7 @@
   </ul>
 </div>
 <script type="module">
-import { showToast } from '{{ url_for('static', filename='components/index.js') }}';
+import { showToast } from '{{ url_for('static', filename='components/toast.js') }}';
 const errors = {{ errors | tojson }};
 Object.values(errors).flat().forEach(msg => showToast(msg, { timeout: 6000 }));
 </script>
@@ -39,7 +39,7 @@ Object.values(errors).flat().forEach(msg => showToast(msg, { timeout: 6000 }));
 </form>
 {% if not form.generate_docxf %}
 <script type="module">
-import { showToast } from '{{ url_for('static', filename='components/index.js') }}';
+import { showToast } from '{{ url_for('static', filename='components/toast.js') }}';
 const messages = {
   fileNotUploaded: {{ t('file_not_uploaded') | tojson }},
   sessionEnded: {{ t('session_ended') | tojson }},

--- a/portal/templates/forms/sample.html
+++ b/portal/templates/forms/sample.html
@@ -8,7 +8,7 @@
 </form>
 <script type="module">
   import { createInput, attachHelpText, attachValidation, attachTooltip } from '{{ url_for('static', filename='forms/index.js') }}';
-  import { showToast } from '{{ url_for('static', filename='components/index.js') }}';
+  import { showToast } from '{{ url_for('static', filename='components/toast.js') }}';
   const container = document.getElementById('form-container');
   const emailField = createInput({ id: 'email', name: 'email', label: 'Email', type: 'email', required: true, copyable: true });
   container.appendChild(emailField.wrapper);


### PR DESCRIPTION
## Summary
- refactor document detail to import toast directly
- update templates to load toast component
- drop showToast re-export from components index

## Testing
- `python portal/static_build.py`
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68af060b4380832b8f92df86bb02fe26