### PR TITLE
Add document checkout locks with expiry and guard

### DIFF
--- a/alembic/versions/0018_add_document_locks.py
+++ b/alembic/versions/0018_add_document_locks.py
@@ -1,0 +1,40 @@
+"""Add lock fields to documents
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2025-09-09
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("documents")]
+    if "locked_by" not in columns:
+        op.add_column("documents", sa.Column("locked_by", sa.Integer(), nullable=True))
+        op.create_foreign_key(
+            "documents_locked_by_fkey", "documents", "users", ["locked_by"], ["id"]
+        )
+    if "lock_expires_at" not in columns:
+        op.add_column("documents", sa.Column("lock_expires_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("documents")]
+    if "lock_expires_at" in columns:
+        op.drop_column("documents", "lock_expires_at")
+    if "locked_by" in columns:
+        op.drop_constraint("documents_locked_by_fkey", "documents", type_="foreignkey")
+        op.drop_column("documents", "locked_by")

--- a/portal/clear_locks_job.py
+++ b/portal/clear_locks_job.py
@@ -1,0 +1,10 @@
+"""Cron job to clear expired document locks."""
+from services import clear_expired_locks
+
+
+def run() -> None:
+    clear_expired_locks()
+
+
+if __name__ == "__main__":
+    run()

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -28,6 +28,28 @@
 
 {% block content %}
 <h1>{{ doc.title }}</h1>
+{% if doc.locked_by and doc.lock_expires_at and doc.lock_expires_at > now %}
+  {% if current_user and current_user.id == doc.locked_by %}
+  <div class="alert alert-info">Checked out by you until {{ doc.lock_expires_at }}.</div>
+  <form class="mb-3" hx-post="/api/documents/{{ doc.id }}/checkin" hx-swap="none">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <button type="submit" class="btn btn-warning">Check in</button>
+  </form>
+  {% else %}
+  <div class="alert alert-warning">Locked by {{ doc.lock_owner.username if doc.lock_owner else 'another user' }} until {{ doc.lock_expires_at }}.</div>
+  {% if 'quality_admin' in user_roles %}
+  <form class="mb-3" hx-post="/api/documents/{{ doc.id }}/checkin" hx-swap="none">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <button type="submit" class="btn btn-danger">Force Check in</button>
+  </form>
+  {% endif %}
+  {% endif %}
+{% else %}
+  <form class="mb-3" hx-post="/api/documents/{{ doc.id }}/checkout" hx-swap="none">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <button type="submit" class="btn btn-outline-primary">Check out</button>
+  </form>
+{% endif %}
 {% if preview.type %}
 <div id="preview-container" class="mb-4"></div>
 <script>

--- a/tests/test_document_locking.py
+++ b/tests/test_document_locking.py
@@ -1,0 +1,97 @@
+import io
+import importlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+from datetime import datetime, timedelta
+
+import pytest
+
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+os.environ["S3_BUCKET_MAIN"] = "local"
+
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+
+@pytest.fixture()
+def app_models():
+    os.environ["S3_BUCKET_MAIN"] = "local"
+    importlib.reload(importlib.import_module("storage"))
+    importlib.reload(importlib.import_module("portal.storage"))
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.reload(importlib.import_module("models"))
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    return app_module, models_module
+
+
+@pytest.fixture()
+def client(app_models):
+    app_module, _ = app_models
+    return app_module.app.test_client()
+
+
+def _login(client, user_id, roles=None):
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": user_id, "name": f"User{user_id}"}
+        sess["roles"] = roles or ["contributor"]
+
+
+def _create_doc_and_users(models):
+    session = models.SessionLocal()
+    u1 = models.User(username="u1")
+    u2 = models.User(username="u2")
+    session.add_all([u1, u2])
+    session.commit()
+    doc = models.Document(
+        file_key="orig.pdf",
+        title="Doc",
+        status="Published",
+        mime="application/pdf",
+    )
+    session.add(doc)
+    session.commit()
+    doc_id = doc.id
+    u1_id, u2_id = u1.id, u2.id
+    session.close()
+    return doc_id, u1_id, u2_id
+
+
+def test_concurrent_upload_blocked_and_expiry(client, app_models):
+    app_module, models = app_models
+    storage = importlib.import_module("storage")
+    storage.storage_client.put = MagicMock()
+    doc_id, user1, user2 = _create_doc_and_users(models)
+
+    _login(client, user1)
+    resp = client.post(f"/api/documents/{doc_id}/checkout")
+    assert resp.status_code == 200
+
+    _login(client, user2)
+    data = {"file": (io.BytesIO(b"data"), "test.pdf")}
+    resp = client.post(
+        f"/api/documents/{doc_id}/versions",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 409
+
+    session = models.SessionLocal()
+    doc = session.get(models.Document, doc_id)
+    doc.lock_expires_at = datetime.utcnow() - timedelta(minutes=1)
+    session.commit()
+    session.close()
+
+    services = importlib.import_module("services")
+    services.clear_expired_locks()
+
+    _login(client, user2)
+    data = {"file": (io.BytesIO(b"data2"), "test.pdf")}
+    resp = client.post(
+        f"/api/documents/{doc_id}/versions",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 201


### PR DESCRIPTION
## Summary
- add `locked_by` and `lock_expires_at` fields to documents
- provide checkout/checkin APIs and UI with locking warnings
- block uploads on locked docs and cleanup expired locks

## Testing
- `pytest tests/test_document_locking.py -q`
- `pytest tests/test_document_version_upload.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34326717c832bab925f333c75cef8