### PR TITLE
Add due date to acknowledgements

### DIFF
--- a/alembic/versions/0022_add_due_at_to_acknowledgements.py
+++ b/alembic/versions/0022_add_due_at_to_acknowledgements.py
@@ -1,0 +1,37 @@
+"""Add due_at to acknowledgements
+
+Revision ID: 0022
+Revises: 0021
+Create Date: 2025-09-10
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "0022"
+down_revision = "0021"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("acknowledgements")]
+    if "due_at" not in columns:
+        op.add_column(
+            "acknowledgements",
+            sa.Column("due_at", sa.DateTime(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("acknowledgements")]
+    if "due_at" in columns:
+        op.drop_column("acknowledgements", "due_at")
+

--- a/portal/models.py
+++ b/portal/models.py
@@ -243,6 +243,7 @@ class Acknowledgement(Base):
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     doc_id = Column(Integer, ForeignKey("documents.id"), nullable=False)
+    due_at = Column(DateTime, nullable=True)
     acknowledged_at = Column(DateTime, nullable=True)
 
     user = relationship("User")


### PR DESCRIPTION
## Summary
- extend acknowledgement model with optional due date
- add alembic migration for acknowledgements.due_at

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b92ef1e7f8832bad6fd8315e4224ce