### PR TITLE
Include document version in download links

### DIFF
--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -28,6 +28,9 @@
     Assign Mandatory Reading <span class="badge bg-secondary" id="assignment-count">{{ ack_count | default(0) }}</span>
   </button>
   {% endif %}
+  {% if can_download %}
+  <a class="btn btn-outline-secondary" href="/documents/{{ doc.id }}/download?version=v{{ doc.major_version }}.{{ doc.minor_version }}">Download</a>
+  {% endif %}
   {% if can_upload_version %}
   <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#uploadVersionModal">Upload New Version</button>
   {% endif %}
@@ -99,12 +102,12 @@
 
 {% include "partials/_audit_log.html" %}
 
-<div class="toolbar" data-component="toolbar">
-  <a class="btn btn-secondary" href="{{ url_for('list_documents') }}">Back to documents</a>
-  {% if can_download %}
-  <a class="btn btn-secondary" href="{{ url_for('document_download', doc_id=doc.id) }}">Download</a>
-  {% endif %}
-</div>
+  <div class="toolbar" data-component="toolbar">
+    <a class="btn btn-secondary" href="{{ url_for('list_documents') }}">Back to documents</a>
+    {% if can_download %}
+    <a class="btn btn-secondary" href="{{ url_for('document_download', doc_id=doc.id) }}?version=v{{ doc.major_version }}.{{ doc.minor_version }}">Download</a>
+    {% endif %}
+  </div>
 
 {% if can_upload_version %}
 <div class="modal fade" id="uploadVersionModal" tabindex="-1" aria-hidden="true">

--- a/portal/templates/documents/_table.html
+++ b/portal/templates/documents/_table.html
@@ -40,7 +40,7 @@
           <span class="btn btn-sm btn-outline-secondary disabled">Workflow</span>
           {% endif %}
           {% if doc.can_download %}
-          <a href="{{ url_for('document_download', doc_id=doc.id) }}" class="btn btn-sm btn-outline-secondary">Download</a>
+          <a href="{{ url_for('document_download', doc_id=doc.id) }}?version=v{{ doc.major_version }}.{{ doc.minor_version }}" class="btn btn-sm btn-outline-secondary">Download</a>
           {% endif %}
           <a href="{{ url_for('document_detail', doc_id=doc.id) }}#uploadVersionModal" class="btn btn-sm btn-outline-secondary">Upload New Version</a>
         </td>

--- a/portal/templates/partials/documents/_versions.html
+++ b/portal/templates/partials/documents/_versions.html
@@ -30,7 +30,7 @@
             data-url="{{ url_for('compare_document_versions', doc_id=doc.id) }}"
             data-rev-id="{{ revision.id }}">Compare to…</button>
           {% if can_download %}
-          <a class="btn btn-outline-secondary mt-2" href="{{ url_for('document_download', doc_id=doc.id) }}">Download</a>
+          <a class="btn btn-outline-secondary mt-2" href="{{ url_for('document_download', doc_id=doc.id) }}?version=v{{ revision.major_version }}.{{ revision.minor_version }}">Download</a>
           {% endif %}
         </div>
         {% else %}


### PR DESCRIPTION
## Summary
- Add top toolbar download button passing current version
- Include version query parameter on document download links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b834e9f694832b8f0f60404debfae2