### PR TITLE
Ensure seeding script initializes database tables

### DIFF
--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -8,7 +8,7 @@ variables.  If the user already exists it will simply be granted the
 
 import os
 
-from portal.models import Role, RoleEnum, SessionLocal, User
+from portal.models import Base, Role, RoleEnum, SessionLocal, User, engine
 
 
 def seed_roles(session) -> None:
@@ -35,6 +35,11 @@ def seed_admin_user(session) -> None:
 
 
 def seed() -> None:
+    """Create tables if needed and seed default data."""
+
+    # Ensure all tables exist before attempting to seed data.
+    Base.metadata.create_all(bind=engine)
+
     session = SessionLocal()
     try:
         seed_roles(session)

--- a/tests/test_seed_data.py
+++ b/tests/test_seed_data.py
@@ -1,0 +1,18 @@
+import runpy
+
+from portal import models
+
+
+def test_seed_creates_roles_and_admin():
+    runpy.run_path("scripts/seed_data.py", run_name="__main__")
+
+    session = models.SessionLocal()
+    try:
+        roles = {r.name for r in session.query(models.Role).all()}
+        expected = {r.value for r in models.RoleEnum}
+        assert expected <= roles
+
+        admin = session.query(models.User).filter_by(username="admin").first()
+        assert admin is not None
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- ensure seed_data creates tables before seeding roles and admin
- add regression test for seeding script

## Testing
- `pytest tests/test_seed_data.py`
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68b045747734832bba731f3bf153fd21