### PR TITLE
chore: remove onlyoffice env settings

### DIFF
--- a/.env
+++ b/.env
@@ -10,10 +10,6 @@ MINIO_BUCKET_MAIN=qdms
 MINIO_BUCKET_ARCHIVE=qdms-archive
 MINIO_BUCKET_PREVIEWS=qdms-previews
 
-# OnlyOffice
-ONLYOFFICE_JWT_SECRET=change_this_super_secret_32c
-ONLYOFFICE_JWT_HEADER=AuthorizationJwt
-
 # Portal
 PORTAL_SECRET_KEY=another_super_secret
 PORTAL_DEBUG=false
@@ -21,8 +17,6 @@ PORTAL_BIND=0.0.0.0:8000
 PORTAL_PUBLIC_BASE_URL=https://qdms.baylan.local
 SESSION_COOKIE_DOMAIN=.baylan.local
 WTF_CSRF_COOKIE_DOMAIN=.baylan.local
-ONLYOFFICE_INTERNAL_URL=http://onlyoffice
-ONLYOFFICE_PUBLIC_URL=https://qdms.baylan.local/onlyoffice
 S3_ENDPOINT=http://minio:9000
 S3_REGION=us-east-1
 S3_ACCESS_KEY_ID=${MINIO_ROOT_USER}


### PR DESCRIPTION
## Summary
- remove unused OnlyOffice environment variables from .env

## Testing
- `docker compose up -d` *(fails: command not found: docker)*
- `pytest` *(fails: OperationalError: ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b599eff404832b8c7d72140a565f89