### PR TITLE
Clarify publish toast for mandatory reading assignment

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -3399,7 +3399,7 @@ def publish_document(id: int):
             resp = make_response("", 204)
             resp.headers["HX-Redirect"] = url_for("document_detail", doc_id=doc.id)
             resp.headers["HX-Trigger"] = json.dumps(
-                {"showToast": "Document published"}
+                {"showToast": "Published – assign mandatory reading"}
             )
             return resp
         return redirect(url_for("list_documents", status="Published"))

--- a/tests/test_document_notifications.py
+++ b/tests/test_document_notifications.py
@@ -66,7 +66,7 @@ def test_publish_document_queues_notification(monkeypatch):
         f"/api/documents/{doc_id}/publish", data={}, headers={"HX-Request": "true"}
     )
     assert resp.status_code == 204
-    assert resp.headers["HX-Trigger"] == json.dumps({"showToast": "Document published"})
+    assert resp.headers["HX-Trigger"] == json.dumps({"showToast": "Published – assign mandatory reading"})
     assert len(q.jobs) == 1
     assert q.jobs[0].args[0] == owner_id
 
@@ -91,7 +91,7 @@ def test_publish_review_document_queues_notification(monkeypatch):
         f"/api/documents/{doc_id}/publish", data={}, headers={"HX-Request": "true"}
     )
     assert resp.status_code == 204
-    assert resp.headers["HX-Trigger"] == json.dumps({"showToast": "Document published"})
+    assert resp.headers["HX-Trigger"] == json.dumps({"showToast": "Published – assign mandatory reading"})
     assert len(q.jobs) == 1
     assert q.jobs[0].args[0] == owner_id
 


### PR DESCRIPTION
## Summary
- Update document publish flow to trigger toast "Published – assign mandatory reading"
- Align tests with new publish toast message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b82cf3cc9c832bb564a81a507f608f