### PR TITLE
Safeguard standard_code migration

### DIFF
--- a/alembic/versions/0006_add_standard_code_to_documents.py
+++ b/alembic/versions/0006_add_standard_code_to_documents.py
@@ -4,6 +4,13 @@ Revision ID: 0006
 Revises: 0005
 Create Date: 2025-02-13 00:00:00
 
+This migration previously attempted to add the ``standard_code`` column to
+``documents`` without checking if the column already existed.  When the
+column had been manually created, running the migration resulted in a
+``DuplicateColumn`` error.  The upgrade and downgrade steps now use
+SQLAlchemy's reflection facilities to inspect the current schema before
+modifying it, avoiding errors if the column or table is already present.
+
 """
 
 from alembic import op
@@ -17,14 +24,42 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("documents", sa.Column("standard_code", sa.String(), nullable=True))
-    op.create_table(
-        "document_standards",
-        sa.Column("doc_id", sa.Integer(), sa.ForeignKey("documents.id"), primary_key=True),
-        sa.Column("standard_code", sa.String(), primary_key=True),
-    )
+    """Add the ``standard_code`` column and ``document_standards`` table.
+
+    Uses SQLAlchemy's reflection utilities to guard against applying the
+    migration twice.  If the ``standard_code`` column already exists on the
+    ``documents`` table, it will not be added again, preventing a database
+    error.  The same approach is used for the ``document_standards`` table.
+    """
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    document_columns = {col["name"] for col in inspector.get_columns("documents")}
+    if "standard_code" not in document_columns:
+        op.add_column(
+            "documents", sa.Column("standard_code", sa.String(), nullable=True)
+        )
+
+    if not inspector.has_table("document_standards"):
+        op.create_table(
+            "document_standards",
+            sa.Column(
+                "doc_id", sa.Integer(), sa.ForeignKey("documents.id"), primary_key=True
+            ),
+            sa.Column("standard_code", sa.String(), primary_key=True),
+        )
 
 
 def downgrade() -> None:
-    op.drop_table("document_standards")
-    op.drop_column("documents", "standard_code")
+    """Drop ``document_standards`` and the ``standard_code`` column if present."""
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if inspector.has_table("document_standards"):
+        op.drop_table("document_standards")
+
+    document_columns = {col["name"] for col in inspector.get_columns("documents")}
+    if "standard_code" in document_columns:
+        op.drop_column("documents", "standard_code")


### PR DESCRIPTION
## Summary
- Use SQLAlchemy reflection in migration 0006 to avoid duplicate column errors
- Guard table creation and downgrade operations with schema inspection

## Testing
- `alembic upgrade 0006`
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_68b0349f9800832b8e143abe3854479d