### PR TITLE
Remove duplicate document creation logs

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1894,7 +1894,6 @@ def create_document():
         session_db.close()
         return "user_id required", 400
     session_db.commit()
-    log_action(user_id, doc.id, "create_document")
     session_db.close()
     return redirect(url_for("document_detail", doc_id=doc.id))
 
@@ -1963,7 +1962,6 @@ def create_document_api(data: dict | None = None):
     if standard:
         session_db.add(DocumentStandard(doc_id=doc.id, standard_code=standard))
     session_db.commit()
-    log_action(user_id, doc.id, "create_document")
     content = extract_text(doc_key)
     index_document(doc, content)
     user_ids = [u.id for u in session_db.query(User).all()]

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -22,6 +22,15 @@ def models():
     return models_module
 
 
+@pytest.fixture()
+def app_models():
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
+    models_module.Base.metadata.create_all(bind=models_module.engine)
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    return app_module, models_module
+
+
 def test_document_crud_logs(models):
     m = models
     session = m.SessionLocal()
@@ -128,4 +137,44 @@ def test_dif_request_crud_logs(models):
     session.commit()
     logs = session.query(m.AuditLog).filter_by(entity_type="DifRequest", entity_id=dif_id, action="delete").all()
     assert len(logs) == 1
+    session.close()
+
+
+def test_create_document_api_logs_once(app_models):
+    app_module, models = app_models
+    from unittest.mock import MagicMock
+    storage = importlib.import_module("storage")
+    storage.storage_client.head_object = MagicMock(return_value={})
+    app_module.extract_text = lambda key: ""
+    app_module.notify_mandatory_read = lambda doc, users: None
+    app_module.index_document = lambda doc, content: None
+
+    client = app_module.app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1}
+        sess["roles"] = [app_module.RoleEnum.CONTRIBUTOR.value]
+
+    first = list(app_module.STANDARD_MAP.keys())[0]
+    payload = {
+        "code": "DOC_API",
+        "title": "API Doc",
+        "type": "T",
+        "department": "Dept",
+        "tags": "tag1,tag2",
+        "uploaded_file_key": "key123",
+        "uploaded_file_name": "file.txt",
+        "standard": first,
+    }
+    resp = client.post("/api/documents", json=payload)
+    assert resp.status_code == 201
+    doc_id = resp.get_json()["id"]
+
+    session = models.SessionLocal()
+    logs = (
+        session.query(models.AuditLog)
+        .filter_by(entity_type="Document", entity_id=doc_id)
+        .all()
+    )
+    assert len(logs) == 1
+    assert logs[0].action == "create"
     session.close()


### PR DESCRIPTION
## Summary
- rely on model events for document creation logging
- drop redundant log calls in document creation endpoints
- add unit test ensuring a single audit log entry when creating a document via API

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*
- `pytest tests/test_audit_log.py::test_create_document_api_logs_once -vv`

------
https://chatgpt.com/codex/tasks/task_e_68b06193f3f0832ba905fc18180bab05