### PR TITLE
Schedule lock cleanup job

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,6 +195,7 @@ services:
       sh -c "pip install -r requirements.txt &&
              ( while :; do python archive_job.py; sleep 86400; done ) &
              ( while :; do python dif_overdue_job.py; sleep 3600; done ) &
+             ( while :; do python clear_locks_job.py; sleep 300; done ) &
              ( while :; do python periodic_review.py; sleep 31536000; done ) &
              wait"
     depends_on:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,3 +9,12 @@
   ```
 - After a document is uploaded, `pdf_preview_job.enqueue_preview` creates `previews/<doc_id>/<version>.pdf` in the preview bucket.
 
+## Scheduled Jobs
+
+- Ensure the scheduler container (or an equivalent cron setup) runs maintenance tasks.
+- The scheduler now executes `clear_locks_job.py` every 5 minutes to release expired document locks:
+  ```bash
+  ( while :; do python clear_locks_job.py; sleep 300; done )
+  ```
+  Configure your deployment to run this command periodically if not using `docker-compose`.
+

--- a/tests/test_clear_locks_job.py
+++ b/tests/test_clear_locks_job.py
@@ -1,0 +1,28 @@
+import importlib
+from datetime import datetime, timedelta
+from sqlalchemy.orm import sessionmaker
+
+
+def test_clear_locks_job_clears_expired_locks():
+    job = importlib.import_module("clear_locks_job")
+    models = importlib.import_module("models")
+    Session = sessionmaker(bind=models.engine)
+    session = Session()
+    doc = models.Document(
+        file_key="orig.pdf",
+        title="Doc",
+        status="Published",
+        mime="application/pdf",
+        locked_by=1,
+        lock_expires_at=datetime.utcnow() - timedelta(minutes=1),
+    )
+    session.add(doc)
+    session.commit()
+    doc_id = doc.id
+    session.close()
+    job.run()
+    session = Session()
+    doc_db = session.get(models.Document, doc_id)
+    assert doc_db.locked_by is None
+    assert doc_db.lock_expires_at is None
+    session.close()


### PR DESCRIPTION
## Summary
- run clear_locks_job periodically via scheduler
- document scheduled job setup
- test lock cleanup job clears expired locks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b95a0e2eac832bb0fd5698f9635c70