### PR TITLE
Track uploader on document revisions

### DIFF
--- a/alembic/versions/0021_add_uploaded_by_to_document_revisions.py
+++ b/alembic/versions/0021_add_uploaded_by_to_document_revisions.py
@@ -1,0 +1,35 @@
+"""Add uploaded_by to document_revisions
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2025-09-09
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "0021"
+down_revision = "0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("document_revisions")]
+    if "uploaded_by" not in columns:
+        op.add_column(
+            "document_revisions",
+            sa.Column("uploaded_by", sa.Integer(), sa.ForeignKey("users.id"), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("document_revisions")]
+    if "uploaded_by" in columns:
+        op.drop_column("document_revisions", "uploaded_by")

--- a/portal/app.py
+++ b/portal/app.py
@@ -1323,7 +1323,10 @@ def document_detail(doc_id: int | None = None, id: int | None = None):
     db = get_session()
     doc = (
         db.query(Document)
-        .options(joinedload(Document.revisions), joinedload(Document.lock_owner))
+        .options(
+            joinedload(Document.revisions).joinedload(DocumentRevision.user),
+            joinedload(Document.lock_owner),
+        )
         .filter(Document.id == doc_id)
         .one_or_none()
     )
@@ -2058,6 +2061,7 @@ def upload_document_version(doc_id: int):
         minor_version=doc.minor_version,
         revision_notes=notes,
         file_key=prev_key,
+        uploaded_by=user.get("id"),
     )
     db.add(revision)
 

--- a/portal/models.py
+++ b/portal/models.py
@@ -123,8 +123,10 @@ class DocumentRevision(Base):
     track_changes = Column(JSON)
     compare_result = Column(JSON)
     created_at = Column(DateTime, default=datetime.utcnow)
+    uploaded_by = Column(Integer, ForeignKey("users.id"), nullable=True)
 
     document = relationship(Document, back_populates="revisions")
+    user = relationship("User", foreign_keys=[uploaded_by])
 
 
 class DocumentPermission(Base):

--- a/tests/test_document_version_upload.py
+++ b/tests/test_document_version_upload.py
@@ -102,6 +102,8 @@ def test_upload_new_version_success(client, app_models):
         "content_type": "application/pdf",
         "note": "rev1",
     }
+    rev = session.query(models.DocumentRevision).filter_by(doc_id=doc_id).first()
+    assert rev.uploaded_by == 1
     session.close()
 
 


### PR DESCRIPTION
## Summary
- record the user who uploads each document revision
- load uploader info on document details
- add Alembic migration for new document revision column

## Testing
- `pytest`
- `alembic upgrade head` *(fails: No support for ALTER of constraints in SQLite dialect)*

------
https://chatgpt.com/codex/tasks/task_e_68b83ef4fd74832bb8cb7ee62e4987a2