### PR TITLE
Make standards migration idempotent

### DIFF
--- a/alembic/versions/0009_create_standards_table.py
+++ b/alembic/versions/0009_create_standards_table.py
@@ -17,47 +17,62 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "standards",
-        sa.Column("code", sa.String(), primary_key=True),
-        sa.Column("description", sa.String(), nullable=True),
-    )
+    """Create standards table and seed data in an idempotent fashion."""
 
-    standards_table = sa.table(
-        "standards",
-        sa.column("code", sa.String()),
-        sa.column("description", sa.String()),
-    )
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
 
-    op.bulk_insert(
-        standards_table,
-        [
-            {"code": "ISO9001", "description": "ISO 9001"},
-            {"code": "ISO27001", "description": "ISO 27001"},
-            {"code": "ISO14001", "description": "ISO 14001"},
-        ],
-    )
+    # Create the table only if it doesn't already exist
+    if not inspector.has_table("standards"):
+        op.create_table(
+            "standards",
+            sa.Column("code", sa.String(), primary_key=True),
+            sa.Column("description", sa.String(), nullable=True),
+        )
 
-    op.create_foreign_key(
-        "fk_document_standards_standard_code_standards",
-        "document_standards",
-        "standards",
-        ["standard_code"],
-        ["code"],
-    )
+    # Seed initial data; ON CONFLICT prevents duplicate rows
+    seed_rows = [
+        {"code": "ISO9001", "description": "ISO 9001"},
+        {"code": "ISO27001", "description": "ISO 27001"},
+        {"code": "ISO14001", "description": "ISO 14001"},
+    ]
+    for row in seed_rows:
+        op.execute(
+            sa.text(
+                "INSERT INTO standards (code, description) "
+                "VALUES (:code, :description) "
+                "ON CONFLICT (code) DO NOTHING"
+            ),
+            row,
+        )
 
+    # Create the foreign key only if it doesn't already exist
+    fk_name = "fk_document_standards_standard_code_standards"
+    existing_fks = inspector.get_foreign_keys("document_standards")
+    if not any(fk["name"] == fk_name for fk in existing_fks):
+        op.create_foreign_key(
+            fk_name,
+            "document_standards",
+            "standards",
+            ["standard_code"],
+            ["code"],
+        )
+
+    # Populate association table for existing documents
     op.execute(
-        """
-        INSERT INTO document_standards (doc_id, standard_code)
-        SELECT d.id, d.standard_code
-        FROM documents d
-        JOIN standards s ON s.code = d.standard_code
-        WHERE d.standard_code IS NOT NULL
-          AND NOT EXISTS (
-                SELECT 1 FROM document_standards ds
-                WHERE ds.doc_id = d.id AND ds.standard_code = d.standard_code
-          )
-        """
+        sa.text(
+            """
+            INSERT INTO document_standards (doc_id, standard_code)
+            SELECT d.id, d.standard_code
+            FROM documents d
+            JOIN standards s ON s.code = d.standard_code
+            WHERE d.standard_code IS NOT NULL
+              AND NOT EXISTS (
+                    SELECT 1 FROM document_standards ds
+                    WHERE ds.doc_id = d.id AND ds.standard_code = d.standard_code
+              )
+            """
+        )
     )
 
 


### PR DESCRIPTION
## Summary
- Ensure standards table creation and seeding are idempotent
- Avoid duplicate foreign key creation for document_standards

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68b0367cd384832ba135339fb88eb6d0