### PR TITLE
Allow unauthenticated OnlyOffice callbacks and permit internal MinIO access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       JWT_ENABLED: ${ONLYOFFICE_JWT_ENABLED:-false}
       JWT_SECRET: ${ONLYOFFICE_JWT_SECRET}
       JWT_HEADER: ${ONLYOFFICE_JWT_HEADER}
+      ALLOW_PRIVATE_IP: "true"  # allow access to services on the internal network
     # Eğer büyük dosyalar/çok kullanıcı planı varsa CPU/RAM artırın
     networks: [qdms]
 

--- a/docs/onlyoffice.md
+++ b/docs/onlyoffice.md
@@ -10,3 +10,4 @@ The portal uses [OnlyOffice](https://www.onlyoffice.com/) for document editing. 
 - `ONLYOFFICE_JWT_ENABLED`: Controls JWT validation in the Document Server. Set to `true` to require JWTs. Defaults to `false`.
 - `ONLYOFFICE_JWT_SECRET`: Shared secret for signing JWT payloads.
 - `ONLYOFFICE_JWT_HEADER`: HTTP header name that carries the JWT. Defaults to `Authorization`.
+- `ALLOW_PRIVATE_IP`: Set to `true` to allow the Document Server to access private network resources such as the local MinIO service.

--- a/portal/app.py
+++ b/portal/app.py
@@ -4339,7 +4339,6 @@ def api_dif_request_changes(id: int):
         db.close()
 
 @app.post("/onlyoffice/callback/<path:doc_key>")
-@login_required
 def onlyoffice_callback(doc_key):
     data = request.get_json(silent=True) or {}
     status = data.get("status")

--- a/tests/test_onlyoffice_callback_no_auth.py
+++ b/tests/test_onlyoffice_callback_no_auth.py
@@ -1,0 +1,39 @@
+import os
+import importlib
+
+# Set required environment variables before importing the application
+os.environ.setdefault("ONLYOFFICE_INTERNAL_URL", "http://oo")
+os.environ.setdefault("ONLYOFFICE_PUBLIC_URL", "http://oo-public")
+os.environ.setdefault("ONLYOFFICE_JWT_SECRET", "secret")
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+
+def test_onlyoffice_callback_allows_unauthenticated_post():
+    os.environ.pop("PORTAL_PUBLIC_BASE_URL", None)
+
+    app_module = importlib.reload(importlib.import_module("app"))
+    models = importlib.reload(importlib.import_module("models"))
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    client = app_module.app.test_client()
+
+    session = models.SessionLocal()
+    doc = models.Document(doc_key="doc.docx", title="Doc")
+    session.add(doc)
+    session.commit()
+    doc_id = doc.id
+    doc_key = doc.doc_key
+    session.close()
+
+    resp = client.post(
+        f"/onlyoffice/callback/{doc_key}",
+        json={"status": 2, "url": "http://s3/doc.docx"},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == {"error": 0}
+
+    session = models.SessionLocal()
+    updated = session.get(models.Document, doc_id)
+    assert updated.minor_version == 1
+    revisions = session.query(models.DocumentRevision).filter_by(doc_id=doc_id).all()
+    assert len(revisions) == 1
+    session.close()


### PR DESCRIPTION
## Summary
- drop login requirement from OnlyOffice callback endpoint
- allow Document Server to reach private services via ALLOW_PRIVATE_IP
- document new env var and add regression test

## Testing
- `pytest tests/test_edit_document_callback_url.py::test_edit_route_builds_callback_url_from_request_host tests/test_onlyoffice_callback_no_auth.py::test_onlyoffice_callback_allows_unauthenticated_post -q`

------
https://chatgpt.com/codex/tasks/task_e_68b313c3c9e4832bb148c3898c0065af