### PR TITLE
Notify subscribers on document version upload

### DIFF
--- a/portal/notifications.py
+++ b/portal/notifications.py
@@ -253,6 +253,10 @@ _TEMPLATES = {
         "Document {title} revised",
         "Document {title} has a new revision {major_version}.{minor_version}.",
     ),
+    "version_uploaded": (
+        "Yeni sürüm yüklendi",
+        "Doküman {title} için yeni sürüm {major_version}.{minor_version} yüklendi.",
+    ),
     "mandatory_read": (
         "Document {title} requires your acknowledgement",
         "Please read and acknowledge document {title}.",
@@ -279,6 +283,17 @@ def notify_approval_queue(doc, user_ids):
 def notify_revision_time(doc, user_ids):
     subject, body = _render(
         "revision_time", title=doc.title, major_version=doc.major_version, minor_version=doc.minor_version
+    )
+    for uid in user_ids:
+        notify_user(uid, subject, body)
+
+
+def notify_version_uploaded(doc, user_ids):
+    subject, body = _render(
+        "version_uploaded",
+        title=doc.title,
+        major_version=doc.major_version,
+        minor_version=doc.minor_version,
     )
     for uid in user_ids:
         notify_user(uid, subject, body)

--- a/tests/test_version_upload_notifications.py
+++ b/tests/test_version_upload_notifications.py
@@ -1,0 +1,58 @@
+import importlib
+import io
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _setup_app(monkeypatch):
+    repo_root = Path(__file__).resolve().parent.parent
+    os.environ.setdefault("S3_ENDPOINT", "http://s3")
+    os.environ["DATABASE_URL"] = f"sqlite:///{repo_root / 'test.db'}"
+    rq = importlib.import_module("rq_stub")
+    sys.modules["rq"] = rq
+    app_module = importlib.reload(importlib.import_module("app"))
+    notifications = importlib.reload(importlib.import_module("notifications"))
+    storage = importlib.import_module("storage")
+
+    q = rq.Queue("notifications")
+    monkeypatch.setattr(notifications, "queue", q)
+    app_module.notify_version_uploaded = notifications.notify_version_uploaded
+    storage.storage_client.put = MagicMock()
+    app_module.enqueue_preview = lambda *args, **kwargs: None
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+
+    return app_module, notifications, q
+
+
+def test_version_upload_enqueues_notifications(monkeypatch):
+    app_module, notifications, q = _setup_app(monkeypatch)
+    models = importlib.import_module("models")
+
+    session = models.SessionLocal()
+    owner = models.User(username="owner")
+    subscriber = models.User(username="sub")
+    doc = models.Document(doc_key="d1", title="Doc1", owner=owner)
+    session.add_all([owner, subscriber, doc])
+    session.commit()
+    owner_id = owner.id
+    subscriber_id = subscriber.id
+    doc_id = doc.id
+    session.add(models.Acknowledgement(user_id=subscriber_id, doc_id=doc_id))
+    session.commit()
+    session.close()
+
+    client = app_module.app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": owner_id}
+        sess["roles"] = [app_module.RoleEnum.CONTRIBUTOR.value]
+
+    data = {"file": (io.BytesIO(b"data"), "f.pdf", "application/pdf")}
+    resp = client.post(
+        f"/api/documents/{doc_id}/versions",
+        data=data,
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code in (200, 201)
+    assert len(q.jobs) == 2


### PR DESCRIPTION
## Summary
- enqueue notifications to document owners and acknowledgement subscribers when a new version is uploaded
- add notification template for "Yeni sürüm yüklendi" and helper to dispatch it
- test that uploading a document version enqueues notification jobs

## Testing
- `pytest tests/test_version_upload_notifications.py tests/test_seed_data.py -q`
- `pytest -k 'not test_seed_data' -q`

------
https://chatgpt.com/codex/tasks/task_e_68b43155cbb0832ba492b0fcf756fdfe