### PR TITLE
Fix audit log insertion for new documents

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -230,7 +230,7 @@ def log_action(
         "at": datetime.utcnow(),
     }
 
-    if connection is not None and not connection.closed:
+    if connection is not None:
         connection.execute(AuditLog.__table__.insert(), [data])
     else:
         Session = sessionmaker(bind=engine)


### PR DESCRIPTION
## Summary
- write audit log entries using the existing event connection

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3')*


------
https://chatgpt.com/codex/tasks/task_e_68b05cc20e44832bb40feec8e57abf28