### PR TITLE
feat: tighten content security policy

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -25,7 +25,7 @@ http {
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options "DENY" always;
-    add_header Content-Security-Policy "frame-ancestors 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline';" always;
 
     # 443 kullanacaksanız:
     # listen 443 ssl http2;
@@ -58,6 +58,5 @@ http {
       add_header Cache-Control "public";
     }
 
-    # OnlyOffice-related proxy paths have been removed.
   }
 }


### PR DESCRIPTION
## Summary
- expand Content-Security-Policy in nginx config
- drop leftover OnlyOffice comment

## Testing
- `pytest`
- `nginx -t -c $PWD/nginx/nginx.conf` *(fails: command not found: nginx)*
- `docker compose restart nginx` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b56e25ed34832bba97eb0d2af5c992