### PR TITLE
Allow inline script/style elements in CSP

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -29,7 +29,7 @@ http {
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options "DENY";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src-elem 'self' https://cdn.jsdelivr.net; style-src-elem 'self' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'" always;
 
     # 443 kullanacaksanız:
     # listen 443 ssl http2;
@@ -74,7 +74,7 @@ http {
       proxy_set_header X-Forwarded-Port $server_port;
       proxy_hide_header X-Frame-Options;
       add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src-elem 'self' https://cdn.jsdelivr.net; style-src-elem 'self' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self' ws: wss:; frame-ancestors 'self'" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self' ws: wss:; frame-ancestors 'self'" always;
     }
 
     # WebSocket yolları (OnlyOffice)


### PR DESCRIPTION
## Summary
- permit inline script and style elements by adding `'unsafe-inline'` to `script-src-elem` and `style-src-elem` in Nginx CSP header

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*
- `nginx -t` *(fails: command not found)*
- `sudo service nginx reload` *(fails: unrecognized service)*

------
https://chatgpt.com/codex/tasks/task_e_68af0fc605ec832b84d54a48d3a30575