### PR TITLE
Remove OnlyOffice proxy and tighten Nginx frame policies

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -14,10 +14,6 @@ http {
     server portal:8000;
   }
 
-  upstream onlyoffice_up {
-    server onlyoffice:80;
-  }
-
   map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;
@@ -28,8 +24,8 @@ http {
     server_name _;
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Frame-Options "DENY";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://qdms.example.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://qdms.example.com; style-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Content-Security-Policy "frame-ancestors 'none'" always;
 
     # 443 kullanacaksanız:
     # listen 443 ssl http2;
@@ -62,51 +58,6 @@ http {
       add_header Cache-Control "public";
     }
 
-    # OnlyOffice callback endpoint should reach the portal
-    location /onlyoffice/callback/ {
-      proxy_pass http://portal_up;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # OnlyOffice Document Server subpath
-    location /onlyoffice/ {
-      proxy_pass http://onlyoffice_up/;
-      proxy_http_version 1.1;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $connection_upgrade;
-      proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Host $host;
-      proxy_set_header X-Forwarded-Port $server_port;
-      proxy_hide_header X-Frame-Options;
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://qdms.example.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://qdms.example.com; style-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self' ws: wss:; frame-ancestors 'self'" always;
-    }
-
-    # WebSocket yolları (OnlyOffice)
-    location /onlyoffice/websocket/ {
-      proxy_pass http://onlyoffice_up/websocket/;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $connection_upgrade;
-      proxy_http_version 1.1;
-    }
-
-    # OnlyOffice versioned resources (e.g. /9.0.4-<hash>/doc/...)
-    location ~ ^/\d+\.\d+\.\d+-[^/]+/ {
-      proxy_pass http://onlyoffice_up;
-      proxy_http_version 1.1;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $connection_upgrade;
-      proxy_set_header Host $host;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Host $host;
-      proxy_set_header X-Forwarded-Port $server_port;
-      proxy_hide_header X-Frame-Options;
-      add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://qdms.example.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://qdms.example.com; style-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self' ws: wss:; frame-ancestors 'self'" always;
-    }
+    # OnlyOffice-related proxy paths have been removed.
   }
 }


### PR DESCRIPTION
## Summary
- drop OnlyOffice upstream and related proxy routes from Nginx config
- replace large CSP/X-Frame overrides with global DENY and frame-ancestors none

## Testing
- `nginx -t -c /workspace/baylan-kys/nginx/nginx.conf` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `pytest` *(fails: ImportError: cannot import name 'mock_s3' from 'moto')*


------
https://chatgpt.com/codex/tasks/task_e_68b333896050832b9f17b84cb4b95e04