### PR TITLE
Sign S3 URLs with public endpoint to avoid signature mismatch

### DIFF
--- a/tests/test_files_route.py
+++ b/tests/test_files_route.py
@@ -91,7 +91,7 @@ def test_files_route_respects_size_limit(app_modules, client):
         backend, type(backend)
     )
     backend.client.head_object = MagicMock(return_value={"ContentLength": 51 * 1024 * 1024})
-    backend.client.generate_presigned_url = MagicMock(return_value="/signed")
+    backend.public_client.generate_presigned_url = MagicMock(return_value="/signed")
     resp = client.get("/files/foo/bar.txt")
     assert resp.status_code == 404
-    backend.client.generate_presigned_url.assert_not_called()
+    backend.public_client.generate_presigned_url.assert_not_called()


### PR DESCRIPTION
## Summary
- Create separate S3 client for public endpoint and use it for presigned URLs
- Drop URL host rewriting for signed links; only fall back to plain URLs when credentials missing
- Test public endpoint signing for previews and file routes

## Testing
- `pytest tests/test_storage_public_endpoint.py tests/test_files_route.py tests/test_pdf_preview.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b68e9d66dc832b90bd4e1a7e645b16