### PR TITLE
Query user acknowledgements with due dates

### DIFF
--- a/portal/templates/partials/ack/_table.html
+++ b/portal/templates/partials/ack/_table.html
@@ -14,7 +14,7 @@
       <td>{{ item.code }}</td>
       <td>{{ item.title }}</td>
       <td>{{ item.status }}</td>
-      <td>{{ item.due_date }}</td>
+      <td>{{ item.due_at }}</td>
       <td>
         <form hx-post="{{ url_for('ack.confirm', id=item.id) }}"
               hx-target="closest tr"


### PR DESCRIPTION
## Summary
- Fetch pending acknowledgements by querying `Acknowledgement` for the current user and joining `Document` for metadata
- Filter and display acknowledgements using `due_at`, exposing it in the acknowledgements table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9399af030832b884cf61f3c54bef3