### PR TITLE
Handle existing endpoint column in audit logs migration

### DIFF
--- a/alembic/versions/0005_add_endpoint_to_audit_logs.py
+++ b/alembic/versions/0005_add_endpoint_to_audit_logs.py
@@ -8,6 +8,7 @@ Create Date: 2025-08-18 05:55:11
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "0005"
@@ -15,11 +16,20 @@ down_revision = "0004"
 branch_labels = None
 depends_on = None
 
-
 def upgrade() -> None:
-    op.add_column("audit_logs", sa.Column("endpoint", sa.String(), nullable=True))
+    connection = op.get_bind()
+    inspector = inspect(connection)
+    columns = [col["name"] for col in inspector.get_columns("audit_logs")]
+
+    if "endpoint" not in columns:
+        op.add_column("audit_logs", sa.Column("endpoint", sa.String(), nullable=True))
 
 
 def downgrade() -> None:
-    op.drop_column("audit_logs", "endpoint")
+    connection = op.get_bind()
+    inspector = inspect(connection)
+    columns = [col["name"] for col in inspector.get_columns("audit_logs")]
+
+    if "endpoint" in columns:
+        op.drop_column("audit_logs", "endpoint")
 


### PR DESCRIPTION
## Summary
- make audit logs migration idempotent by checking for an existing `endpoint` column

## Testing
- `pytest` (fails: ImportError: cannot import name 'mock_s3' from 'moto')

------
https://chatgpt.com/codex/tasks/task_e_68b033c96ffc832b86a358961b1e04ac