### PR TITLE
Generate and display PDF previews for documents

### DIFF
--- a/portal/pdf_preview_job.py
+++ b/portal/pdf_preview_job.py
@@ -1,0 +1,62 @@
+"""Background job to generate PDF previews for documents."""
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any
+
+from signing import convert_to_pdf
+from storage import storage_client
+
+try:  # pragma: no cover - real redis only used in production
+    from redis import Redis
+    from rq import Queue
+except Exception:  # pragma: no cover - fallback stubs for tests
+    from rq_stub import Queue  # type: ignore
+
+    class Redis:  # type: ignore
+        def __init__(self, *_, **__):
+            pass
+
+        @classmethod
+        def from_url(cls, url: str):
+            return cls()
+
+
+redis_conn = Redis(
+    host=os.getenv("REDIS_HOST", "localhost"),
+    port=int(os.getenv("REDIS_PORT", "6379")),
+    db=int(os.getenv("REDIS_DB", "0")),
+    password=os.getenv("REDIS_PASSWORD"),
+)
+
+queue: Queue = Queue("pdf_previews", connection=redis_conn)
+
+
+def generate_preview(doc_id: int, version: str, key: str) -> None:
+    """Download a document, convert to PDF, and store the preview."""
+    obj = storage_client.get_object(Key=key, Bucket=storage_client.bucket_main)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src_path = os.path.join(tmpdir, os.path.basename(key))
+        with open(src_path, "wb") as f:
+            f.write(obj["Body"].read())
+        pdf_path = convert_to_pdf(src_path, tmpdir)
+        dest_key = f"previews/{doc_id}/{version}.pdf"
+        with open(pdf_path, "rb") as f:
+            storage_client.put_object(
+                Key=dest_key,
+                Body=f,
+                Bucket=storage_client.bucket_previews,
+                ContentType="application/pdf",
+            )
+
+
+def enqueue_preview(doc_id: int, version: str, key: str) -> None:
+    """Queue a job to generate a PDF preview for a document."""
+    try:
+        queue.enqueue(generate_preview, doc_id, version, key)
+    except Exception:  # pragma: no cover - queue backend unavailable
+        pass
+
+
+__all__ = ["enqueue_preview", "generate_preview", "queue"]

--- a/portal/templates/approvals/detail.html
+++ b/portal/templates/approvals/detail.html
@@ -8,10 +8,10 @@
 <script type="module" src="{{ url_for('static', filename='toolbar/toolbar.js') }}"></script>
 {% endblock %}
 {% block content %}
+{% if preview.type == 'pdf' %}
+<div class="mb-3">
+  <a href="{{ preview.url }}" target="_blank">Preview (PDF)</a>
+</div>
+{% endif %}
 <div class="alert alert-info mb-3">Review the document, add a comment, then choose to approve or reject.</div>
-<div id="preview-container" class="vh-100 overflow-auto"></div>
-<script>
-  window.previewData = {{ preview | tojson }};
-</script>
-<script type="module" src="{{ url_for('static', filename='document_preview.js') }}"></script>
 {% endblock %}

--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -68,12 +68,10 @@
     <button type="submit" class="btn btn-outline-primary">Check out</button>
   </form>
 {% endif %}
-{% if preview.type %}
-<div id="preview-container" class="mb-4"></div>
-<script>
-  window.previewData = {{ preview | tojson }};
-</script>
-<script type="module" src="{{ url_for('static', filename='document_preview.js') }}"></script>
+{% if preview.type == 'pdf' %}
+<div class="mb-4">
+  <a href="{{ preview.url }}" target="_blank">Preview (PDF)</a>
+</div>
 {% endif %}
 <ul>
   <li><strong>Code:</strong> {{ doc.code }}</li>

