### PR TITLE
Add can_upload_version column to document_permissions

### DIFF
--- a/alembic/versions/0019_add_can_upload_version_to_document_permissions.py
+++ b/alembic/versions/0019_add_can_upload_version_to_document_permissions.py
@@ -1,0 +1,38 @@
+"""Add can_upload_version to document_permissions
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2025-09-01
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("document_permissions")]
+    if "can_upload_version" not in columns:
+        op.add_column(
+            "document_permissions",
+            sa.Column(
+                "can_upload_version", sa.Boolean(), nullable=False, server_default=sa.false()
+            ),
+        )
+        op.alter_column("document_permissions", "can_upload_version", server_default=None)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("document_permissions")]
+    if "can_upload_version" in columns:
+        op.drop_column("document_permissions", "can_upload_version")


### PR DESCRIPTION
## Summary
- add database migration for document_permissions.can_upload_version

## Testing
- `pytest -q` *(fails: tests/test_seed_data.py::test_seed_creates_roles_and_admin - sqlalchemy.exc.OperationalError: no such table: roles)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b0450428832b99d748adf67ae86b