### PR TITLE
Add approval and publish notifications

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -35,6 +35,8 @@ from notifications import (
     notify_revision_time,
     notify_user,
     notify_version_uploaded,
+    notify_document_approved,
+    notify_document_published,
     _render,
 )
 from ocr import extract_text
@@ -2378,6 +2380,8 @@ def api_approve_step(step_id: int):
         )
         if remaining == 0:
             document.status = "Approved"
+            if document.owner_id:
+                notify_document_approved(document, [document.owner_id])
         db.commit()
         if next_step and next_step.user_id:
             notify_approval_queue(document, [next_step.user_id])
@@ -3237,6 +3241,7 @@ def publish_document(id: int):
                     user_ids.add(user.id)
         _assign_acknowledgements(db, doc.id, user_ids)
         db.commit()
+        notify_document_published(doc, [doc.owner_id] if doc.owner_id else [])
         if user_ids:
             notify_mandatory_read(doc, list(user_ids))
         publisher = session.get("user")

--- a/portal/notifications.py
+++ b/portal/notifications.py
@@ -269,6 +269,14 @@ _TEMPLATES = {
         "DIF workflow step overdue",
         "A workflow step for DIF request {dif_id} assigned to {role} is overdue.",
     ),
+    "document_approved": (
+        "Document {title} approved",
+        "Document {title} has been approved.",
+    ),
+    "document_published": (
+        "Document {title} published",
+        "Document {title} is now published.",
+    ),
 }
 
 
@@ -313,6 +321,18 @@ def notify_dif_step_overdue(step, user_ids):
     subject, body = _render(
         "dif_step_overdue", dif_id=step.dif_id, role=step.role
     )
+    for uid in user_ids:
+        notify_user(uid, subject, body)
+
+
+def notify_document_approved(doc, user_ids):
+    subject, body = _render("document_approved", title=doc.title)
+    for uid in user_ids:
+        notify_user(uid, subject, body)
+
+
+def notify_document_published(doc, user_ids):
+    subject, body = _render("document_published", title=doc.title)
     for uid in user_ids:
         notify_user(uid, subject, body)
 

--- a/tests/test_document_notifications.py
+++ b/tests/test_document_notifications.py
@@ -1,0 +1,70 @@
+import importlib
+from pathlib import Path
+
+
+def _setup_app(monkeypatch):
+    repo_root = Path(__file__).resolve().parent.parent
+    monkeypatch.setenv("S3_ENDPOINT", "http://s3")
+    models = importlib.import_module("models")
+    notifications = importlib.import_module("notifications")
+    app_module = importlib.import_module("app")
+    app_module.app.config["WTF_CSRF_ENABLED"] = False
+    models.Base.metadata.create_all(bind=models.engine)
+    calls = []
+
+    def fake_notify_user(uid, subject, body):
+        calls.append((uid, subject, body))
+
+    monkeypatch.setattr(notifications, "notify_user", fake_notify_user)
+    app_module.notify_document_approved = notifications.notify_document_approved
+    app_module.notify_document_published = notifications.notify_document_published
+    return app_module, models, calls
+
+
+def test_document_approval_queues_notification(monkeypatch):
+    app_module, models, calls = _setup_app(monkeypatch)
+    session = models.SessionLocal()
+    owner = models.User(username="owner")
+    approver = models.User(username="approver")
+    doc = models.Document(doc_key="doc1", title="Doc1", status="Review", owner=owner)
+    session.add_all([owner, approver, doc])
+    session.commit()
+    step = models.WorkflowStep(doc_id=doc.id, step_order=1, user_id=approver.id, status="Pending")
+    session.add(step)
+    session.commit()
+    owner_id = owner.id
+    step_id = step.id
+    approver_id = approver.id
+    session.close()
+    client = app_module.app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": approver_id}
+        sess["roles"] = [app_module.RoleEnum.APPROVER.value]
+    resp = client.post(f"/api/approvals/{step_id}/approve", json={})
+    assert resp.status_code == 200
+    assert len(calls) == 1
+    assert calls[0][0] == owner_id
+
+
+def test_publish_document_queues_notification(monkeypatch):
+    app_module, models, calls = _setup_app(monkeypatch)
+    session = models.SessionLocal()
+    owner = models.User(username="owner")
+    publisher = models.User(username="publisher")
+    doc = models.Document(doc_key="doc1", title="Doc1", status="Approved", owner=owner)
+    session.add_all([owner, publisher, doc])
+    session.commit()
+    doc_id = doc.id
+    owner_id = owner.id
+    publisher_id = publisher.id
+    session.close()
+    client = app_module.app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": publisher_id}
+        sess["roles"] = [app_module.RoleEnum.PUBLISHER.value]
+    resp = client.post(
+        f"/api/documents/{doc_id}/publish", data={}, headers={"HX-Request": "true"}
+    )
+    assert resp.status_code == 204
+    assert len(calls) == 1
+    assert calls[0][0] == owner_id


### PR DESCRIPTION
## Summary
- notify document owner when a document is fully approved
- send notification when an approved document is published
- add tests ensuring approval and publish events queue notifications

## Testing
- `pytest tests/test_document_notifications.py tests/test_seed_data.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b55013c418832bae70752f6d9f8996