--- a/tests/test_pdf_preview.py
+++ b/tests/test_pdf_preview.py
@@ -1,0 +1,111 @@
+import io
+import os
+import sys
+import importlib
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from flask import template_rendered
+
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "portal"))
+
+
+@pytest.fixture()
+def app_models(tmp_path):
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        db_url = f"sqlite:///{Path(tmp_path)/'test.db'}"
+    os.environ["DATABASE_URL"] = db_url
+    os.environ["STORAGE__TYPE"] = "fs"
+    os.environ["STORAGE__FS_PATH"] = str(tmp_path / "files")
+    import storage as storage_root
+    import portal.storage as portal_storage
+    importlib.reload(storage_root)
+    importlib.reload(portal_storage)
+    app_module = importlib.reload(importlib.import_module("app"))
+    models_module = importlib.import_module("models")
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    app_module.extract_text = lambda key: ""
+    app_module.index_document = lambda doc, content: None
+    app_module.notify_mandatory_read = lambda doc, users: None
+    pdf_job = importlib.reload(importlib.import_module("pdf_preview_job"))
+    import rq_stub
+    pdf_job.queue = rq_stub.Queue()
+    return app_module, models_module, pdf_job, portal_storage
+
+
+@pytest.fixture()
+def client(app_models):
+    app_module, _, _, _ = app_models
+    return app_module.app.test_client()
+
+
+def _login(client):
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1}
+        sess["roles"] = ["contributor", "reader"]
+
+
+def test_enqueue_preview_called_on_docx_upload(app_models, client):
+    app_module, models, pdf_job, _ = app_models
+    _login(client)
+    app_module.enqueue_preview = MagicMock()
+    storage_root = importlib.import_module("storage")
+    storage_root.storage_client.head_object = MagicMock(return_value={})
+
+    first = list(app_module.STANDARD_MAP.keys())[0]
+    payload = {
+        "code": "DOCX1",
+        "title": "Docx",
+        "type": "T",
+        "department": "Dept",
+        "tags": "tag",
+        "uploaded_file_key": "upload1",
+        "uploaded_file_name": "file.docx",
+        "standard": first,
+    }
+    resp = client.post("/api/documents", json=payload)
+    assert resp.status_code == 201
+    assert app_module.enqueue_preview.called
+
+
+def test_generate_preview_creates_file_and_view_shows_preview(app_models, client):
+    app_module, models, pdf_job, portal_storage = app_models
+    _login(client)
+    session = models.SessionLocal()
+    doc = models.Document(
+        doc_key="docs/test.docx",
+        title="Test",
+        mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    )
+    session.add(doc)
+    session.commit()
+    doc_id = doc.id
+    session.close()
+
+    portal_storage.storage_client.put(Key="docs/test.docx", Body=b"data")
+
+    def fake_convert(src, outdir):
+        pdf_path = os.path.join(outdir, "test.pdf")
+        with open(pdf_path, "wb") as f:
+            f.write(b"%PDF-1.4\n")
+        return pdf_path
+
+    pdf_job.convert_to_pdf = fake_convert
+    pdf_job.generate_preview(doc_id, "1.0", "docs/test.docx")
+
+    preview_key = f"previews/{doc_id}/1.0.pdf"
+    portal_storage.storage_client.head_object(Key=preview_key)
+
+    captured = {}
+
+    def record(sender, template, context, **extra):
+        captured.update(context)
+
+    with template_rendered.connected_to(record, app_module.app):
+        resp = client.get(f"/documents/{doc_id}")
+    assert resp.status_code == 200
+    assert captured["preview"]["type"] == "pdf"


### PR DESCRIPTION
## Summary
- add `pdf_preview_job` to convert uploaded documents to PDF previews and store in previews bucket
- trigger preview job on document creation and version upload
- surface PDF preview links in document and approval views
- test preview job and enqueue behavior

## Testing
- `pytest` *(fails: tests/test_seed_data.py::test_seed_creates_roles_and_admin - sqlite3.OperationalError: no such table: roles)*


------
https://chatgpt.com/codex/tasks/task_e_68b42721a4cc832bb028954d51a6e8c6