### PR TITLE
chore: drop onlyoffice service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,16 +49,6 @@ services:
       "
     restart: "no"
 
-  onlyoffice:
-    image: onlyoffice/documentserver:latest
-    restart: unless-stopped
-    environment:
-      JWT_ENABLED: ${ONLYOFFICE_JWT_ENABLED:-false}
-      JWT_SECRET: ${ONLYOFFICE_JWT_SECRET}
-      JWT_HEADER: ${ONLYOFFICE_JWT_HEADER}
-      ONLYOFFICE_DOCUMENT_SERVER_SERVICES_COAUTHORING_REQUEST_RESTRICTIONS_ALLOWPRIVATEIPADDRESS: "true"  # allow access to services on the internal network
-    # Eğer büyük dosyalar/çok kullanıcı planı varsa CPU/RAM artırın
-    networks: [qdms]
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
@@ -82,10 +72,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 0
-      ONLYOFFICE_INTERNAL_URL: ${ONLYOFFICE_INTERNAL_URL}
-      ONLYOFFICE_PUBLIC_URL: ${ONLYOFFICE_PUBLIC_URL}
-      ONLYOFFICE_JWT_SECRET: ${ONLYOFFICE_JWT_SECRET}
-      ONLYOFFICE_JWT_HEADER: ${ONLYOFFICE_JWT_HEADER}
       S3_ENDPOINT: ${S3_ENDPOINT}
       S3_REGION: ${S3_REGION}
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
@@ -107,7 +93,6 @@ services:
       - redis
       - minio
       - minio-setup
-      - onlyoffice
       - elasticsearch
     networks: [qdms]
     volumes:
@@ -130,10 +115,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 0
-      ONLYOFFICE_INTERNAL_URL: ${ONLYOFFICE_INTERNAL_URL}
-      ONLYOFFICE_PUBLIC_URL: ${ONLYOFFICE_PUBLIC_URL}
-      ONLYOFFICE_JWT_SECRET: ${ONLYOFFICE_JWT_SECRET}
-      ONLYOFFICE_JWT_HEADER: ${ONLYOFFICE_JWT_HEADER}
       S3_ENDPOINT: ${S3_ENDPOINT}
       S3_REGION: ${S3_REGION}
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
@@ -156,7 +137,6 @@ services:
       - redis
       - minio
       - minio-setup
-      - onlyoffice
       - elasticsearch
     networks: [qdms]
 
@@ -175,10 +155,6 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 0
-      ONLYOFFICE_INTERNAL_URL: ${ONLYOFFICE_INTERNAL_URL}
-      ONLYOFFICE_PUBLIC_URL: ${ONLYOFFICE_PUBLIC_URL}
-      ONLYOFFICE_JWT_SECRET: ${ONLYOFFICE_JWT_SECRET}
-      ONLYOFFICE_JWT_HEADER: ${ONLYOFFICE_JWT_HEADER}
       S3_ENDPOINT: ${S3_ENDPOINT}
       S3_REGION: ${S3_REGION}
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
@@ -206,7 +182,6 @@ services:
       - redis
       - minio
       - minio-setup
-      - onlyoffice
       - elasticsearch
     networks: [qdms]
 
@@ -215,7 +190,6 @@ services:
     restart: unless-stopped
     depends_on:
       - portal
-      - onlyoffice
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       # Serve static assets built at image creation


### PR DESCRIPTION
## Summary
- remove OnlyOffice document server from docker-compose
- drop ONLYOFFICE_* environment variables
- update dependencies and nginx configuration

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `pip install "moto<5"` *(fails: Could not connect to proxy / No matching distribution)*
- `docker compose up -d` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b328dc6568832bb8d87ee3ad56215f