### PR TITLE
Add audit action translations and fallback logic

### DIFF
--- a/portal/audit_display.py
+++ b/portal/audit_display.py
@@ -8,16 +8,16 @@ from translations import get_locale
 # Mapping of audit log actions to display metadata used in templates.
 # Each entry maps an action name to an icon identifier and a translation key.
 AUDIT_DISPLAY: Mapping[str, Dict[str, str]] = {
-    "create": {"icon": "plus", "label_key": "create"},
-    "view": {"icon": "search", "label_key": "view"},
-    "download_document": {"icon": "download", "label_key": "download_document"},
-    "download_revision": {"icon": "download", "label_key": "download_revision"},
-    "version_uploaded": {"icon": "upload", "label_key": "version_uploaded"},
-    "publish_document": {"icon": "upload", "label_key": "publish_document"},
-    "assign_mr": {"icon": "bell", "label_key": "assign_mr"},
-    "checkout_document": {"icon": "download", "label_key": "checkout_document"},
-    "checkin_document": {"icon": "upload", "label_key": "checkin_document"},
-    "rollback": {"icon": "filter", "label_key": "rollback"},
+    "create": {"icon": "plus", "label_key": "audit_create"},
+    "view": {"icon": "search", "label_key": "audit_view"},
+    "download_document": {"icon": "download", "label_key": "audit_download_document"},
+    "download_revision": {"icon": "download", "label_key": "audit_download_revision"},
+    "version_uploaded": {"icon": "upload", "label_key": "audit_version_uploaded"},
+    "publish_document": {"icon": "upload", "label_key": "audit_publish_document"},
+    "assign_mr": {"icon": "bell", "label_key": "audit_assign_mr"},
+    "checkout_document": {"icon": "download", "label_key": "audit_checkout_document"},
+    "checkin_document": {"icon": "upload", "label_key": "audit_checkin_document"},
+    "rollback": {"icon": "filter", "label_key": "audit_rollback"},
 }
 
 

--- a/portal/translations.py
+++ b/portal/translations.py
@@ -30,6 +30,16 @@ TRANSLATIONS = {
         "standard_label": "Standard",
         "no_versions_yet": "No versions uploaded yet.",
         "upload_new_version": "Upload New Version",
+        "audit_create": "Created",
+        "audit_view": "Viewed",
+        "audit_download_document": "Document downloaded",
+        "audit_download_revision": "Revision downloaded",
+        "audit_version_uploaded": "Version uploaded",
+        "audit_publish_document": "Document published",
+        "audit_assign_mr": "MR assigned",
+        "audit_checkout_document": "Document checked out",
+        "audit_checkin_document": "Document checked in",
+        "audit_rollback": "Rolled back",
     },
     "tr": {
         "new_document_step3_title": "Yeni Doküman - Adım 3",
@@ -58,6 +68,16 @@ TRANSLATIONS = {
         "standard_label": "Standart",
         "no_versions_yet": "Henüz sürüm yüklenmedi.",
         "upload_new_version": "Yeni Sürüm Yükle",
+        "audit_create": "Oluşturuldu",
+        "audit_view": "Görüntülendi",
+        "audit_download_document": "Doküman indirildi",
+        "audit_download_revision": "Revizyon indirildi",
+        "audit_version_uploaded": "Sürüm yüklendi",
+        "audit_publish_document": "Doküman yayımlandı",
+        "audit_assign_mr": "MR atandı",
+        "audit_checkout_document": "Doküman check-out yapıldı",
+        "audit_checkin_document": "Doküman check-in yapıldı",
+        "audit_rollback": "Geri alındı",
     },
 }
 
@@ -70,7 +90,8 @@ def get_locale() -> str:
 
 def t(key: str, **kwargs: str) -> str:
     locale = get_locale()
-    text = TRANSLATIONS.get(locale, TRANSLATIONS["en"]).get(key, key)
+    # Look up translation in the requested locale, fall back to English, then the key
+    text = TRANSLATIONS.get(locale, {}).get(key, TRANSLATIONS["en"].get(key, key))
     try:
         return text.format(**kwargs)
     except Exception:


### PR DESCRIPTION
## Summary
- add English and Turkish translations for audit log actions
- update audit log metadata to use audit-specific translation keys
- make `t()` fall back to English and key when translations are missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba7611f72c832badec6bf36dc19334