### PR TITLE
Log PDF preview enqueue errors

### DIFF
--- a/portal/pdf_preview_job.py
+++ b/portal/pdf_preview_job.py
@@ -1,12 +1,15 @@
 """Background job to generate PDF previews for documents."""
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 from typing import Any
 
 from signing import convert_to_pdf
 from storage import storage_client
+
+logger = logging.getLogger(__name__)
 
 try:  # pragma: no cover - real redis only used in production
     from redis import Redis
@@ -61,7 +64,7 @@ def enqueue_preview(doc_id: int, version: str, key: str) -> None:
     try:
         queue.enqueue(generate_preview, doc_id, version, key)
     except Exception:  # pragma: no cover - queue backend unavailable
-        pass
+        logger.exception("Failed to enqueue PDF preview job")
 
 
 __all__ = ["enqueue_preview", "generate_preview", "queue"]


### PR DESCRIPTION
## Summary
- log failures when enqueuing PDF preview jobs so queue issues appear in logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6c76ae81c832b9b7f5e9c0c63bb90