### PR TITLE
feat: add document rollback via API

### DIFF
--- a/portal/static/document_detail.js
+++ b/portal/static/document_detail.js
@@ -321,6 +321,29 @@ function initUploadVersionForm() {
   });
 }
 
+function initRollbackForms() {
+  document.body.addEventListener('htmx:afterRequest', (evt) => {
+    const el = evt.target;
+    if (!el.classList || !el.classList.contains('rollback-form')) {
+      return;
+    }
+    if (evt.detail.successful) {
+      showToast('Sürüm geri alındı');
+    } else {
+      let message = 'Geri alma başarısız oldu';
+      try {
+        const data = JSON.parse(evt.detail.xhr.responseText);
+        if (data && data.error) {
+          message = data.error;
+        }
+      } catch (e) {
+        // ignore
+      }
+      showToast(message, { timeout: 6000 });
+    }
+  });
+}
+
 function getDocStatus() {
   const statusEl = Array.from(document.querySelectorAll('li')).find((li) =>
     li.textContent.trim().startsWith('Status:')
@@ -352,6 +375,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initAssignForm();
   initUploadVersionForm();
   initLockControls();
+  initRollbackForms();
 
   const params = new URLSearchParams(window.location.search);
   if (params.get('created') === '1') {

--- a/portal/static/src/document_detail.js
+++ b/portal/static/src/document_detail.js
@@ -292,6 +292,29 @@ function initUploadVersionForm() {
   });
 }
 
+function initRollbackForms() {
+  document.body.addEventListener('htmx:afterRequest', (evt) => {
+    const el = evt.target;
+    if (!el.classList || !el.classList.contains('rollback-form')) {
+      return;
+    }
+    if (evt.detail.successful) {
+      showToast('Sürüm geri alındı');
+    } else {
+      let message = 'Geri alma başarısız oldu';
+      try {
+        const data = JSON.parse(evt.detail.xhr.responseText);
+        if (data && data.error) {
+          message = data.error;
+        }
+      } catch (e) {
+        // ignore
+      }
+      showToast(message, { timeout: 6000 });
+    }
+  });
+}
+
 function getDocStatus() {
   const statusEl = Array.from(document.querySelectorAll('li')).find((li) =>
     li.textContent.trim().startsWith('Status:')
@@ -322,6 +345,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initWorkflowForm();
   initAssignForm();
   initUploadVersionForm();
+  initRollbackForms();
 
   const params = new URLSearchParams(window.location.search);
   if (params.get('created') === '1') {

--- a/portal/templates/partials/documents/_versions.html
+++ b/portal/templates/partials/documents/_versions.html
@@ -40,7 +40,7 @@
               <td>{{ rev.revision_notes or '' }}</td>
               {% if has_role('editor') or has_role('publisher') or has_role('quality_admin') %}
               <td>
-                <form class="d-inline rollback-form" hx-post="{{ url_for('rollback_document_api', doc_id=doc.id) }}?to=v{{ rev.major_version }}.{{ rev.minor_version }}" hx-swap="none">
+                <form class="d-inline rollback-form" hx-post="{{ url_for('rollback_document_api', doc_id=doc.id) }}?to=v{{ rev.major_version }}.{{ rev.minor_version }}" hx-target="#tab-versions" hx-swap="outerHTML">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <button type="submit" class="btn btn-sm btn-outline-danger">Rollback</button>
                 </form>


### PR DESCRIPTION
## Summary
- return refreshed version list for rollback API requests
- add rollback button for each document revision
- show toast on rollback and refresh versions panel

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bae5380004832b8617758a60e9c95f