### PR TITLE
Handle audit log FK issue when document missing

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -246,6 +246,8 @@ def log_action(
     Session = sessionmaker(bind=engine)
     _session = Session()
     try:
+        if doc_id is not None and _session.get(Document, doc_id) is None:
+            data["doc_id"] = None
         _session.execute(AuditLog.__table__.insert(), [data])
         _session.commit()
     finally:


### PR DESCRIPTION
## Summary
- prevent audit log FK violations by dropping `doc_id` when the referenced document isn't yet persisted

## Testing
- `pytest tests/test_audit_log.py::test_document_crud_logs -q` *(fails: OperationalError database is locked / Elasticsearch connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b068044ab4832b836c50217a200f32