### PR TITLE
Handle closed connection for audit logging

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -230,7 +230,7 @@ def log_action(
         "at": datetime.utcnow(),
     }
 
-    if connection is not None:
+    if connection is not None and not connection.closed:
         connection.execute(AuditLog.__table__.insert(), [data])
     else:
         Session = sessionmaker(bind=engine)


### PR DESCRIPTION
## Summary
- avoid using closed SQLAlchemy connections when writing audit logs

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68b05a241a60832b9d4c2cadf9a9be27