### PR TITLE
feat: expose locked_until in checkout response

### DIFF
--- a/docs/document-locking.md
+++ b/docs/document-locking.md
@@ -1,0 +1,13 @@
+# Document Locking API
+
+When a document is checked out via `POST /api/documents/<id>/checkout`, the response includes information about the lock:
+
+```json
+{
+  "locked_by": <user_id>,
+  "locked_until": "<ISO timestamp>",
+  "lock_expires_at": "<ISO timestamp>"
+}
+```
+
+`locked_until` is the preferred key. `lock_expires_at` is provided for backward compatibility and will be removed in a future release.

--- a/portal/app.py
+++ b/portal/app.py
@@ -2242,7 +2242,11 @@ def checkout_document(doc_id: int):
     if previous_locked_by and previous_locked_by not in {owner_id, user_id}:
         notify_user(previous_locked_by, subject, body)
     SessionLocal.remove()
-    return jsonify(locked_by=user_id, lock_expires_at=doc.lock_expires_at.isoformat())
+    return jsonify(
+        locked_by=user_id,
+        locked_until=doc.lock_expires_at.isoformat(),
+        lock_expires_at=doc.lock_expires_at.isoformat(),
+    )
 
 
 @app.post("/api/documents/<int:doc_id>/checkin")

--- a/tests/test_document_locking.py
+++ b/tests/test_document_locking.py
@@ -141,8 +141,9 @@ def test_checkout_respects_lock_duration(client, app_models, monkeypatch):
     resp = client.post(f"/api/documents/{doc_id}/checkout")
     assert resp.status_code == 200
     data = resp.get_json()
-    lock_expires_at = datetime.fromisoformat(data["lock_expires_at"])
-    assert abs((lock_expires_at - before) - timedelta(minutes=5)) < timedelta(seconds=5)
+    locked_until = datetime.fromisoformat(data["locked_until"])
+    assert abs((locked_until - before) - timedelta(minutes=5)) < timedelta(seconds=5)
+    assert data["lock_expires_at"] == data["locked_until"]
 
 
 def test_checkin_requires_permission(client, app_models):


### PR DESCRIPTION
## Summary
- include new `locked_until` field in document checkout response while keeping `lock_expires_at` for backward compatibility
- verify `locked_until` in document locking tests and ensure both fields match
- document checkout lock response fields

## Testing
- `pytest tests/test_document_locking.py -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b95afc1440832bb42e43ddbd631550