### PR TITLE
Make later migrations idempotent

### DIFF
--- a/alembic/versions/0013_add_role_due_at_to_workflow_steps.py
+++ b/alembic/versions/0013_add_role_due_at_to_workflow_steps.py
@@ -7,6 +7,7 @@ Create Date: 2025-03-01 00:00:00
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "0013"
@@ -16,10 +17,22 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("workflow_steps", sa.Column("required_role", sa.String(), nullable=True))
-    op.add_column("workflow_steps", sa.Column("due_at", sa.DateTime(), nullable=True))
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("workflow_steps")]
+    if "required_role" not in columns:
+        op.add_column(
+            "workflow_steps", sa.Column("required_role", sa.String(), nullable=True)
+        )
+    if "due_at" not in columns:
+        op.add_column("workflow_steps", sa.Column("due_at", sa.DateTime(), nullable=True))
 
 
 def downgrade() -> None:
-    op.drop_column("workflow_steps", "due_at")
-    op.drop_column("workflow_steps", "required_role")
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("workflow_steps")]
+    if "due_at" in columns:
+        op.drop_column("workflow_steps", "due_at")
+    if "required_role" in columns:
+        op.drop_column("workflow_steps", "required_role")

--- a/alembic/versions/0014_add_entity_fields_to_audit_logs.py
+++ b/alembic/versions/0014_add_entity_fields_to_audit_logs.py
@@ -7,6 +7,7 @@ Create Date: 2025-08-19
 """
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 revision = "0014"
 down_revision = "0013"
@@ -14,16 +15,33 @@ branch_labels = None
 depends_on = None
 
 def upgrade() -> None:
-    op.add_column("audit_logs", sa.Column("entity_type", sa.String(), nullable=True))
-    op.add_column("audit_logs", sa.Column("entity_id", sa.Integer(), nullable=True))
-    op.add_column("audit_logs", sa.Column("payload", sa.JSON(), nullable=True))
-    op.alter_column("audit_logs", "created_at", new_column_name="at")
-    op.alter_column("audit_logs", "user_id", existing_type=sa.Integer(), nullable=True)
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = {c["name"]: c for c in inspector.get_columns("audit_logs")}
+    if "entity_type" not in columns:
+        op.add_column("audit_logs", sa.Column("entity_type", sa.String(), nullable=True))
+    if "entity_id" not in columns:
+        op.add_column("audit_logs", sa.Column("entity_id", sa.Integer(), nullable=True))
+    if "payload" not in columns:
+        op.add_column("audit_logs", sa.Column("payload", sa.JSON(), nullable=True))
+    if "created_at" in columns and "at" not in columns:
+        op.alter_column("audit_logs", "created_at", new_column_name="at")
+    user_col = columns.get("user_id")
+    if user_col and not user_col["nullable"]:
+        op.alter_column("audit_logs", "user_id", existing_type=sa.Integer(), nullable=True)
 
 
 def downgrade() -> None:
-    op.alter_column("audit_logs", "user_id", existing_type=sa.Integer(), nullable=False)
-    op.alter_column("audit_logs", "at", new_column_name="created_at")
-    op.drop_column("audit_logs", "payload")
-    op.drop_column("audit_logs", "entity_id")
-    op.drop_column("audit_logs", "entity_type")
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = {c["name"]: c for c in inspector.get_columns("audit_logs")}
+    if "user_id" in columns and columns["user_id"]["nullable"]:
+        op.alter_column("audit_logs", "user_id", existing_type=sa.Integer(), nullable=False)
+    if "at" in columns and "created_at" not in columns:
+        op.alter_column("audit_logs", "at", new_column_name="created_at")
+    if "payload" in columns:
+        op.drop_column("audit_logs", "payload")
+    if "entity_id" in columns:
+        op.drop_column("audit_logs", "entity_id")
+    if "entity_type" in columns:
+        op.drop_column("audit_logs", "entity_type")

--- a/alembic/versions/0015_add_dif_requests.py
+++ b/alembic/versions/0015_add_dif_requests.py
@@ -8,6 +8,7 @@ Create Date: 2025-09-07
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 from sqlalchemy.dialects import postgresql
 
 revision = "0015"
@@ -17,6 +18,8 @@ depends_on = None
 
 
 def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
     op.execute(
         """
         DO $$
