### PR TITLE
refactor templates to externalize scripts and styles

### DIFF
--- a/portal/static/base.css
+++ b/portal/static/base.css
@@ -1,0 +1,10 @@
+body{color:#1a1a1a;background-color:#fff;}
+.skip-link{position:absolute;top:-40px;left:0;background:#fff;color:#005ea2;padding:8px;z-index:100;}
+.skip-link:focus{top:0;}
+.container{width:100%;margin:0 auto;}
+.icon{width:1em;height:1em;vertical-align:-0.125em;fill:currentColor;}
+.quick-search-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.5);z-index:1100;}
+.quick-search-box{max-width:600px;margin:10vh auto;background:#fff;padding:1rem;border-radius:.5rem;}
+.quick-search-overlay .list-group-item{cursor:pointer;}
+.page-title{font-size:var(--font-size-lg);margin-bottom:var(--spacing-md);}
+.preview-frame{height:600px;}

--- a/portal/static/documents/new_step1.js
+++ b/portal/static/documents/new_step1.js
@@ -1,0 +1,28 @@
+import { attachHelpText, attachTooltip } from '../forms/index.js';
+
+const code = document.getElementById('code');
+attachHelpText(code, 'Unique identifier for the document.');
+attachTooltip(code, 'Unique document code');
+
+const titleInput = document.getElementById('title');
+attachHelpText(titleInput, 'Title of the document.');
+attachTooltip(titleInput, 'Document title');
+
+const typeInput = document.getElementById('type');
+attachHelpText(typeInput, 'Type of document.');
+attachTooltip(typeInput, 'Document type');
+
+const departmentInput = document.getElementById('department');
+attachHelpText(departmentInput, 'Department responsible for the document.');
+attachTooltip(departmentInput, 'Responsible department');
+
+const standardSelect = document.getElementById('standard');
+attachHelpText(standardSelect, 'Choose the standard that applies.');
+attachTooltip(standardSelect, 'Applicable standard');
+
+const tagsInput = document.getElementById('tags');
+attachHelpText(tagsInput, 'Add comma-separated tags.');
+attachTooltip(tagsInput, 'Comma-separated tags');
+
+const nextBtn = document.getElementById('next-step1');
+attachTooltip(nextBtn, 'Proceed to next step');

--- a/portal/static/documents/new_step2.js
+++ b/portal/static/documents/new_step2.js
@@ -1,0 +1,16 @@
+import { attachHelpText, attachTooltip } from '../forms/index.js';
+
+const templateSelect = document.getElementById('template');
+attachHelpText(templateSelect, 'Select a template to start from.');
+attachTooltip(templateSelect, 'Select a template');
+
+const uploadInput = document.getElementById('upload_file');
+attachHelpText(uploadInput, 'Upload the document file.');
+attachTooltip(uploadInput, 'Upload document file');
+
+const generateDocxf = document.getElementById('generate_docxf');
+attachHelpText(generateDocxf, 'Generate document from a DOCXF file.');
+attachTooltip(generateDocxf, 'Generate from DOCXF');
+
+const nextBtn = document.getElementById('next-step2');
+attachTooltip(nextBtn, 'Proceed to next step');

--- a/portal/static/documents/new_step3.js
+++ b/portal/static/documents/new_step3.js
@@ -1,0 +1,61 @@
+import { showToast } from '../components/toast.js';
+
+document.querySelectorAll('[data-errors]').forEach(el => {
+  try {
+    const errors = JSON.parse(el.dataset.errors || '{}');
+    Object.values(errors).flat().forEach(msg => showToast(msg, { timeout: 6000 }));
+  } catch (e) {
+    console.error('Failed to parse errors', e);
+  }
+});
+
+const saveDraftBtn = document.getElementById('save-draft');
+if (saveDraftBtn) {
+  const messages = {
+    fileNotUploaded: saveDraftBtn.dataset.fileNotUploaded,
+    sessionEnded: saveDraftBtn.dataset.sessionEnded,
+    documentUploaded: saveDraftBtn.dataset.documentUploaded,
+    documentCreateError: saveDraftBtn.dataset.documentCreateError,
+  };
+
+  saveDraftBtn.addEventListener('click', async () => {
+    const data = {
+      code: saveDraftBtn.dataset.code,
+      title: saveDraftBtn.dataset.title,
+      department: saveDraftBtn.dataset.department,
+      process: saveDraftBtn.dataset.process,
+      standard: saveDraftBtn.dataset.standard,
+      tags: saveDraftBtn.dataset.tags.split(',').map(t => t.trim()).filter(Boolean),
+      template: saveDraftBtn.dataset.template,
+      uploaded_file_key: saveDraftBtn.dataset.uploadedFileKey,
+      uploaded_file_name: saveDraftBtn.dataset.uploadedFileName,
+      generate_docxf: saveDraftBtn.dataset.generateDocxf === 'true'
+    };
+    if (!data.uploaded_file_key) {
+      showToast(messages.fileNotUploaded, { timeout: 6000 });
+      return;
+    }
+    const csrf = document.querySelector('input[name=csrf_token]').value;
+    const response = await fetch('/api/documents', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': csrf
+      },
+      body: JSON.stringify(data)
+    });
+    if (response.status === 403) {
+      showToast(messages.sessionEnded, { timeout: 6000 });
+      return;
+    }
+    const result = await response.json();
+    if (result.id) {
+      showToast(messages.documentUploaded);
+      window.location = `/documents/${result.id}?created=1`;
+    } else if (result.errors) {
+      Object.values(result.errors).forEach(msg => showToast(msg, { timeout: 6000 }));
+    } else {
+      showToast(messages.documentCreateError, { timeout: 6000 });
+    }
+  });
+}

