### PR TITLE
Improve skeleton accessibility

### DIFF
--- a/portal/templates/partials/_skeleton.html
+++ b/portal/templates/partials/_skeleton.html
@@ -1,7 +1,10 @@
 <template id="skeleton-template">
-  <div class="placeholder-glow">
-    <span class="placeholder col-12 mb-2"></span>
-    <span class="placeholder col-12 mb-2"></span>
-    <span class="placeholder col-12 mb-2"></span>
+  <div role="status" aria-live="polite">
+    <div class="placeholder-glow" aria-hidden="true">
+      <span class="placeholder col-12 mb-2"></span>
+      <span class="placeholder col-12 mb-2"></span>
+      <span class="placeholder col-12 mb-2"></span>
+    </div>
+    <span class="visually-hidden">Loading...</span>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Make loading skeleton accessible with status role, aria-live, and hidden text
- Hide placeholder elements from assistive tech

## Testing
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b976d66218832b830d161b08224b60