### PR TITLE
Use document download endpoint for version links

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -1531,7 +1531,7 @@ def document_download(doc_id: int):
                 user["id"],
                 doc_id,
                 "download_document",
-                payload={"version": version_str},
+                payload={"downloaded_version": version_str},
             )
             return redirect(url)
         obj = storage_client.get_object(Key=file_key)

--- a/portal/templates/partials/documents/_versions.html
+++ b/portal/templates/partials/documents/_versions.html
@@ -21,7 +21,7 @@
             <tr>
               <td>
                 <div class="form-check mb-0">
-                  <input class="form-check-input me-2 version-checkbox" type="checkbox" name="rev_id" value="{{ rev.id }}" id="rev-{{ rev.id }}" data-label="{{ rev.major_version }}.{{ rev.minor_version }}" data-download-url="{{ url_for('get_file', file_key=rev.file_key) }}" hx-get="{{ url_for('document_detail', doc_id=doc.id, revision_id=rev.id) }}" hx-target="#revision-panel" hx-select="#revision-note" hx-swap="innerHTML" hx-trigger="change" hx-push-url="false">
+                  <input class="form-check-input me-2 version-checkbox" type="checkbox" name="rev_id" value="{{ rev.id }}" id="rev-{{ rev.id }}" data-label="{{ rev.major_version }}.{{ rev.minor_version }}" data-download-url="/documents/{{doc.id}}/download?version=v{{rev.major_version}}.{{rev.minor_version}}" hx-get="{{ url_for('document_detail', doc_id=doc.id, revision_id=rev.id) }}" hx-target="#revision-panel" hx-select="#revision-note" hx-swap="innerHTML" hx-trigger="change" hx-push-url="false">
                   <label class="form-check-label" for="rev-{{ rev.id }}">{{ rev.major_version }}.{{ rev.minor_version }}</label>
                 </div>
               </td>

--- a/tests/test_document_download.py
+++ b/tests/test_document_download.py
@@ -114,7 +114,7 @@ def test_document_download_specific_version(app_modules):
             .all()
         )
         assert len(logs) == 1
-        assert logs[0].payload["version"] == "v1.0"
+        assert logs[0].payload["downloaded_version"] == "v1.0"
     finally:
         log_session.close()
 


### PR DESCRIPTION
## Summary
- link revision downloads to document download endpoint
- log downloaded version in audit entries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bab8ea0bf8832bb0ecab542b5e7040