--- a/portal/static/importmap.json
+++ b/portal/static/importmap.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "bootstrap": "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.esm.min.js",
+    "bootstrap/dist/css/bootstrap.css": "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+  }
+}

--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -10,24 +10,8 @@
     integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
     crossorigin="anonymous"
   >
-  <script type="importmap">
-    {
-      "imports": {
-        "bootstrap": "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.esm.min.js",
-        "bootstrap/dist/css/bootstrap.css": "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-      }
-    }
-  </script>
-  <style>
-    body{color:#1a1a1a;background-color:#fff;}
-    .skip-link{position:absolute;top:-40px;left:0;background:#fff;color:#005ea2;padding:8px;z-index:100;}
-    .skip-link:focus{top:0;}
-    .container{width:100%;margin:0 auto;}
-    .icon{width:1em;height:1em;vertical-align:-0.125em;fill:currentColor;}
-    .quick-search-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.5);z-index:1100;}
-    .quick-search-box{max-width:600px;margin:10vh auto;background:#fff;padding:1rem;border-radius:.5rem;}
-    .quick-search-overlay .list-group-item{cursor:pointer;}
-  </style>
+  <script type="importmap" src="{{ url_for('static', filename='importmap.json') }}"></script>
+  <link rel="stylesheet" href="{{ url_for('static', filename='base.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='app.css') }}">
 </head>
 <body data-poll-interval="{{ config['POLL_INTERVAL_MS'] }}">

--- a/portal/templates/documents/new_step1.html
+++ b/portal/templates/documents/new_step1.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}New Document - Step 1{% endblock %}
 {% block content %}
-<h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">New Document - Step 1</h1>
+<h1 class="fw-bold page-title">New Document - Step 1</h1>
 {% if errors %}
 <div class="alert alert-danger">Please correct the errors below.</div>
 {% endif %}
@@ -41,37 +41,8 @@
     <input type="text" class="form-control{% if errors.tags %} is-invalid{% endif %}" id="tags" name="tags" value="{{ form.tags or '' }}" placeholder="tag1, tag2" title="Comma-separated tags">
     {% if errors.tags %}<div class="invalid-feedback">{{ errors.tags }}</div>{% endif %}
   </div>
-    <button type="submit" class="btn btn-primary" id="next-step1" title="Proceed to next step">Next</button>
+  <button type="submit" class="btn btn-primary" id="next-step1" title="Proceed to next step">Next</button>
   </form>
 
-<script type="module">
-  import { attachHelpText, attachTooltip } from '{{ url_for('static', filename='forms/index.js') }}';
-
-  const code = document.getElementById('code');
-  attachHelpText(code, 'Unique identifier for the document.');
-  attachTooltip(code, 'Unique document code');
-
-  const titleInput = document.getElementById('title');
-  attachHelpText(titleInput, 'Title of the document.');
-  attachTooltip(titleInput, 'Document title');
-
-  const typeInput = document.getElementById('type');
-  attachHelpText(typeInput, 'Type of document.');
-  attachTooltip(typeInput, 'Document type');
-
-  const departmentInput = document.getElementById('department');
-  attachHelpText(departmentInput, 'Department responsible for the document.');
-  attachTooltip(departmentInput, 'Responsible department');
-
-  const standardSelect = document.getElementById('standard');
-  attachHelpText(standardSelect, 'Choose the standard that applies.');
-  attachTooltip(standardSelect, 'Applicable standard');
-
-  const tagsInput = document.getElementById('tags');
-  attachHelpText(tagsInput, 'Add comma-separated tags.');
-  attachTooltip(tagsInput, 'Comma-separated tags');
-
-  const nextBtn = document.getElementById('next-step1');
-  attachTooltip(nextBtn, 'Proceed to next step');
-</script>
+<script type="module" src="{{ url_for('static', filename='documents/new_step1.js') }}"></script>
   {% endblock %}

--- a/portal/templates/documents/new_step2.html
+++ b/portal/templates/documents/new_step2.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}New Document - Step 2{% endblock %}
 {% block content %}
