### PR TITLE
Add document version upload endpoint with file tracking

### DIFF
--- a/alembic/versions/0017_add_file_key_to_document_revisions.py
+++ b/alembic/versions/0017_add_file_key_to_document_revisions.py
@@ -1,0 +1,36 @@
+"""Add file_key column to document_revisions
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2025-09-08
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "0017"
+down_revision = "0016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("document_revisions")]
+    if "file_key" not in columns:
+        op.add_column(
+            "document_revisions",
+            sa.Column("file_key", sa.String(), nullable=False, server_default=""),
+        )
+        op.alter_column("document_revisions", "file_key", server_default=None)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("document_revisions")]
+    if "file_key" in columns:
+        op.drop_column("document_revisions", "file_key")

--- a/portal/models.py
+++ b/portal/models.py
@@ -113,6 +113,7 @@ class DocumentRevision(Base):
     doc_id = Column(Integer, ForeignKey('documents.id'), nullable=False)
     major_version = Column(Integer, nullable=False)
     minor_version = Column(Integer, nullable=False)
+    file_key = Column(String, nullable=False)
     revision_notes = Column(Text)
     track_changes = Column(JSON)
     compare_result = Column(JSON)

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -42,15 +42,16 @@
 </ul>
 
 <h2>Revision History</h2>
-{% if revisions %}
-<ul>
-  {% for rev in revisions %}
-  <li>Version {{ rev.major_version }}.{{ rev.minor_version }} – {{ rev.created_at.strftime('%Y-%m-%d') }}</li>
-  {% endfor %}
-</ul>
-{% else %}
-<p>No revisions found.</p>
-{% endif %}
+{% include "partials/documents/_versions.html" %}
+<form class="mt-3" hx-post="/api/documents/{{ doc.id }}/versions" hx-target="#version-list" hx-swap="outerHTML" hx-encoding="multipart/form-data">
+  <div class="mb-2">
+    <input type="file" name="file" required>
+  </div>
+  <div class="mb-2">
+    <input type="text" class="form-control" name="notes" placeholder="Revision notes">
+  </div>
+  <button type="submit" class="btn btn-primary">Upload New Version</button>
+</form>
 
 {% include "partials/_audit_log.html" %}
 

--- a/portal/templates/partials/documents/_versions.html
+++ b/portal/templates/partials/documents/_versions.html
@@ -1,4 +1,4 @@
-<form method="get" action="{{ url_for('compare_document_versions', doc_id=doc.id) }}">
+<form id="version-list" method="get" action="{{ url_for('compare_document_versions', doc_id=doc.id) }}">
   <div class="row">
     <div class="col-md-8">
       <ul class="list-group">

--- a/tests/test_archive_retention.py
+++ b/tests/test_archive_retention.py
@@ -30,7 +30,10 @@ def test_move_to_archive_retains_object_and_lists():
 
         head = client.head_object(Bucket="qdms-archive", Key=dest_key)
         assert head["ObjectLockMode"] == "COMPLIANCE"
-        assert head["ObjectLockRetainUntilDate"] > datetime.utcnow()
+        retain = head["ObjectLockRetainUntilDate"]
+        if getattr(retain, "tzinfo", None):
+            retain = retain.replace(tzinfo=None)
+        assert retain > datetime.utcnow()
 
         assert dest_key in storage.list_archived()
 

--- a/tests/test_dashboard_cards.py
+++ b/tests/test_dashboard_cards.py
@@ -40,7 +40,7 @@ def app_models():
         step_type="approval",
     )
     revision = m.DocumentRevision(
-        doc_id=recent_doc.id, major_version=1, minor_version=0
+        doc_id=recent_doc.id, major_version=1, minor_version=0, file_key="recent.docx"
     )
     session.add_all([step, revision])
     session.commit()

--- a/tests/test_document_version_upload.py
+++ b/tests/test_document_version_upload.py
@@ -1,0 +1,133 @@
+import io
+import importlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+os.environ["S3_BUCKET_MAIN"] = "local"
+
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+
+@pytest.fixture()
+def app_models():
+    os.environ["S3_BUCKET_MAIN"] = "local"
+    importlib.reload(importlib.import_module("storage"))
+    importlib.reload(importlib.import_module("portal.storage"))
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    return app_module, models_module
+
+
+@pytest.fixture()
+def client(app_models):
+    app_module, _ = app_models
+    return app_module.app.test_client()
+
+
+def _login(client):
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1, "name": "Tester"}
+        sess["roles"] = ["contributor"]
+
+
+def _create_doc(models):
+    session = models.SessionLocal()
+    doc = models.Document(
+        file_key="orig.pdf",
+        title="Doc",
+        status="Published",
+        mime="application/pdf",
+    )
+    session.add(doc)
+    session.commit()
+    doc_id = doc.id
+    session.close()
+    return doc_id
+
+
+def test_upload_new_version_success(client, app_models):
+    app_module, models = app_models
+    _login(client)
+    doc_id = _create_doc(models)
+
+    storage = importlib.import_module("storage")
+    storage.storage_client.put = MagicMock()
+
+    data = {"file": (io.BytesIO(b"data"), "test.pdf"), "notes": "rev1"}
+    resp = client.post(
+        f"/api/documents/{doc_id}/versions",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body["minor_version"] == 1
+
+    session = models.SessionLocal()
+    doc = session.get(models.Document, doc_id)
+    assert doc.minor_version == 1
+    assert doc.doc_key.endswith("1.1.pdf")
+    revs = session.query(models.DocumentRevision).filter_by(doc_id=doc_id).all()
+    assert len(revs) == 1
+    assert revs[0].file_key == "orig.pdf"
+    session.close()
+    assert storage.storage_client.put.called
+
+
+def test_upload_new_version_invalid_mime(client, app_models):
+    app_module, models = app_models
+    _login(client)
+    doc_id = _create_doc(models)
+
+    storage = importlib.import_module("storage")
+    storage.storage_client.put = MagicMock()
+
+    data = {"file": (io.BytesIO(b"data"), "test.txt")}
+    resp = client.post(
+        f"/api/documents/{doc_id}/versions",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 400
+
+    session = models.SessionLocal()
+    doc = session.get(models.Document, doc_id)
+    assert doc.minor_version == 0
+    revs = session.query(models.DocumentRevision).filter_by(doc_id=doc_id).all()
+    assert len(revs) == 0
+    session.close()
+    storage.storage_client.put.assert_not_called()
+
+
+def test_upload_new_version_too_large(client, app_models):
+    app_module, models = app_models
+    _login(client)
+    doc_id = _create_doc(models)
+
+    storage = importlib.import_module("storage")
+    storage.storage_client.put = MagicMock()
+
+    app_module.MAX_UPLOAD_SIZE = 100
+    data = {"file": (io.BytesIO(b"x" * 101), "test.pdf")}
+    resp = client.post(
+        f"/api/documents/{doc_id}/versions",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 400
+
+    session = models.SessionLocal()
+    doc = session.get(models.Document, doc_id)
+    assert doc.minor_version == 0
+    revs = session.query(models.DocumentRevision).filter_by(doc_id=doc_id).all()
+    assert len(revs) == 0
+    session.close()
+    storage.storage_client.put.assert_not_called()

--- a/tests/test_new_document_session.py
+++ b/tests/test_new_document_session.py
@@ -72,8 +72,8 @@ def test_final_payload_includes_department_and_type():
 
     captured = {}
 
-    def fake_create_document_api():
-        captured.update(app_module.request.get_json() or {})
+    def fake_create_document_api(data=None):
+        captured.update(data or {})
         return app_module.jsonify({"id": 1}), 201
 
     app_module.create_document_api = fake_create_document_api

--- a/tests/test_z_dashboard_api.py
+++ b/tests/test_z_dashboard_api.py
@@ -65,8 +65,18 @@ def models(reset_database):
     session.add_all([ack1, ack2])
     session.commit()
 
-    rev1 = DocumentRevision(doc_id=mandatory_doc1.id, major_version=1, minor_version=0)
-    rev2 = DocumentRevision(doc_id=mandatory_doc2.id, major_version=1, minor_version=0)
+    rev1 = DocumentRevision(
+        doc_id=mandatory_doc1.id,
+        major_version=1,
+        minor_version=0,
+        file_key="mandatory1.docx",
+    )
+    rev2 = DocumentRevision(
+        doc_id=mandatory_doc2.id,
+        major_version=1,
+        minor_version=0,
+        file_key="mandatory2.docx",
+    )
     session.add_all([rev1, rev2])
     session.commit()
 


### PR DESCRIPTION
## Summary
- track revision file paths via new `file_key` column and migration
- implement `/api/documents/<doc_id>/versions` to upload new document versions
- add UI form for uploading new versions and update revision listing
- ensure uploads validate size and MIME; add test coverage

## Testing
- `pytest tests/test_archive_retention.py tests/test_document_versioning.py tests/test_new_document_session.py tests/test_dashboard_cards.py tests/test_z_dashboard_api.py tests/test_document_version_upload.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b33d078458832b90d2bc3ca6a430c1