### PR TITLE
Log version upload details

### DIFF
--- a/tests/test_document_version_upload.py
+++ b/tests/test_document_version_upload.py
@@ -89,6 +89,21 @@ def test_upload_new_version_success(client, app_models):
     assert body["minor_version"] == 1
     assert storage.storage_client.put.called
 
+    session = models.SessionLocal()
+    log = (
+        session.query(models.AuditLog)
+        .filter_by(doc_id=doc_id, action="version_uploaded")
+        .first()
+    )
+    assert log is not None
+    assert log.payload == {
+        "version": f"{body['major_version']}.{body['minor_version']}",
+        "size": 4,
+        "content_type": "application/pdf",
+        "note": "rev1",
+    }
+    session.close()
+
 
 def test_upload_new_version_forbidden(client, app_models):
     app_module, models = app_models


### PR DESCRIPTION
## Summary
- log document version uploads with file size, content type, notes and version string
- verify version upload audit logging in tests

## Testing
- `pytest tests/test_document_version_upload.py::test_upload_new_version_success -q`
- `pytest tests/test_version_upload_notifications.py::test_version_upload_enqueues_notifications -q`
- `pytest tests/test_document_versioning.py::test_start_revision_increments_version_and_logs -q`
- `pytest tests/test_document_version_upload.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f00ea2c8832b90465af88437b90d