### PR TITLE
Handle existing standard_scope column in roles migration

### DIFF
--- a/alembic/versions/0007_add_standard_scope_to_roles.py
+++ b/alembic/versions/0007_add_standard_scope_to_roles.py
@@ -8,6 +8,7 @@ Create Date: 2025-02-14 00:00:00
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "0007"
@@ -17,16 +18,28 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "roles",
-        sa.Column(
-            "standard_scope",
-            sa.String(),
-            nullable=False,
-            server_default="ALL",
-        ),
-    )
+    """Add standard_scope column if it does not already exist."""
+
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [col["name"] for col in inspector.get_columns("roles")]
+    if "standard_scope" not in columns:
+        op.add_column(
+            "roles",
+            sa.Column(
+                "standard_scope",
+                sa.String(),
+                nullable=False,
+                server_default="ALL",
+            ),
+        )
 
 
 def downgrade() -> None:
-    op.drop_column("roles", "standard_scope")
+    """Drop standard_scope column if it exists."""
+
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [col["name"] for col in inspector.get_columns("roles")]
+    if "standard_scope" in columns:
+        op.drop_column("roles", "standard_scope")


### PR DESCRIPTION
## Summary
- prevent duplicate `standard_scope` column errors by checking for existing column in roles migration

## Testing
- `alembic upgrade head` *(fails: table standards already exists)*
- `pytest` *(fails: ImportError: cannot import name 'mock_s3')*

------
https://chatgpt.com/codex/tasks/task_e_68b0356c3b70832bacbe67eed9895725