### PR TITLE
Verify preview bucket before generating PDFs

### DIFF
--- a/portal/pdf_preview_job.py
+++ b/portal/pdf_preview_job.py
@@ -35,6 +35,11 @@ queue: Queue = Queue("pdf_previews", connection=redis_conn)
 
 def generate_preview(doc_id: int, version: str, key: str) -> None:
     """Download a document, convert to PDF, and store the preview."""
+    # Ensure the configured preview bucket is available before doing any work.
+    # This raises an informative error if misconfigured, helping operators
+    # detect missing ``S3_BUCKET_PREVIEWS`` or permission issues early.
+    storage_client.verify_preview_bucket()
+
     obj = storage_client.get_object(Key=key, Bucket=storage_client.bucket_main)
     with tempfile.TemporaryDirectory() as tmpdir:
         src_path = os.path.join(tmpdir, os.path.basename(key))


### PR DESCRIPTION
## Summary
- validate S3 preview bucket availability before generating PDF previews
- add `verify_preview_bucket` helper in storage backend for clearer misconfiguration errors

## Testing
- `pytest tests/test_pdf_preview.py::test_enqueue_preview_called_on_docx_upload -q`
- `pytest tests/test_pdf_preview.py::test_generate_preview_creates_file_and_view_shows_preview -q`
- `pytest tests/test_pdf_preview.py::test_presigned_preview_uses_public_endpoint -q`


------
https://chatgpt.com/codex/tasks/task_e_68b693cec420832b9be9e18e9902fc6f