### PR TITLE
Limit document version comparison to two selections

### DIFF
--- a/portal/static/document_detail.js
+++ b/portal/static/document_detail.js
@@ -55,10 +55,15 @@ function initVersionSelection() {
     });
   }
   if (!checkboxes.length) return;
-  const update = () => {
+  const update = (evt) => {
     if (!summary || !compareBtn) return;
+    let selected = Array.from(checkboxes).filter((cb) => cb.checked);
+    if (selected.length > 2 && evt?.target.checked) {
+      evt.target.checked = false;
+      showToast('En fazla iki sürüm seçebilirsiniz');
+      selected = selected.filter((cb) => cb !== evt.target);
+    }
     summary.innerHTML = '';
-    const selected = Array.from(checkboxes).filter((cb) => cb.checked);
     revA = selected[0]?.value || null;
     revB = selected[1]?.value || null;
     selected.forEach((cb) => {


### PR DESCRIPTION
## Summary
- Restrict document version comparison to only two selections
- Show a toast and uncheck when a third version is selected

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8417f5600832b92c2362569e7d236