### PR TITLE
Fix standard seeding in migration

### DIFF
--- a/alembic/versions/0009_create_standards_table.py
+++ b/alembic/versions/0009_create_standards_table.py
@@ -37,7 +37,7 @@ def upgrade() -> None:
         {"code": "ISO14001", "description": "ISO 14001"},
     ]
     for row in seed_rows:
-        op.execute(
+        bind.execute(
             sa.text(
                 "INSERT INTO standards (code, description) "
                 "VALUES (:code, :description) "


### PR DESCRIPTION
## Summary
- use database connection's execute for inserting seeded standard rows

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_68b0389cbf64832bab9d2f71c9dc6a16