### PR TITLE
Route versioned OnlyOffice paths

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -93,5 +93,20 @@ http {
       proxy_set_header Connection $connection_upgrade;
       proxy_http_version 1.1;
     }
+
+    # OnlyOffice versioned resources (e.g. /9.0.4-<hash>/doc/...)
+    location ~ ^/\d+\.\d+\.\d+-[^/]+/ {
+      proxy_pass http://onlyoffice_up;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_hide_header X-Frame-Options;
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://qdms.example.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://qdms.example.com; style-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self' ws: wss:; frame-ancestors 'self'" always;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Forward OnlyOffice versioned endpoints (like `/9.0.4-<hash>/doc/...`) to the Document Server upstream
- Preserve WebSocket headers and security headers for these requests

## Testing
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_68b31f7a77a8832b9059e82ef9f19b19