### PR TITLE
Add empty state for document version list

### DIFF
--- a/portal/templates/partials/documents/_versions.html
+++ b/portal/templates/partials/documents/_versions.html
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-md-8">
       <div class="table-responsive">
+        {% if revisions %}
         <table class="table table-hover align-middle">
           <thead>
             <tr>
@@ -24,13 +25,16 @@
               <td>{{ rev.user.username if rev.user else '' }}</td>
               <td>{{ rev.revision_notes or '' }}</td>
             </tr>
-            {% else %}
-            <tr>
-              <td colspan="4">No versions found.</td>
-            </tr>
             {% endfor %}
           </tbody>
         </table>
+        {% else %}
+        <div class="text-center p-4" role="status">
+          <svg class="icon mb-2" aria-hidden="true"><use href="#icon-upload"></use></svg>
+          <p class="mb-2">{{ t('no_versions_yet') }}</p>
+          <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#uploadVersionModal">{{ t('upload_new_version') }}</button>
+        </div>
+        {% endif %}
       </div>
       {% if can_server_diff %}
       <button type="submit" id="compare-button" class="btn btn-secondary mt-2" data-can-server-diff="true" disabled>Compare</button>

--- a/portal/translations.py
+++ b/portal/translations.py
@@ -26,6 +26,8 @@ TRANSLATIONS = {
         "department_label": "Department",
         "type_label": "Type",
         "standard_label": "Standard",
+        "no_versions_yet": "No versions uploaded yet.",
+        "upload_new_version": "Upload New Version",
     },
     "tr": {
         "new_document_step3_title": "Yeni Doküman - Adım 3",
@@ -50,6 +52,8 @@ TRANSLATIONS = {
         "department_label": "Departman",
         "type_label": "Tür",
         "standard_label": "Standart",
+        "no_versions_yet": "Henüz sürüm yüklenmedi.",
+        "upload_new_version": "Yeni Sürüm Yükle",
     },
 }
 


### PR DESCRIPTION
## Summary
- Replace empty revisions row with an accessible empty-state component and modal trigger
- Add translation strings for new empty-state message and button

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b972a948b8832b95bf84afa4f31f40