-<h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">New Document - Step 2</h1>
+<h1 class="fw-bold page-title">New Document - Step 2</h1>
 {% if form.docxf_error %}
 <div class="alert alert-danger">Generation failed: {{ form.docxf_error }}</div>
 {% elif form.preview_url %}
@@ -41,22 +41,5 @@
   <button type="submit" class="btn btn-primary" id="next-step2" title="Proceed to next step">Next</button>
 </form>
 
-<script type="module">
-  import { attachHelpText, attachTooltip } from '{{ url_for('static', filename='forms/index.js') }}';
-
-  const templateSelect = document.getElementById('template');
-  attachHelpText(templateSelect, 'Select a template to start from.');
-  attachTooltip(templateSelect, 'Select a template');
-
-  const uploadInput = document.getElementById('upload_file');
-  attachHelpText(uploadInput, 'Upload the document file.');
-  attachTooltip(uploadInput, 'Upload document file');
-
-  const generateDocxf = document.getElementById('generate_docxf');
-  attachHelpText(generateDocxf, 'Generate document from a DOCXF file.');
-  attachTooltip(generateDocxf, 'Generate from DOCXF');
-
-  const nextBtn = document.getElementById('next-step2');
-  attachTooltip(nextBtn, 'Proceed to next step');
-</script>
+<script type="module" src="{{ url_for('static', filename='documents/new_step2.js') }}"></script>
 {% endblock %}

--- a/portal/templates/documents/new_step3.html
+++ b/portal/templates/documents/new_step3.html
@@ -1,30 +1,25 @@
 {% extends "base.html" %}
 {% block title %}{{ t('new_document_step3_title') }}{% endblock %}
 {% block content %}
-<h1 class="fw-bold" style="font-size: var(--font-size-lg); margin-bottom: var(--spacing-md);">{{ t('new_document_step3_title') }}</h1>
+<h1 class="fw-bold page-title">{{ t('new_document_step3_title') }}</h1>
 {% if form.docxf_error %}
 <div class="alert alert-danger">{{ t('generation_failed', error=form.docxf_error) }}</div>
 {% elif form.preview_url %}
 <div class="alert alert-success">{{ t('document_generated_success') }}</div>
-<div class="mb-3"><iframe src="{{ form.preview_url }}" class="w-100" style="height:600px;"></iframe></div>
+<div class="mb-3"><iframe src="{{ form.preview_url }}" class="w-100 preview-frame"></iframe></div>
 {% elif form.upload_error %}
 <div class="alert alert-danger">{{ t('upload_failed', error=form.upload_error) }}</div>
 {% elif form.uploaded_file_key %}
 <div class="alert alert-success">{{ t('file_uploaded_success') }}</div>
 {% endif %}
 {% if errors %}
-<div class="alert alert-danger">
+<div class="alert alert-danger" data-errors='{{ errors | tojson }}'>
   <ul class="mb-0">
     {% for msg in errors.values() %}
     <li>{{ msg }}</li>
     {% endfor %}
   </ul>
 </div>
