### PR TITLE
Show revision versions in dashboard

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -597,6 +597,7 @@ def _get_recent_revisions(db, limit: int = 5):
     return [
         (
             r.document.title,
+            f"{r.major_version}.{r.minor_version}",
             url_for("document_detail", doc_id=r.doc_id, revision_id=r.id),
         )
         for r in revisions

--- a/portal/templates/partials/dashboard/_cards.html
+++ b/portal/templates/partials/dashboard/_cards.html
@@ -3,7 +3,9 @@
     {% if items %}
       <ul class="list-unstyled mb-0">
       {% for item in items %}
-        {% if item[1] is defined %}
+        {% if item[2] is defined %}
+          <li><a href="{{ item[2] }}">{{ item[0] }} {{ item[1] }}</a></li>
+        {% elif item[1] is defined %}
           <li><a href="{{ item[1] }}">{{ item[0] }}</a></li>
         {% else %}
           <li>{{ item }}</li>

--- a/tests/test_dashboard_cards.py
+++ b/tests/test_dashboard_cards.py
@@ -103,7 +103,7 @@ def test_dashboard_card_endpoints(app_models, client):
         recent_url = url_for(
             "document_detail", doc_id=recent_doc_id, revision_id=revision_id
         )
-    assert "Recent Doc" in html
+    assert "Recent Doc 1.0" in html
     assert recent_url in html
 
     # Recent documents

--- a/tests/test_z_dashboard_api.py
+++ b/tests/test_z_dashboard_api.py
@@ -169,10 +169,13 @@ def test_api_recent_changes(client, models):
     assert set(data.keys()) == {"items", "error"}
     assert data["error"] is None
     assert len(data["items"]) == 2
+    assert all(item[1] == "1.0" for item in data["items"])
 
     resp = client.get("/api/dashboard/recent-changes?limit=1")
     assert resp.status_code == 200
-    assert len(resp.get_json()["items"]) == 1
+    data = resp.get_json()
+    assert len(data["items"]) == 1
+    assert data["items"][0][1] == "1.0"
 
     db = SessionLocal()
     db.query(DocumentRevision).delete()


### PR DESCRIPTION
## Summary
- include major/minor version in dashboard recent revisions
- display revision version numbers in dashboard cards
- verify version numbers via dashboard tests

## Testing
- `pytest tests/test_dashboard_cards.py tests/test_z_dashboard_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5590763b4832ba7fb3d226316595d