### PR TITLE
Add notification trigger tests and dashboard integration coverage

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -26,3 +26,22 @@ The dashboard can stream card updates over Server-Sent Events from
 connects to this stream and receives real-time updates. If SSE is not
 available, the templates fall back to polling every `POLL_INTERVAL_MS`
 milliseconds.
+
+### Testing
+
+Unit tests exercise notification triggers with a stubbed RQ queue. Run them
+with:
+
+```
+pytest tests/test_version_upload_notifications.py \
+       tests/test_checkout_notifications.py \
+       tests/test_document_notifications.py
+```
+
+Integration tests cover dashboard behaviour, including pending approvals and
+recent changes cards:
+
+```
+pytest tests/test_z_dashboard_api.py::test_api_pending_approvals_includes_unassigned_for_role_user \
+       tests/test_dashboard_cards.py::test_recent_changes_shows_version_numbers
+```

--- a/tests/test_dashboard_cards.py
+++ b/tests/test_dashboard_cards.py
@@ -121,3 +121,23 @@ def test_dashboard_card_endpoints(app_models, client):
     resp = client.get("/")
     assert resp.status_code == 200
 
+
+def test_recent_changes_shows_version_numbers(app_models, client):
+    app = app_models["app"]
+    revision_id = app_models["revision_id"]
+    recent_doc_id = app_models["recent_doc_id"]
+
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1, "name": "Tester"}
+        sess["roles"] = ["approver", "reader"]
+
+    resp = client.get("/api/dashboard/cards/recent", headers={"HX-Request": "true"})
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    with app.test_request_context():
+        recent_url = url_for(
+            "document_detail", doc_id=recent_doc_id, revision_id=revision_id
+        )
+    assert "Recent Doc 1.0" in html
+    assert recent_url in html
+


### PR DESCRIPTION
## Summary
- add unit tests for approval and publish notification triggers using `rq_stub`
- cover pending approvals unassigned steps and recent change version numbers with integration tests
- document how to execute notification and dashboard tests

## Testing
- `pytest tests/test_version_upload_notifications.py tests/test_checkout_notifications.py tests/test_document_notifications.py tests/test_z_dashboard_api.py::test_api_pending_approvals_includes_unassigned_for_role_user tests/test_dashboard_cards.py::test_recent_changes_shows_version_numbers -q`

------
https://chatgpt.com/codex/tasks/task_e_68b55b42d5b4832bb394dc8e87c63141