### PR TITLE
Handle presign failure in diff API

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1780,7 +1780,8 @@ def compare_document_revisions_api(doc_id: int):
             filename, bucket=storage_client.bucket_previews
         )
         if not url:
-            app.logger.warning("Failed to generate presigned URL for %s", filename)
+            app.logger.error("Failed to generate presigned URL for %s", filename)
+            return jsonify(error="Could not generate diff link"), 500
         return jsonify(filename=filename, url=url)
     finally:
         SessionLocal.remove()


### PR DESCRIPTION
## Summary
- fail diff compare API when presigned URL generation fails
- test document diff API presign failure

## Testing
- `pytest tests/test_document_compare_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b84e7bafe0832ba4900959c54860d8