### PR TITLE
Add audit log display metadata and date filter

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -52,6 +52,7 @@ from pdf_preview_job import enqueue_preview
 from translations import t
 from static_build import build_all
 import services
+from audit_display import inject_audit_display, format_dt
 
 
 # Automatically run database migrations in non-SQLite environments.
@@ -133,6 +134,8 @@ def set_security_headers(response):
 CSRFProtect(app)
 auth_init(app)
 app.register_blueprint(auth_bp)
+app.context_processor(inject_audit_display)
+app.jinja_env.filters["format_dt"] = format_dt
 
 
 @app.errorhandler(403)

--- a/portal/audit_display.py
+++ b/portal/audit_display.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping, Dict
+
+from translations import get_locale
+
+# Mapping of audit log actions to display metadata used in templates.
+# Each entry maps an action name to an icon identifier and a translation key.
+AUDIT_DISPLAY: Mapping[str, Dict[str, str]] = {
+    "create": {"icon": "plus", "label_key": "create"},
+    "view": {"icon": "search", "label_key": "view"},
+    "download_document": {"icon": "download", "label_key": "download_document"},
+    "download_revision": {"icon": "download", "label_key": "download_revision"},
+    "version_uploaded": {"icon": "upload", "label_key": "version_uploaded"},
+    "publish_document": {"icon": "upload", "label_key": "publish_document"},
+    "assign_mr": {"icon": "bell", "label_key": "assign_mr"},
+    "checkout_document": {"icon": "download", "label_key": "checkout_document"},
+    "checkin_document": {"icon": "upload", "label_key": "checkin_document"},
+    "rollback": {"icon": "filter", "label_key": "rollback"},
+}
+
+
+def inject_audit_display() -> dict[str, Mapping[str, Dict[str, str]]]:
+    """Context processor that exposes ``AUDIT_DISPLAY`` to templates."""
+    return {"audit_display": AUDIT_DISPLAY}
+
+
+def format_dt(dt: datetime | None) -> str:
+    """Return a locale-aware string representation of ``dt``.
+
+    For Turkish locale (``tr``) the format ``dd.MM.yyyy HH:mm`` is used.  For
+    any other locale, the timestamp is rendered in ISO format to minutes.
+    ``None`` values yield an empty string.
+    """
+    if dt is None:
+        return ""
+    if get_locale() == "tr":
+        return dt.strftime("%d.%m.%Y %H:%M")
+    return dt.isoformat(sep=" ", timespec="minutes")
+

--- a/portal/templates/partials/_audit_log.html
+++ b/portal/templates/partials/_audit_log.html
@@ -2,8 +2,11 @@
 <h4>Audit History</h4>
 <ul class="list-unstyled">
   {% for log in logs %}
+  {% set meta = audit_display.get(log.action, {'icon':'default','label_key':log.action}) %}
   <li>
-    {{ log.at.strftime('%Y-%m-%d %H:%M') }} - {{ log.action }}
+    {{ log.at|format_dt }} -
+    <svg class="icon"><use href="#icon-{{ meta.icon }}"></use></svg>
+    {{ t(meta.label_key) }}
     {% if log.user %}by {{ log.user.username }}{% endif %}
   </li>
   {% endfor %}


### PR DESCRIPTION
## Summary
- provide audit log action metadata with icons and translation keys
- expose audit display mapping via context processor and add `format_dt` Jinja filter
- render audit log entries using metadata and locale-aware date formatting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba75035218832bb6a49d55cd88deea