### PR TITLE
Add secure document download endpoint

### DIFF
--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -56,8 +56,8 @@
 
 <div class="toolbar" data-component="toolbar">
   <a class="btn btn-secondary" href="{{ url_for('list_documents') }}">Back to documents</a>
-  {% if download_url %}
-  <a class="btn btn-secondary" href="{{ download_url }}">Download</a>
+  {% if can_download %}
+  <a class="btn btn-secondary" href="{{ url_for('document_download', doc_id=doc.id) }}">Download</a>
   {% endif %}
 </div>
 

--- a/portal/templates/documents/_table.html
+++ b/portal/templates/documents/_table.html
@@ -39,7 +39,9 @@
           {% else %}
           <span class="btn btn-sm btn-outline-secondary disabled">Workflow</span>
           {% endif %}
-          <a href="{{ url_for('get_file', file_key=doc.doc_key) }}" class="btn btn-sm btn-outline-secondary">Download</a>
+          {% if doc.can_download %}
+          <a href="{{ url_for('document_download', doc_id=doc.id) }}" class="btn btn-sm btn-outline-secondary">Download</a>
+          {% endif %}
           <a href="{{ url_for('new_document', step=1) }}?doc_id={{ doc.id }}" class="btn btn-sm btn-outline-secondary">Upload New Version</a>
         </td>
       </tr>

--- a/portal/templates/partials/documents/_versions.html
+++ b/portal/templates/partials/documents/_versions.html
@@ -25,8 +25,8 @@
           <button type="button" id="compare-to-button" class="btn btn-outline-primary mt-2"
             data-url="{{ url_for('compare_document_versions', doc_id=doc.id) }}"
             data-rev-id="{{ revision.id }}">Compare to…</button>
-          {% if download_url %}
-          <a class="btn btn-outline-secondary mt-2" href="{{ download_url }}">Download</a>
+          {% if can_download %}
+          <a class="btn btn-outline-secondary mt-2" href="{{ url_for('document_download', doc_id=doc.id) }}">Download</a>
           {% endif %}
         </div>
         {% else %}

--- a/tests/test_document_download.py
+++ b/tests/test_document_download.py
@@ -1,0 +1,84 @@
+import sys
+import importlib
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+os = __import__("os")
+
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+os.environ.setdefault("S3_BUCKET_MAIN", "test-bucket")
+os.environ.setdefault("S3_ACCESS_KEY", "test")
+os.environ.setdefault("S3_SECRET_KEY", "test")
+
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+
+@pytest.fixture()
+def app_modules():
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    return app_module, models_module
+
+
+def _setup_document(models, can_download: bool):
+    session = models.SessionLocal()
+    try:
+        role = models.Role(id=1, name="reader")
+        user = models.User(id=1, username="u1")
+        user.roles.append(role)
+        doc = models.Document(id=1, file_key="foo/bar.txt", title="t")
+        session.add_all([role, user, doc])
+        session.commit()
+        perm = models.DocumentPermission(
+            role_id=role.id, doc_id=doc.id, can_download=can_download
+        )
+        session.add(perm)
+        session.commit()
+    finally:
+        session.close()
+
+
+def test_document_download_redirects_and_logs(app_modules):
+    app_module, models = app_modules
+    _setup_document(models, can_download=True)
+    app_module.storage_client.generate_presigned_url = MagicMock(
+        return_value="/signed"
+    )
+    client = app_module.app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1}
+        sess["roles"] = ["reader"]
+    resp = client.get("/documents/1/download")
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/signed"
+    app_module.storage_client.generate_presigned_url.assert_called_once_with(
+        "foo/bar.txt"
+    )
+    log_session = models.SessionLocal()
+    try:
+        logs = (
+            log_session.query(models.AuditLog)
+            .filter_by(doc_id=1, action="download_document")
+            .all()
+        )
+        assert len(logs) == 1
+    finally:
+        log_session.close()
+
+
+def test_document_download_forbidden(app_modules):
+    app_module, models = app_modules
+    _setup_document(models, can_download=False)
+    app_module.storage_client.generate_presigned_url = MagicMock(return_value="/signed")
+    client = app_module.app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1}
+        sess["roles"] = ["reader"]
+    resp = client.get("/documents/1/download")
+    assert resp.status_code == 403
+    app_module.storage_client.generate_presigned_url.assert_not_called()


### PR DESCRIPTION
## Summary
- add `/documents/<doc_id>/download` endpoint that checks permissions, logs downloads and redirects to presigned URLs
- update document detail, version history, and document list templates to use the new endpoint and hide download buttons when not permitted
- cover download permission logic and audit logging with tests

## Testing
- `pytest tests/test_document_download.py::test_document_download_redirects_and_logs -q`
- `pytest tests/test_document_download.py::test_document_download_forbidden -q`
- `pytest tests/test_file_access.py::test_file_access_requires_role -q`


------
https://chatgpt.com/codex/tasks/task_e_68b33be981d0832b86c57bc0f029899b