### PR TITLE
Install LibreOffice for portal PDF previews

### DIFF
--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -6,6 +6,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends tesseract-ocr poppler-utils clamav-daemon && \
     rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libreoffice-common libreoffice-writer libreoffice-calc && \
+    rm -rf /var/lib/apt/lists/*
+
 # copy portal requirements first to leverage Docker layer cache
 COPY portal/requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- Install LibreOffice packages in portal Docker image to enable PDF previews

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba8a475948832b9fade752695d04d4