@@ -35,30 +38,34 @@ def upgrade() -> None:
         END$$;
         """
     )
-    status = postgresql.ENUM(
-        "new",
-        "in_review",
-        "approved",
-        "rejected",
-        "implemented",
-        name="dif_request_status",
-        create_type=False,
-    )
-    op.create_table(
-        "dif_requests",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("subject", sa.String(), nullable=False),
-        sa.Column("description", sa.Text(), nullable=True),
-        sa.Column("requester_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
-        sa.Column("impact", sa.String(), nullable=True),
-        sa.Column("priority", sa.String(), nullable=True),
-        sa.Column("status", status, nullable=False, server_default="new"),
-        sa.Column("related_doc_id", sa.Integer(), sa.ForeignKey("documents.id"), nullable=True),
-        sa.Column("attachment_key", sa.String(), nullable=True),
-        sa.Column("created_at", sa.DateTime(), nullable=True),
-    )
+    if not inspector.has_table("dif_requests"):
+        status = postgresql.ENUM(
+            "new",
+            "in_review",
+            "approved",
+            "rejected",
+            "implemented",
+            name="dif_request_status",
+            create_type=False,
+        )
+        op.create_table(
+            "dif_requests",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("subject", sa.String(), nullable=False),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("requester_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+            sa.Column("impact", sa.String(), nullable=True),
+            sa.Column("priority", sa.String(), nullable=True),
+            sa.Column("status", status, nullable=False, server_default="new"),
+            sa.Column("related_doc_id", sa.Integer(), sa.ForeignKey("documents.id"), nullable=True),
+            sa.Column("attachment_key", sa.String(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+        )
 
 
 def downgrade() -> None:
-    op.drop_table("dif_requests")
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if inspector.has_table("dif_requests"):
+        op.drop_table("dif_requests")
     op.execute("DROP TYPE IF EXISTS dif_request_status")

--- a/alembic/versions/0016_add_dif_workflow_steps.py
+++ b/alembic/versions/0016_add_dif_workflow_steps.py
@@ -8,6 +8,7 @@ Create Date: 2025-09-07
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 revision = "0016"
 down_revision = "0015"
@@ -16,18 +17,28 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "dif_workflow_steps",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("dif_id", sa.Integer(), sa.ForeignKey("dif_requests.id"), nullable=False),
-        sa.Column("role", sa.String(), nullable=False),
-        sa.Column("step_order", sa.Integer(), nullable=False),
-        sa.Column("sla_hours", sa.Integer(), nullable=True),
-        sa.Column("status", sa.String(), nullable=False, server_default="Pending"),
-        sa.Column("acted_at", sa.DateTime(), nullable=True),
-        sa.Column("comment", sa.Text(), nullable=True),
-    )
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table("dif_workflow_steps"):
+        op.create_table(
+            "dif_workflow_steps",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "dif_id", sa.Integer(), sa.ForeignKey("dif_requests.id"), nullable=False
+            ),
+            sa.Column("role", sa.String(), nullable=False),
+            sa.Column("step_order", sa.Integer(), nullable=False),
+            sa.Column("sla_hours", sa.Integer(), nullable=True),
+            sa.Column(
+                "status", sa.String(), nullable=False, server_default="Pending"
+            ),
+            sa.Column("acted_at", sa.DateTime(), nullable=True),
+            sa.Column("comment", sa.Text(), nullable=True),
+        )
 
 
 def downgrade() -> None:
-    op.drop_table("dif_workflow_steps")
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if inspector.has_table("dif_workflow_steps"):
+        op.drop_table("dif_workflow_steps")


### PR DESCRIPTION
## Summary
- Avoid duplicate column errors in WorkflowStep by checking for existing columns before adding or dropping
- Guard new AuditLog columns and renames so running migrations on an up-to-date schema is safe
- Only create dif_requests and dif_workflow_steps tables when missing

## Testing
- `alembic upgrade head` *(fails: No support for ALTER of constraints in SQLite dialect)*
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*
- `pip install 'moto[s3]==4.2.0'` *(fails: Could not find a version that satisfies the requirement moto==4.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b03c7307a8832bb57b35240776a242