### PR TITLE
Use 'to' query parameter for document rollback

### DIFF
--- a/tests/test_document_versioning.py
+++ b/tests/test_document_versioning.py
@@ -104,7 +104,7 @@ def test_rollback_document_creates_new_revision_and_serves_content(client, app_m
         sess["user"] = {"id": 1, "name": "Tester"}
         sess["roles"] = ["reviewer", "reader"]
 
-    resp = client.post(f"/api/documents/{doc_id}/rollback", json={"version": "v1.0"})
+    resp = client.post(f"/api/documents/{doc_id}/rollback?to=v1.0")
     assert resp.status_code == 200
     body = resp.get_json()
     assert body["minor_version"] == 2


### PR DESCRIPTION
## Summary
- read rollback target version from `to` query arg instead of `version`
- rename variables/messages to `target_version`
- adjust tests to use `?to=` when rolling back

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b95d3be11c832ba5eccfa4c0f7dd83