### PR TITLE
Enforce tags requirement during document creation

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1008,6 +1008,8 @@ def new_document():
                 errors["standard"] = "Standard is required"
             tags = request.form.get("tags", "")
             data["tags"] = ",".join([t.strip() for t in tags.split(",") if t.strip()])
+            if not data["tags"]:
+                errors["tags"] = "Tags are required"
             DOCUMENT_DRAFTS[draft_id] = data
             if errors:
                 standard_map = get_standard_map()


### PR DESCRIPTION
## Summary
- Validate that tags are provided in new document step 1

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*
- `pip install 'moto<5' -q` *(fails: Could not find a version that satisfies the requirement moto<5)*

------
https://chatgpt.com/codex/tasks/task_e_68b04e240f84832ba2943bd589a7c7a8