### PR TITLE
Implement major version increment API with admin UI and tests

### DIFF
--- a/portal/models.py
+++ b/portal/models.py
@@ -59,6 +59,8 @@ STANDARD_MAP = _parse_standard_map(
 
 
 class RoleEnum(PyEnum):
+    ADMIN = "admin"
+    QUALITY = "quality"
     READER = "reader"
     CONTRIBUTOR = "contributor"
     REVIEWER = "reviewer"

--- a/portal/static/document_detail.js
+++ b/portal/static/document_detail.js
@@ -147,11 +147,22 @@ function initAssignForm() {
   });
 }
 
+function initVersioningMenu() {
+  const form = document.getElementById('increment-major-form');
+  if (!form) return;
+  form.addEventListener('htmx:afterRequest', (evt) => {
+    if (evt.detail.successful) {
+      window.location.reload();
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initTabs();
   initVersionSelection();
   initWorkflowForm();
   initAssignForm();
+  initVersioningMenu();
 
   const params = new URLSearchParams(window.location.search);
   if (params.get('created') === '1') {

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -24,6 +24,22 @@
     Assign Mandatory Reading <span class="badge bg-secondary" id="assignment-count">{{ ack_count | default(0) }}</span>
   </button>
   {% endif %}
+  {% if has_role('admin') or has_role('quality') %}
+  <div class="btn-group">
+    <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">
+      Sürüm İşlemleri
+    </button>
+    <ul class="dropdown-menu">
+      <li>
+        <form id="increment-major-form" hx-patch="/api/documents/{{ doc.id }}/versioning" hx-swap="none">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <input type="hidden" name="action" value="increment_major">
+          <button type="submit" class="dropdown-item">Majör Sürümü Artır</button>
+        </form>
+      </li>
+    </ul>
+  </div>
+  {% endif %}
 </div>
 <script type="module" src="{{ url_for('static', filename='toolbar/toolbar.js') }}"></script>
 {% endblock %}

--- a/tests/test_seed_data.py
+++ b/tests/test_seed_data.py
@@ -1,4 +1,12 @@
 import runpy
+import os
+import sys
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+os.environ.setdefault("DATABASE_URL", f"sqlite:///{repo_root / 'test.db'}")
 
 from portal import models
 


### PR DESCRIPTION
## Summary
- add PATCH /api/documents/<id>/versioning for major version increments
- expose "Sürüm İşlemleri" UI and HTMX action for privileged roles
- test major version reset and audit log creation

## Testing
- `pytest tests/test_document_versioning.py::test_increment_major_resets_minor_and_logs -q`
- `pytest tests/test_seed_data.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3ee7193ec832bbd59b42d447a409c