### PR TITLE
Route OnlyOffice callbacks through portal

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -62,6 +62,15 @@ http {
       add_header Cache-Control "public";
     }
 
+    # OnlyOffice callback endpoint should reach the portal
+    location /onlyoffice/callback/ {
+      proxy_pass http://portal_up;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # OnlyOffice Document Server subpath
     location /onlyoffice/ {
       proxy_pass http://onlyoffice_up/;


### PR DESCRIPTION
## Summary
- ensure OnlyOffice callback URLs are routed to the portal instead of the document server

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68b31753f070832ba1ca7cdce31c41a9