### PR TITLE
Add SSE dashboard stream and update polling interval

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -15,6 +15,14 @@ The following environment variables control email and webhook notifications:
 ### REST polling
 
 Unread notifications and dashboard counts can be retrieved by polling the
-`/api/notifications` and `/api/counts` endpoints.  Clients poll at an interval
-configured by the `POLL_INTERVAL_MS` environment variable (default 5000 ms).
+`/api/notifications` and `/api/counts` endpoints. Clients poll at an interval
+configured by the `POLL_INTERVAL_MS` environment variable (default 10000 ms).
 Each request to `/api/notifications` marks returned notifications as read.
+
+### Server-Sent Events
+
+The dashboard can stream card updates over Server-Sent Events from
+`/api/dashboard/stream`. When the browser supports `hx-sse`, the dashboard
+connects to this stream and receives real-time updates. If SSE is not
+available, the templates fall back to polling every `POLL_INTERVAL_MS`
+milliseconds.

--- a/portal/templates/dashboard.html
+++ b/portal/templates/dashboard.html
@@ -2,7 +2,7 @@
 {% block title %}Dashboard{% endblock %}
 
 {% block content %}
-<div class="row row-cols-1 row-cols-md-2 g-3">
+<div class="row row-cols-1 row-cols-md-2 g-3" hx-ext="sse" hx-sse="connect:/api/dashboard/stream">
   <div class="col">
     <div class="card h-100">
       <div class="card-header d-flex align-items-center">
@@ -23,7 +23,8 @@
            hx-get="/api/dashboard/cards/pending"
            hx-trigger="load, every {{ poll_interval }}s"
            hx-swap="innerHTML"
-           hx-include="#pending-standard">
+           hx-include="#pending-standard"
+           hx-sse="swap:pending">
         {% set card = 'pending' %}
         {% include 'partials/dashboard/_cards.html' %}
       </div>
@@ -50,7 +51,8 @@
            hx-get="/api/dashboard/cards/mandatory"
            hx-trigger="load, every {{ poll_interval }}s"
            hx-swap="innerHTML"
-           hx-include="#mandatory-standard">
+           hx-include="#mandatory-standard"
+           hx-sse="swap:mandatory">
         {% set card = 'mandatory' %}
         {% include 'partials/dashboard/_cards.html' %}
       </div>
@@ -63,7 +65,8 @@
       <div class="card-body"
            hx-get="/api/dashboard/cards/recent"
            hx-trigger="load, every {{ poll_interval }}s"
-           hx-swap="innerHTML">
+           hx-swap="innerHTML"
+           hx-sse="swap:recent">
         {% set card = 'recent' %}
         {% include 'partials/dashboard/_cards.html' %}
       </div>
@@ -76,7 +79,8 @@
       <div class="card-body"
            hx-get="/api/dashboard/cards/recent-docs"
            hx-trigger="load, every {{ poll_interval }}s"
-           hx-swap="innerHTML">
+           hx-swap="innerHTML"
+           hx-sse="swap:recent_docs">
         {% set card = 'recent_docs' %}
         {% include 'partials/dashboard/_cards.html' %}
       </div>
@@ -89,7 +93,8 @@
         <div class="card-body"
              hx-get="/api/dashboard/cards/shortcuts"
              hx-trigger="load, every {{ poll_interval }}s"
-             hx-swap="innerHTML">
+             hx-swap="innerHTML"
+             hx-sse="swap:shortcuts">
           {% set card = 'shortcuts' %}
           {% include 'partials/dashboard/_cards.html' %}
         </div>

--- a/tests/test_dashboard_stream.py
+++ b/tests/test_dashboard_stream.py
@@ -1,0 +1,36 @@
+import os
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    os.environ.setdefault("S3_ENDPOINT", "http://s3")
+    a = importlib.import_module("app")
+    return a.app.test_client()
+
+
+def _login(client):
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1, "name": "Tester"}
+        sess["roles"] = ["reader"]
+
+
+def test_dashboard_polling_and_sse(client):
+    _login(client)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "every 10s" in html
+    assert 'hx-sse="connect:/api/dashboard/stream"' in html
+    assert 'hx-sse="swap:pending"' in html
+
+
+def test_dashboard_sse_stream(client):
+    _login(client)
+    resp = client.get("/api/dashboard/stream")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/event-stream"
+    first = next(resp.response).decode()
+    assert "event: pending" in first


### PR DESCRIPTION
## Summary
- increase default polling interval to 10 seconds
- stream dashboard card updates via `/api/dashboard/stream`
- use `hx-sse` in dashboard template to consume SSE events
- document polling and SSE configuration
- test both polling and SSE modes

## Testing
- `pytest tests/test_dashboard_cards.py tests/test_dashboard_stream.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b557ee4228832b842332316e0b58bb