### PR TITLE
Restrict upload new version action

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1073,6 +1073,9 @@ def list_documents():
     user = session.get("user")
     for d in docs:
         d.can_download = bool(user) and permission_check(user["id"], d, download=True)
+        d.can_upload_version = bool(user) and permission_check(
+            user["id"], d, upload=True
+        )
 
     db_session = get_session()
     departments = [d[0] for d in db_session.query(Document.department).distinct().all()]
@@ -1105,6 +1108,9 @@ def documents_table():
     user = session.get("user")
     for d in docs:
         d.can_download = bool(user) and permission_check(user["id"], d, download=True)
+        d.can_upload_version = bool(user) and permission_check(
+            user["id"], d, upload=True
+        )
     context = {
         "documents": docs,
         "page": page,

--- a/portal/templates/documents/_table.html
+++ b/portal/templates/documents/_table.html
@@ -42,10 +42,12 @@
           {% if doc.can_download %}
           <a href="{{ url_for('document_download', doc_id=doc.id) }}?version=v{{ doc.major_version }}.{{ doc.minor_version }}" class="btn btn-sm btn-outline-secondary">Download</a>
           {% endif %}
-          <a href="{{ url_for('document_detail', doc_id=doc.id) }}#uploadVersionModal" class="btn btn-sm btn-outline-secondary">Upload New Version</a>
-        </td>
-      </tr>
-      {% endfor %}
+            {% if has_role('editor') or has_role('publisher') or has_role('quality_admin') and doc.can_upload_version %}
+            <a href="{{ url_for('document_detail', doc_id=doc.id) }}#uploadVersionModal" class="btn btn-sm btn-outline-secondary">Upload New Version</a>
+            {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
     </tbody>
     {% else %}
     <tbody>


### PR DESCRIPTION
## Summary
- hide “Upload New Version” link unless editor/publisher/quality admin with upload permission
- compute `doc.can_upload_version` for documents in list views to avoid missing attribute

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9904e64d4832ba00da5c987020f68