### PR TITLE
Restrict document actions by role

### DIFF
--- a/portal/templates/document_detail.html
+++ b/portal/templates/document_detail.html
@@ -5,28 +5,32 @@
 {% block page_actions %}
 <link rel="stylesheet" href="{{ url_for('static', filename='toolbar/toolbar.css') }}">
 <div class="toolbar" data-component="toolbar" data-variant="icon-text">
-  {% if doc.status in ['Review', 'Approved'] %}
-    {% if doc.file_key %}
-    <form id="publish-form" hx-post="/api/documents/{{ doc.id }}/publish" hx-swap="none" class="d-inline">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <button type="submit" class="btn btn-primary" id="publish-button">Publish</button>
-    </form>
+  {% if has_role('editor') or has_role('publisher') or has_role('quality_admin') %}
+    {% if doc.status in ['Review', 'Approved'] %}
+      {% if doc.file_key %}
+      <form id="publish-form" hx-post="/api/documents/{{ doc.id }}/publish" hx-swap="none" class="d-inline">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button type="submit" class="btn btn-primary" id="publish-button">Publish</button>
+      </form>
+      {% else %}
+      <button type="button" class="btn btn-primary" id="publish-button" disabled title="No active version">Publish (No active version)</button>
+      {% endif %}
+    {% elif doc.status == 'Draft' %}
+    <button type="button" class="btn btn-primary" id="publish-button" disabled title="Document is in draft status">Publish (Draft)</button>
     {% else %}
-    <button type="button" class="btn btn-primary" id="publish-button" disabled title="No active version">Publish (No active version)</button>
+    <button type="button" class="btn btn-primary" id="publish-button" disabled title="Publish unavailable">Publish</button>
     {% endif %}
-  {% elif doc.status == 'Draft' %}
-  <button type="button" class="btn btn-primary" id="publish-button" disabled title="Document is in draft status">Publish (Draft)</button>
-  {% else %}
-  <button type="button" class="btn btn-primary" id="publish-button" disabled title="Publish unavailable">Publish</button>
   {% endif %}
-  {% if doc.status == 'Published' %}
-  <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#assignModal">
-    Assign Mandatory Reading <span class="badge bg-secondary" id="assignment-count">{{ ack_count }}</span>
-  </button>
-  {% else %}
-  <button type="button" class="btn btn-outline-primary" disabled>
-    Assign Mandatory Reading <span class="badge bg-secondary" id="assignment-count">{{ ack_count | default(0) }}</span>
-  </button>
+  {% if has_role('editor') or has_role('publisher') or has_role('quality_admin') %}
+    {% if doc.status == 'Published' %}
+    <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#assignModal">
+      Assign Mandatory Reading <span class="badge bg-secondary" id="assignment-count">{{ ack_count }}</span>
+    </button>
+    {% else %}
+    <button type="button" class="btn btn-outline-primary" disabled>
+      Assign Mandatory Reading <span class="badge bg-secondary" id="assignment-count">{{ ack_count | default(0) }}</span>
+    </button>
+    {% endif %}
   {% endif %}
   {% if preview %}
   <a class="btn btn-primary" href="{{ preview.url }}" target="_blank">Preview (PDF)</a>
@@ -36,8 +40,10 @@
   {% if can_download %}
   <a class="btn btn-outline-secondary" href="/documents/{{ doc.id }}/download?version=v{{ doc.major_version }}.{{ doc.minor_version }}">Download</a>
   {% endif %}
-  {% if can_upload_version %}
-  <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#uploadVersionModal">Upload New Version</button>
+  {% if has_role('editor') or has_role('publisher') or has_role('quality_admin') %}
+    {% if can_upload_version %}
+    <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#uploadVersionModal">Upload New Version</button>
+    {% endif %}
   {% endif %}
   {% if has_role('admin') or has_role('quality') %}
   <div class="btn-group">
@@ -61,30 +67,32 @@
 
 {% block content %}
 <h1>{{ doc.title }}</h1>