-<script type="module">
-import { showToast } from '{{ url_for('static', filename='components/toast.js') }}';
-const errors = {{ errors | tojson }};
-Object.values(errors).flat().forEach(msg => showToast(msg, { timeout: 6000 }));
-</script>
 {% endif %}
 <form method="post" action="{{ url_for('new_document', step=3) }}">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -34,59 +29,23 @@ Object.values(errors).flat().forEach(msg => showToast(msg, { timeout: 6000 }));
   <p><strong>{{ t('type_label') }}:</strong> {{ form.type }}</p>
   <p><strong>{{ t('standard_label') }}:</strong> {{ standard_map.get(form.standard, form.standard) }}</p>
   <button type="submit" class="btn btn-primary">{% if form.generate_docxf %}{{ t('view_document') }}{% else %}{{ t('create') }}{% endif %}</button>
-  {% if not form.generate_docxf %}<button type="button" id="save-draft" class="btn btn-secondary ms-2">{{ t('save_draft') }}</button>{% endif %}
+  {% if not form.generate_docxf %}<button type="button" id="save-draft" class="btn btn-secondary ms-2"
+    data-code="{{ form.code }}"
+    data-title="{{ form.title }}"
+    data-department="{{ form.department }}"
+    data-process="{{ form.type }}"
+    data-standard="{{ form.standard }}"
+    data-tags="{{ form.tags }}"
+    data-template="{{ form.template }}"
+    data-uploaded-file-key="{{ form.uploaded_file_key }}"
+    data-uploaded-file-name="{{ form.uploaded_file_name }}"
+    data-generate-docxf="{{ 'true' if form.generate_docxf else 'false' }}"
+    data-file-not-uploaded="{{ t('file_not_uploaded') }}"
+    data-session-ended="{{ t('session_ended') }}"
+    data-document-uploaded="{{ t('document_uploaded_for_approval') }}"
+    data-document-create-error="{{ t('document_create_error') }}"
+  >{{ t('save_draft') }}</button>{% endif %}
   <button type="submit" name="cancel" value="1" class="btn btn-secondary ms-2">{{ t('cancel') }}</button>
 </form>
-{% if not form.generate_docxf %}
-<script type="module">
-import { showToast } from '{{ url_for('static', filename='components/toast.js') }}';
-const messages = {
-  fileNotUploaded: {{ t('file_not_uploaded') | tojson }},
-  sessionEnded: {{ t('session_ended') | tojson }},
-  documentUploaded: {{ t('document_uploaded_for_approval') | tojson }},
-  documentCreateError: {{ t('document_create_error') | tojson }},
-};
-
-document.getElementById('save-draft').addEventListener('click', async () => {
-  const data = {
-    code: "{{ form.code }}",
-    title: "{{ form.title }}",
-    department: "{{ form.department }}",
-    process: "{{ form.type }}",
-    standard: "{{ form.standard }}",
-    tags: "{{ form.tags }}".split(',').map(t => t.trim()).filter(Boolean),
-    template: "{{ form.template }}",
-    uploaded_file_key: "{{ form.uploaded_file_key }}",
-    uploaded_file_name: "{{ form.uploaded_file_name }}",
-    generate_docxf: {{ 'true' if form.generate_docxf else 'false' }}
-  };
-  if (!data.uploaded_file_key) {
-    showToast(messages.fileNotUploaded, { timeout: 6000 });
-    return;
-  }
-  const csrf = document.querySelector('input[name=csrf_token]').value;
-  const response = await fetch('/api/documents', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-CSRFToken': csrf
-    },
-    body: JSON.stringify(data)
-  });
-  if (response.status === 403) {
-    showToast(messages.sessionEnded, { timeout: 6000 });
-    return;
-  }
-  const result = await response.json();
-  if (result.id) {
-    showToast(messages.documentUploaded);
-    window.location = `/documents/${result.id}?created=1`;
-  } else if (result.errors) {
-    Object.values(result.errors).forEach(msg => showToast(msg, { timeout: 6000 }));
-  } else {
-    showToast(messages.documentCreateError, { timeout: 6000 });
-  }
-});
-</script>
-{% endif %}
+<script type="module" src="{{ url_for('static', filename='documents/new_step3.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- move inline import map and base styles to static files
- externalize document creation scripts into dedicated modules
- replace inline styles with reusable CSS classes

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68af10d0c550832b82c09ba383707a6f