### PR TITLE
Allow jsDelivr in Nginx CSP

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -25,7 +25,7 @@ http {
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options "DENY" always;
-    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline';" always;
+    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;" always;
 
     # 443 kullanacaksanız:
     # listen 443 ssl http2;


### PR DESCRIPTION
## Summary
- allow assets from jsdelivr in Nginx Content-Security-Policy

## Testing
- `nginx -t -c $(pwd)/nginx/nginx.conf` *(fails: command not found)*
- `pytest -q` *(fails: sqlite3.OperationalError: no such table: roles)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ac59c08c832b99540042b60f42ff