### PR TITLE
Clarify LibreOffice PDF conversion

### DIFF
--- a/portal/signing.py
+++ b/portal/signing.py
@@ -11,7 +11,7 @@ HSM_API_URL = os.environ.get("HSM_API_URL", "http://hsm.example.com/sign")
 
 
 def convert_to_pdf(source_path: str, output_dir: str) -> str:
-    """Convert a document to PDF using LibreOffice.
+    """Convert a document to PDF using LibreOffice in headless mode.
 
     The caller is responsible for providing a temporary ``output_dir`` and
     cleaning up any files created within it.


### PR DESCRIPTION
## Summary
- clarify convert_to_pdf docstring to indicate LibreOffice headless usage

## Testing
- `pytest` (5 failed, 95 passed, 610 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b339c35694832ba748eb8737cb7aff