### PR TITLE
Add webhook notifier for user notifications

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -5,7 +5,8 @@ The following environment variables control email and webhook notifications:
 - `SMTP_SERVER`: Hostname of the SMTP server used to send emails.
 - `SMTP_PORT`: Port number for the SMTP server (e.g., 587 for TLS).
 - `SMTP_SENDER`: Default `From` address for outgoing emails.
-- `WEBHOOK_URL_DEFAULT`: Fallback webhook URL used when no specific webhook is configured.
+- `ENABLE_WEBHOOK_NOTIFIER`: Enable per-user webhooks when set to `1`.
+- `WEBHOOK_URL_DEFAULT`: Fallback webhook URL used when a user's setting does not provide one.
 - `REDIS_HOST`: Hostname of the Redis server used for the notifications queue.
 - `REDIS_PORT`: Port number for the Redis server.
 - `REDIS_DB`: Redis database number that stores queued notifications.

--- a/tests/test_webhook_notifications.py
+++ b/tests/test_webhook_notifications.py
@@ -1,0 +1,53 @@
+import importlib
+from unittest.mock import patch
+
+from sqlalchemy.orm import sessionmaker
+
+
+def _create_user(models, *, user_id: int, url: str | None) -> None:
+    Session = sessionmaker(bind=models.engine)
+    sess = Session()
+    sess.add(models.User(id=user_id, username=f"u{user_id}"))
+    sess.add(
+        models.UserSetting(
+            user_id=user_id, webhook_enabled=True, webhook_url=url
+        )
+    )
+    sess.commit()
+    sess.close()
+
+
+def test_webhook_uses_user_url(monkeypatch):
+    models = importlib.import_module("models")
+    _create_user(models, user_id=2001, url="http://example.com/hook")
+
+    monkeypatch.setenv("ENABLE_WEBHOOK_NOTIFIER", "1")
+    notifications = importlib.reload(importlib.import_module("notifications"))
+    monkeypatch.setattr(notifications, "_load_notifiers", lambda: [])
+
+    with patch.object(notifications.requests, "post") as mock_post:
+        notifications._send_notification(2001, "Sub", "Body")
+
+    mock_post.assert_called_once_with(
+        "http://example.com/hook",
+        json={"user_id": 2001, "subject": "Sub", "body": "Body"},
+    )
+
+
+def test_webhook_uses_default_url(monkeypatch):
+    models = importlib.import_module("models")
+    _create_user(models, user_id=2002, url=None)
+
+    monkeypatch.setenv("ENABLE_WEBHOOK_NOTIFIER", "1")
+    monkeypatch.setenv("WEBHOOK_URL_DEFAULT", "http://default/hook")
+    notifications = importlib.reload(importlib.import_module("notifications"))
+    monkeypatch.setattr(notifications, "_load_notifiers", lambda: [])
+
+    with patch.object(notifications.requests, "post") as mock_post:
+        notifications._send_notification(2002, "Subject", "Body")
+
+    mock_post.assert_called_once_with(
+        "http://default/hook",
+        json={"user_id": 2002, "subject": "Subject", "body": "Body"},
+    )
+


### PR DESCRIPTION
## Summary
- add WebhookNotifier for sending JSON payloads to external URLs
- invoke webhooks when users enable them, with optional default URL
- document webhook env vars and test webhook delivery

## Testing
- `pytest tests/test_webhook_notifications.py tests/test_notifications_queue.py -q`
- `pytest -q` *(fails: sqlite3.OperationalError: no such table: roles)*

------
https://chatgpt.com/codex/tasks/task_e_68b42c4b9630832bbc5b1a0f14fdef4d