### PR TITLE
Ensure proper session disposal for archive route

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -898,7 +898,12 @@ def list_archived_documents():
         }
         for d in docs
     ]
-    session.close()
+    # ``get_session`` returns a scoped session.  Using ``session.close`` would
+    # leave a closed session in the registry which can surface as
+    # ``ResourceClosedError`` in subsequent requests.  ``SessionLocal.remove``
+    # disposes of the current session and ensures a fresh one is used next
+    # time.
+    SessionLocal.remove()
     return jsonify(result)
 
 

--- a/tests/test_session_cleanup.py
+++ b/tests/test_session_cleanup.py
@@ -1,0 +1,35 @@
+import importlib
+import os
+from unittest.mock import MagicMock
+
+# Ensure S3 endpoint is set before importing app
+os.environ.setdefault("S3_ENDPOINT", "http://s3")
+
+def test_create_document_after_standard_map():
+    app_module = importlib.reload(importlib.import_module("app"))
+    app_module.app.config.update(WTF_CSRF_ENABLED=False)
+    client = app_module.app.test_client()
+
+    # Authenticate as contributor
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": 1, "username": "tester"}
+        sess["roles"] = [app_module.RoleEnum.CONTRIBUTOR.value]
+
+    # ensure storage head succeeds
+    app_module.storage_client.head_object = MagicMock()
+
+    # Call standard map helper before creating a document to exercise session cleanup
+    app_module.get_standard_map()
+
+    payload = {
+        "code": "DOC-SESSION",
+        "title": "Session Test",
+        "type": "T",
+        "department": "Dept",
+        "tags": "tag1,tag2",
+        "uploaded_file_key": "key",
+        "uploaded_file_name": "file.txt",
+        "standard": "ISO9001",
+    }
+    resp = client.post("/api/documents", json=payload)
+    assert resp.status_code == 201


### PR DESCRIPTION
## Summary
- avoid `ResourceClosedError` by removing scoped session instead of closing it in the archive listing
- add regression test verifying document creation succeeds after fetching standard map

## Testing
- `pytest tests/test_session_cleanup.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6a4b83c3c832b8449719c06e092ff