### PR TITLE
Fix OnlyOffice JWT header mismatch

### DIFF
--- a/docs/onlyoffice.md
+++ b/docs/onlyoffice.md
@@ -5,3 +5,7 @@ The portal uses [OnlyOffice](https://www.onlyoffice.com/) for document editing. 
 ## Environment Variables
 
 - `PORTAL_PUBLIC_BASE_URL`: Public base URL used to build OnlyOffice callback URLs. Defaults to the request's host URL when not defined.
+- `ONLYOFFICE_INTERNAL_URL`: Base URL the portal uses to contact the Document Server.
+- `ONLYOFFICE_PUBLIC_URL`: Publicly reachable URL of the Document Server used by the browser.
+- `ONLYOFFICE_JWT_SECRET`: Shared secret for signing JWT payloads.
+- `ONLYOFFICE_JWT_HEADER`: HTTP header name that carries the JWT. Defaults to `Authorization`.

--- a/portal/app.py
+++ b/portal/app.py
@@ -166,7 +166,7 @@ if USE_ONLYOFFICE:
     ONLYOFFICE_PUBLIC_URL = os.environ.get("ONLYOFFICE_PUBLIC_URL")
     ONLYOFFICE_JWT_SECRET = os.environ.get("ONLYOFFICE_JWT_SECRET", "")
     ONLYOFFICE_JWT_HEADER = os.environ.get(
-        "ONLYOFFICE_JWT_HEADER", "AuthorizationJwt"
+        "ONLYOFFICE_JWT_HEADER", "Authorization"
     )
 else:
     ONLYOFFICE_INTERNAL_URL = None

--- a/tests/test_document_versioning.py
+++ b/tests/test_document_versioning.py
@@ -101,7 +101,7 @@ def test_compare_config_returns_expected_fields(client, app_models):
         f"http://s3/local/{doc_key}"
     )
     assert data["token"]
-    assert data["token_header"] == "AuthorizationJwt"
+    assert data["token_header"] == "Authorization"
 
 
 def test_revert_document_preserves_history(client, app_models):


### PR DESCRIPTION
## Summary
- default to the standard `Authorization` header for OnlyOffice JWTs
- document OnlyOffice environment variables and JWT header default
- update tests to expect the new header

## Testing
- `pytest tests/test_document_versioning.py::test_compare_config_returns_expected_fields -q`

------
https://chatgpt.com/codex/tasks/task_e_68b076e9bc88832b8557768949be24f1