### PR TITLE
Handle existing step_type column in migration

### DIFF
--- a/alembic/versions/0002_add_step_type.py
+++ b/alembic/versions/0002_add_step_type.py
@@ -8,6 +8,7 @@ Create Date: 2024-05-27 00:00:00
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "0002"
@@ -18,14 +19,22 @@ depends_on = None
 
 def upgrade() -> None:
     step_type = sa.Enum("review", "approval", name="workflow_step_type")
-    step_type.create(op.get_bind(), checkfirst=True)
-    op.add_column(
-        "workflow_steps",
-        sa.Column("step_type", step_type, nullable=False, server_default="review"),
-    )
+    bind = op.get_bind()
+    step_type.create(bind, checkfirst=True)
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("workflow_steps")]
+    if "step_type" not in columns:
+        op.add_column(
+            "workflow_steps",
+            sa.Column("step_type", step_type, nullable=False, server_default="review"),
+        )
 
 
 def downgrade() -> None:
-    op.drop_column("workflow_steps", "step_type")
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("workflow_steps")]
+    if "step_type" in columns:
+        op.drop_column("workflow_steps", "step_type")
     step_type = sa.Enum("review", "approval", name="workflow_step_type")
-    step_type.drop(op.get_bind(), checkfirst=True)
+    step_type.drop(bind, checkfirst=True)


### PR DESCRIPTION
## Summary
- avoid duplicate-column error when adding workflow_steps.step_type in migration

## Testing
- `alembic upgrade head` *(fails: duplicate column name: user_id)*
- `pytest -q` *(fails: ImportError: cannot import name 'mock_s3')*
- `pytest tests/test_modal_ids.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b02e3c3534832badd625b7c25e03f7