### PR TITLE
Allow disabling OnlyOffice JWT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     image: onlyoffice/documentserver:latest
     restart: unless-stopped
     environment:
-      JWT_ENABLED: "true"
+      JWT_ENABLED: ${ONLYOFFICE_JWT_ENABLED:-false}
       JWT_SECRET: ${ONLYOFFICE_JWT_SECRET}
       JWT_HEADER: ${ONLYOFFICE_JWT_HEADER}
     # Eğer büyük dosyalar/çok kullanıcı planı varsa CPU/RAM artırın

--- a/docs/onlyoffice.md
+++ b/docs/onlyoffice.md
@@ -7,5 +7,6 @@ The portal uses [OnlyOffice](https://www.onlyoffice.com/) for document editing. 
 - `PORTAL_PUBLIC_BASE_URL`: Public base URL used to build OnlyOffice callback URLs. Defaults to the request's host URL when not defined.
 - `ONLYOFFICE_INTERNAL_URL`: Base URL the portal uses to contact the Document Server.
 - `ONLYOFFICE_PUBLIC_URL`: Publicly reachable URL of the Document Server used by the browser.
+- `ONLYOFFICE_JWT_ENABLED`: Controls JWT validation in the Document Server. Set to `true` to require JWTs. Defaults to `false`.
 - `ONLYOFFICE_JWT_SECRET`: Shared secret for signing JWT payloads.
 - `ONLYOFFICE_JWT_HEADER`: HTTP header name that carries the JWT. Defaults to `Authorization`.


### PR DESCRIPTION
## Summary
- Make JWT authentication on the OnlyOffice Document Server optional
- Document the new ONLYOFFICE_JWT_ENABLED flag

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*
- `pip install moto==4.2.4` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68b310524bb8832ba69951f937a90f89