-{% if doc.locked_by and doc.lock_expires_at and doc.lock_expires_at > now %}
-  {% if current_user and current_user.id == doc.locked_by %}
-  <div class="alert alert-info">Checked out by you until {{ doc.lock_expires_at }}.</div>
-  {% if can_checkin %}
-  <form class="mb-3" hx-post="/api/documents/{{ doc.id }}/checkin" hx-swap="none">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    <button type="submit" class="btn btn-warning">Check in</button>
-  </form>
-  {% endif %}
+{% if has_role('editor') or has_role('publisher') or has_role('quality_admin') %}
+  {% if doc.locked_by and doc.lock_expires_at and doc.lock_expires_at > now %}
+    {% if current_user and current_user.id == doc.locked_by %}
+    <div class="alert alert-info">Checked out by you until {{ doc.lock_expires_at }}.</div>
+    {% if can_checkin %}
+    <form class="mb-3" hx-post="/api/documents/{{ doc.id }}/checkin" hx-swap="none">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit" class="btn btn-warning">Check in</button>
+    </form>
+    {% endif %}
+    {% else %}
+    <div class="alert alert-warning">Locked by {{ doc.lock_owner.username if doc.lock_owner else 'another user' }} until {{ doc.lock_expires_at }}.</div>
+    {% if can_override or 'quality_admin' in user_roles %}
+    <form class="mb-3" hx-post="/api/documents/{{ doc.id }}/checkin" hx-swap="none">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit" class="btn btn-danger">Force Check in</button>
+    </form>
+    {% endif %}
+    {% endif %}
   {% else %}
-  <div class="alert alert-warning">Locked by {{ doc.lock_owner.username if doc.lock_owner else 'another user' }} until {{ doc.lock_expires_at }}.</div>
-  {% if can_override or 'quality_admin' in user_roles %}
-  <form class="mb-3" hx-post="/api/documents/{{ doc.id }}/checkin" hx-swap="none">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    <button type="submit" class="btn btn-danger">Force Check in</button>
-  </form>
-  {% endif %}
-  {% endif %}
-{% else %}
-  {% if can_checkout %}
-  <form class="mb-3" hx-post="/api/documents/{{ doc.id }}/checkout" hx-swap="none">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    <button type="submit" class="btn btn-outline-primary">Check out</button>
-  </form>
+    {% if can_checkout %}
+    <form class="mb-3" hx-post="/api/documents/{{ doc.id }}/checkout" hx-swap="none">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit" class="btn btn-outline-primary">Check out</button>
+    </form>
+    {% endif %}
   {% endif %}
 {% endif %}
 <ul>
@@ -105,33 +113,36 @@
     {% endif %}
   </div>
 
-{% if can_upload_version %}
-<div class="modal fade" id="uploadVersionModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <form id="upload-version-form" hx-post="/api/documents/{{ doc.id }}/versions" hx-target="#version-list" hx-swap="outerHTML" hx-encoding="multipart/form-data">
-        <div class="modal-header">
-          <h5 class="modal-title">Upload New Version</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body">
-          <div class="mb-3">
-            <input type="file" name="file" required>
+{% if has_role('editor') or has_role('publisher') or has_role('quality_admin') %}
+  {% if can_upload_version %}
+  <div class="modal fade" id="uploadVersionModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="upload-version-form" hx-post="/api/documents/{{ doc.id }}/versions" hx-target="#version-list" hx-swap="outerHTML" hx-encoding="multipart/form-data">
+          <div class="modal-header">
+            <h5 class="modal-title">Upload New Version</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
-          <div class="mb-3">
-            <input type="text" class="form-control" name="notes" placeholder="Revision notes">
+          <div class="modal-body">
+            <div class="mb-3">
+              <input type="file" name="file" required>
+            </div>
+            <div class="mb-3">
+              <input type="text" class="form-control" name="notes" placeholder="Revision notes">
+            </div>
           </div>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <button type="submit" class="btn btn-primary">Upload</button>
-        </div>
-      </form>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-primary">Upload</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
-</div>
+  {% endif %}
 {% endif %}
 
+{% if has_role('editor') or has_role('publisher') or has_role('quality_admin') %}
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -175,6 +186,7 @@
     </div>
   </div>
 </div>
+{% endif %}
 
 <script type="module" src="{{ url_for('static', filename='document_detail.js') }}"></script>
 <script type="module">


### PR DESCRIPTION
## Summary
- Require editor, publisher, or quality_admin roles for publish, assign mandatory reading, upload new version, and checkout actions
- Apply the same role guard to associated modals

## Testing
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b9891aa5b4832b8be92f9e11892408