### PR TITLE
Allow publishing review documents with active version

### DIFF
--- a/tests/test_document_notifications.py
+++ b/tests/test_document_notifications.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import sys
 from pathlib import Path
 
@@ -65,5 +66,6 @@ def test_publish_document_queues_notification(monkeypatch):
         f"/api/documents/{doc_id}/publish", data={}, headers={"HX-Request": "true"}
     )
     assert resp.status_code == 204
+    assert resp.headers["HX-Trigger"] == json.dumps({"showToast": "Document published"})
     assert len(q.jobs) == 1
     assert q.jobs[0].args[0] == owner_id


### PR DESCRIPTION
## Summary
- permit publishing documents in Review status when an active version exists
- send clearer toast message when documents are published
- test review publish path and missing active version errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b827a21420832b987ca3c24c3f27ed