### PR TITLE
Notify document owners when check-outs occur

### DIFF
--- a/portal/notifications.py
+++ b/portal/notifications.py
@@ -257,6 +257,10 @@ _TEMPLATES = {
         "Yeni sürüm yüklendi",
         "Doküman {title} için yeni sürüm {major_version}.{minor_version} yüklendi.",
     ),
+    "checkout_taken": (
+        "Check-out alındı",
+        "Doküman {title} {username} tarafından check-out alındı.",
+    ),
     "mandatory_read": (
         "Document {title} requires your acknowledgement",
         "Please read and acknowledge document {title}.",

--- a/tests/test_checkout_notifications.py
+++ b/tests/test_checkout_notifications.py
@@ -1,0 +1,63 @@
+import importlib
+import sys
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+
+def _setup_app(monkeypatch):
+    rq = importlib.import_module("rq_stub")
+    sys.modules["rq"] = rq
+    app_module = importlib.reload(importlib.import_module("app"))
+    notifications = importlib.reload(importlib.import_module("notifications"))
+    q = rq.Queue("notifications")
+    monkeypatch.setattr(notifications, "queue", q)
+    app_module.notify_user = notifications.notify_user
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    return app_module, notifications, q
+
+
+def test_checkout_sends_notifications(monkeypatch):
+    app_module, notifications, q = _setup_app(monkeypatch)
+    models = importlib.import_module("models")
+
+    session = models.SessionLocal()
+    owner = models.User(username="owner", email="o@example.com")
+    previous = models.User(username="prev", email="p@example.com")
+    actor = models.User(username="actor", email="a@example.com")
+    session.add_all([owner, previous, actor])
+    session.commit()
+    owner_id, previous_id, actor_id = owner.id, previous.id, actor.id
+    doc = models.Document(
+        doc_key="d1",
+        title="Doc1",
+        owner_id=owner_id,
+        locked_by=previous_id,
+        lock_expires_at=datetime.utcnow() - timedelta(minutes=1),
+    )
+    session.add(doc)
+    session.add(models.UserSetting(user_id=owner_id, email_enabled=True))
+    session.add(models.UserSetting(user_id=previous_id, email_enabled=False))
+    session.commit()
+    doc_id = doc.id
+    session.close()
+
+    client = app_module.app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": actor_id, "name": "Actor"}
+        sess["roles"] = [app_module.RoleEnum.CONTRIBUTOR.value]
+
+    resp = client.post(f"/api/documents/{doc_id}/checkout")
+    assert resp.status_code == 200
+    assert {job.args[0] for job in q.jobs} == {owner_id, previous_id}
+
+    monkeypatch.setattr(
+        notifications, "_load_notifiers", lambda: [("email", notifications.EmailNotifier())]
+    )
+    send_mock = MagicMock()
+    monkeypatch.setattr(notifications.EmailNotifier, "send", send_mock)
+
+    for job in q.jobs:
+        job.perform()
+
+    send_mock.assert_called_once()
+    assert send_mock.call_args[0][0].id == owner_id

--- a/tests/test_document_locking.py
+++ b/tests/test_document_locking.py
@@ -24,6 +24,7 @@ def app_models():
     app_module = importlib.reload(importlib.import_module("app"))
     models_module = importlib.reload(importlib.import_module("models"))
     app_module.app.config["WTF_CSRF_ENABLED"] = False
+    app_module.notify_user = lambda *a, **k: None
     return app_module, models_module
 
 


### PR DESCRIPTION
## Summary
- notify owner and prior lock holder when a document is checked out
- add "Check-out alındı" notification template
- cover checkout notifications with tests

## Testing
- `pytest tests/test_checkout_notifications.py tests/test_document_locking.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b54ce426c8832ba55ed9a25e8206ca