### PR TITLE
docs: clarify storage signing and proxying

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -11,19 +11,24 @@ The portal supports pluggable storage and selects the implementation via the
 When `STORAGE__TYPE` is `minio`, the following variables must be set:
 
 - `S3_ENDPOINT` – URL of the S3 service.
-- `S3_PUBLIC_ENDPOINT` *(optional)* – public URL to expose in presigned links.
+- `S3_PUBLIC_ENDPOINT` *(optional)* – external URL or reverse-proxy path to expose in presigned links; this must be reachable by clients.
 - `S3_ACCESS_KEY` / `S3_ACCESS_KEY_ID`
 - `S3_SECRET_KEY` / `S3_SECRET_ACCESS_KEY`
 - `S3_BUCKET_MAIN` / `S3_BUCKET` – bucket for uploaded files.
 - `S3_BUCKET_ARCHIVE` *(optional)* – bucket for archived items, defaults to the main bucket.
 - `S3_BUCKET_PREVIEWS` *(optional)* – bucket for preview assets, defaults to the main bucket.
 
-`SIGNED_URL_EXPIRE_SECONDS` controls the TTL of presigned URLs generated for
+`STORAGE__SIGNED_URL_EXPIRE_SECONDS` controls the TTL of presigned URLs generated for
 clients.  It defaults to one hour.
+
+Presigned URLs are only generated for objects up to 200 MB (`max_presign_size`).
+To download larger files or hide the storage endpoint, append `?via=proxy` to a
+download URL to stream the file through the portal instead of redirecting.
 
 When `S3_PUBLIC_ENDPOINT` is set, the hostname of presigned URLs is replaced
 with this value.  This allows clients to download files even when the internal
-S3 endpoint is not reachable from their network.
+S3 endpoint is not reachable from their network, provided the value points to
+an externally accessible host or path.
 
 ## Filesystem
 
@@ -42,6 +47,7 @@ location /fs {
 }
 ```
 
-Signed URL TTL is still governed by `SIGNED_URL_EXPIRE_SECONDS`, though the
-filesystem backend simply returns the public URL without signing.
+Signed URL TTL is still governed by `STORAGE__SIGNED_URL_EXPIRE_SECONDS`, though the
+filesystem backend simply returns the public URL without signing. The 200 MB
+`max_presign_size` limit and `?via=proxy` download option also apply here.
 


### PR DESCRIPTION
## Summary
- document 200MB presign limit and optional proxy downloads
- clarify that S3_PUBLIC_ENDPOINT must be publicly reachable
- rename docs to STORAGE__SIGNED_URL_EXPIRE_SECONDS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba95306380832bae5e9e33aad55e56