### PR TITLE
Handle existing column in document permissions migration

### DIFF
--- a/alembic/versions/0004_add_can_download_to_document_permissions.py
+++ b/alembic/versions/0004_add_can_download_to_document_permissions.py
@@ -8,6 +8,7 @@ Create Date: 2025-08-18 05:55:11
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "0004"
@@ -17,12 +18,22 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "document_permissions",
-        sa.Column("can_download", sa.Boolean(), nullable=False, server_default=sa.true()),
-    )
-    op.alter_column("document_permissions", "can_download", server_default=None)
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("document_permissions")]
+    if "can_download" not in columns:
+        op.add_column(
+            "document_permissions",
+            sa.Column(
+                "can_download", sa.Boolean(), nullable=False, server_default=sa.true()
+            ),
+        )
+        op.alter_column("document_permissions", "can_download", server_default=None)
 
 
 def downgrade() -> None:
-    op.drop_column("document_permissions", "can_download")
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("document_permissions")]
+    if "can_download" in columns:
+        op.drop_column("document_permissions", "can_download")


### PR DESCRIPTION
## Summary
- Safeguard document permissions migration from duplicate `can_download` column

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_68b0322c1c20832baf55aa43e7338807