### PR TITLE
Ensure audit logs use current session

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -204,6 +204,7 @@ def log_action(
     entity_id=None,
     payload=None,
     connection=None,
+    session=None,
 ):
     """Persist an audit log entry."""
     if entity_type is None and entity_id is None and doc_id is not None:
@@ -238,13 +239,17 @@ def log_action(
         except ResourceClosedError:
             pass
 
-    Session = sessionmaker(bind=engine)
-    session = Session()
-    try:
+    if session is not None:
         session.execute(AuditLog.__table__.insert(), [data])
-        session.commit()
+        return
+
+    Session = sessionmaker(bind=engine)
+    _session = Session()
+    try:
+        _session.execute(AuditLog.__table__.insert(), [data])
+        _session.commit()
     finally:
-        session.close()
+        _session.close()
 
 
 # Demo quiz questions

--- a/portal/models.py
+++ b/portal/models.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import (
     scoped_session,
     joinedload,
     synonym,
+    object_session,
 )
 import sys
 
@@ -452,6 +453,7 @@ def _capture_changes(target):
 @event.listens_for(Document, "after_insert")
 def _log_document_insert(mapper, connection, target):
     from app import log_action
+    session = object_session(target)
 
     payload = {"title": target.title, "status": target.status}
     log_action(
@@ -462,12 +464,14 @@ def _log_document_insert(mapper, connection, target):
         entity_id=target.id,
         payload=payload,
         connection=connection,
+        session=session,
     )
 
 
 @event.listens_for(Document, "after_update")
 def _log_document_update(mapper, connection, target):
     from app import log_action
+    session = object_session(target)
 
     changes = _capture_changes(target)
     if changes:
@@ -479,6 +483,7 @@ def _log_document_update(mapper, connection, target):
             entity_id=target.id,
             payload={"changes": changes},
             connection=connection,
+            session=session,
         )
 
 


### PR DESCRIPTION
## Summary
- allow `log_action` to accept an existing SQLAlchemy session
- use the active session when logging document inserts and updates so audit rows participate in the same transaction

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*
- `pip install 'moto[boto3]==4.1.14'` *(fails: Could not find a version that satisfies the requirement moto==4.1.14)*
- `pytest tests/test_audit_log.py::test_create_document_api_logs_once -q`


------
https://chatgpt.com/codex/tasks/task_e_68b065edabd0832b9785d8251df2158f