### PR TITLE
Validate standards against database entries

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -333,13 +333,11 @@ STANDARD_MAP = get_standard_map()
 def get_allowed_standards() -> set[str]:
     """Return a set of allowed standard codes.
 
-    Standards are only enforced when the ``ISO_STANDARDS`` environment variable is
-    defined.  This mirrors previous behaviour where the absence of this
-    variable meant standards were optional.
+    Validation now relies solely on the standards stored in the database. This
+    ensures the application honours configured standards even when the
+    ``ISO_STANDARDS`` environment variable is unset or unavailable.
     """
 
-    if not os.environ.get("ISO_STANDARDS"):
-        return set()
     return set(get_standard_map().keys())
 
 

--- a/tests/test_document_upload_key_extension.py
+++ b/tests/test_document_upload_key_extension.py
@@ -37,6 +37,7 @@ def test_api_appends_extension_to_key():
     portal_app.extract_text = lambda key: "dummy"
     portal_app.notify_mandatory_read = lambda doc, users: None
 
+    first_standard = next(iter(portal_app.STANDARD_MAP.keys()))
     payload = {
         "code": "DOC1",
         "title": "My Doc",
@@ -45,6 +46,7 @@ def test_api_appends_extension_to_key():
         "tags": "tag1,tag2",
         "uploaded_file_key": "abc123",
         "uploaded_file_name": "file.txt",
+        "standard": first_standard,
     }
 
     resp = client.post("/api/documents", json=payload)

--- a/tests/test_mandatory_read_notifications.py
+++ b/tests/test_mandatory_read_notifications.py
@@ -29,6 +29,7 @@ def test_mandatory_read_notification_does_not_detach():
         sess["user"] = {"id": 1}
         sess["roles"] = [app_module.RoleEnum.CONTRIBUTOR.value]
 
+    first_standard = next(iter(app_module.STANDARD_MAP.keys()))
     payload = {
         "code": "DOC1",
         "title": "My Doc",
@@ -37,6 +38,7 @@ def test_mandatory_read_notification_does_not_detach():
         "tags": "tag1,tag2",
         "uploaded_file_key": "abc123",
         "uploaded_file_name": "file.txt",
+        "standard": first_standard,
     }
 
     resp = client.post("/api/documents", json=payload)


### PR DESCRIPTION
## Summary
- ensure standard validation uses database values instead of the `ISO_STANDARDS` environment variable
- adjust tests to include a standard when creating documents

## Testing
- `pytest tests/test_document_standard_api.py tests/test_document_upload_key_extension.py tests/test_mandatory_read_notifications.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*
- `pip install 'moto<5'` *(fails: Could not find a version that satisfies the requirement moto<5)*

------
https://chatgpt.com/codex/tasks/task_e_68b0570380bc832b98e9db808eb54b5a